### PR TITLE
Section chi square

### DIFF
--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1308,7 +1308,7 @@ def get_section_info(
     ht: hl.Table, section_num: int, is_middle: bool, indices: Tuple[int], is_first: bool
 ) -> hl.Table:
     """
-    Get the number of observed variants, number of expected variants, and chi square value for the first or last section of a transcript.
+    Get the number of observed variants, number of expected variants, and chi square value for transcript section.
 
     .. note::
         Assumes that the input Table is annotated with a list of breakpoint positions (`break_pos`).
@@ -1320,7 +1320,7 @@ def get_section_info(
         Relevant only if is_middle is True.
     :param bool is_first: Boolean for whether to get the first section of the transcript.
         Relevant only if is_middle is False.
-    :return: Table containing transcript and first section obs, exp, and chi square values.
+    :return: Table containing transcript and new section obs, exp, and chi square annotations.
     """
     logger.info("Getting info for section of transcript between two breakpoints...")
     if is_middle:


### PR DESCRIPTION
Each section of a transcript (for transcripts with evidence of regional missense constraint) gets assigned a chi square value. For example:
![image](https://user-images.githubusercontent.com/19142091/131173865-5aa6d7fc-ffb3-4650-bac5-1554ebbec18f.png)
in the screenshot above, you can see that the right half of KCNQ2 has a chi square value of 102.2 (https://gnomad.broadinstitute.org/gene/ENSG00000075043?dataset=exac).

This PR adds functions to fix the section chi square calculation to make sure it gets correctly added for all transcripts, including transcripts with more than a single break (i.e., transcripts that get split into more than two distinct sections). These new functions aren't called yet in the pipeline code (I haven't added the code to call them yet)