### PR TITLE
Fixed small bugs in transcript check

### DIFF
--- a/rmc/resources/basics.py
+++ b/rmc/resources/basics.py
@@ -150,7 +150,7 @@ simul_break_over_threshold = f"{MODEL_PREFIX}/{CURRENT_VERSION}/transcripts_over
 SetExpression containing transcripts with greater than or equal to the cutoff for possible missense positions.
 """
 
-simul_break_temp = f"{temp_path}/simul_breaks/"
+simul_break_temp = f"{temp_path}/simul_breaks"
 """
 Bucket to store temporary results for simultaneous results.
 """

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -194,7 +194,7 @@ def check_for_successful_transcripts(
     :return: List of transcripts didn't have success TSVs and therefore still need to be processed.
     """
     logger.info("Checking if any transcripts have already been searched...")
-    success_file_path = f"{simul_break_temp}success_files"
+    success_file_path = f"{simul_break_temp}/success_files"
     transcript_success_map = {}
     transcripts_to_run = []
     for transcript in transcripts:


### PR DESCRIPTION
- Removed unnecessary slash from end of `simul_break_temp` resource path
- Changed success TSV path to {transcript}.tsv (instead of {transcript}_success.tsv)