### PR TITLE
Updated section split

### DIFF
--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -745,11 +745,7 @@ def process_additional_breaks(
     )
     ht = ht.annotate(
         section=hl.if_else(
-            # NOTE: Initially added breakpoint position to second section ("post") with logic that
-            # first position of scan is always missing
-            # Have fixed scans to not be one line behind -- should breakpoint pos still get added to
-            # second section?
-            ht.locus.position >= break_ht[ht.transcript].locus.position,
+            ht.locus.position > break_ht[ht.transcript].locus.position,
             hl.format("%s_%s", ht.transcript, "post"),
             hl.format("%s_%s", ht.transcript, "pre"),
         ),


### PR DESCRIPTION
Breakpoint pos is now included in section pre-breakpoint section (rather than post) based on this comment:
```
As in, a breakpoint means [0,99], (99,200] (i.e. [100,200]) and the breakpoint itself is between 99 and 100
```