### PR TITLE
MPC fixes

### DIFF
--- a/rmc/pipeline/calculate_mpc.py
+++ b/rmc/pipeline/calculate_mpc.py
@@ -42,6 +42,7 @@ def main(args):
             run_regressions(
                 variables=args.variables.split(","),
                 additional_variables=args.extra_variables.split(","),
+                overwrite=args.overwrite,
             )
 
         if args.command == "calculate-mpc":

--- a/rmc/pipeline/calculate_mpc.py
+++ b/rmc/pipeline/calculate_mpc.py
@@ -47,11 +47,10 @@ def main(args):
         if args.command == "calculate-mpc":
             hl.init(log="/calculate_mpc_release.log")
             create_mpc_release_ht(
-                n_partitions=args.n_partitions,
                 overwrite=args.overwrite,
             )
 
-        if args.command == "annotate_hts":
+        if args.command == "annotate-hts":
             hl.init(log="/annotate_hts.log")
             if args.clinvar:
                 from rmc.resources.grch37.reference_data import clinvar_path_mis
@@ -76,6 +75,16 @@ def main(args):
                 annotate_mpc(
                     ht=control_ht,
                     output_path=f"{MPC_PREFIX}/{CURRENT_VERSION}/dd_control_mpc_annot.ht",
+                    overwrite=args.overwrite,
+                )
+
+            if args.gnomad_exomes:
+                from gnomad.resources.grch37.gnomad import public_release
+
+                ht = public_release("exomes").ht()
+                annotate_mpc(
+                    ht=ht,
+                    output_path=f"{MPC_PREFIX}/{CURRENT_VERSION}/gnomAD_mpc_annot.ht",
                     overwrite=args.overwrite,
                 )
 
@@ -146,12 +155,6 @@ if __name__ == "__main__":
         Calculate MPC release Table (VEP context Table filtered to missense variants in canonical, non-outlier transcripts).
         """,
     )
-    calculate_score.add_argument(
-        "--n-partitions",
-        help="Desired number of partitions for VEP context HT.",
-        default=30000,
-        type=int,
-    )
 
     annotate_hts = subparsers.add_parser(
         "annotate-hts", help="Annotate specified dataset with MPC."
@@ -162,6 +165,11 @@ if __name__ == "__main__":
     annotate_hts.add_argument(
         "--dd",
         help="Calculate MPC for de novo variants from developmental disorder (DD) cases and controls",
+        action="store_true",
+    )
+    annotate_hts.add_argument(
+        "--gnomad-exomes",
+        help="Calculate MPC for all gnomAD exomes variants",
         action="store_true",
     )
     annotate_hts.add_argument(

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -215,7 +215,7 @@ def main(args):
                 "Annotating context HT with number of observed and expected variants per site..."
             )
             # Add observed variants to context HT
-            context_ht = add_obs_annotation(context_ht, filter_csq=True, csq=MISSENSE)
+            context_ht = add_obs_annotation(context_ht, filter_csq=True)
 
             logger.info(
                 "Collecting by key to run constraint per base and not per base-allele..."

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -23,7 +23,7 @@ from rmc.resources.grch37.gnomad import (
     processed_exomes,
     prop_obs_coverage,
 )
-from rmc.resources.grch37.reference_data import processed_context
+from rmc.resources.grch37.reference_data import filtered_context
 from rmc.resources.resource_utils import CURRENT_VERSION, MISSENSE
 from rmc.slack_creds import slack_token
 from rmc.utils.constraint import (
@@ -75,7 +75,7 @@ def main(args):
             context_ht = filter_context_using_gnomad(
                 context_ht, "exomes", filter_context_using_cov=True
             )
-            context_ht.write(processed_context.path, overwrite=args.overwrite)
+            context_ht.write(filtered_context.path, overwrite=args.overwrite)
 
             logger.info(
                 "Filtering gnomAD exomes HT to missense variants in canonical transcripts only..."
@@ -106,7 +106,7 @@ def main(args):
                 exome_ht = filtered_exomes.ht()
 
             logger.info("Reading in context HT...")
-            context_ht = processed_context.ht()
+            context_ht = filtered_context.ht()
 
             logger.info("Building plateau and coverage models...")
             coverage_ht = prop_obs_coverage.ht()
@@ -367,7 +367,7 @@ def main(args):
             exome_ht = filtered_exomes.ht()
 
             logger.info("Reading in context HT...")
-            context_ht = processed_context.ht()
+            context_ht = filtered_context.ht()
 
             logger.info("Adding models from constraint prep HT...")
             constraint_prep_ht = constraint_prep.ht().select()
@@ -430,7 +430,7 @@ def main(args):
 
             logger.info("Reading in context HT...")
             # Drop extra annotations from context HT
-            context_ht = processed_context.ht().drop(
+            context_ht = filtered_context.ht().drop(
                 "_obs_scan", "_mu_scan", "forward_oe", "values"
             )
             context_ht = context_ht.filter(

--- a/rmc/resources/basics.py
+++ b/rmc/resources/basics.py
@@ -245,6 +245,24 @@ Each row is annotated with RMC transcript subsection missense OE if it exists, o
 the transcript level missense OE.
 """
 
+context_with_oe_dedup = VersionedTableResource(
+    default_version=CURRENT_VERSION,
+    versions={
+        version: TableResource(
+            path=f"{CONSTRAINT_PREFIX}/{version}/context_with_oe_dedup.ht"
+        )
+        for version in GNOMAD_VERSIONS
+    },
+)
+"""
+Deduplicated version of `context_with_oe`.
+
+Some locus/alleles combinations are present more than once in `context_with_oe` if they have
+a most severe consequence of 'missense_variant' in more than one canonical transcript.
+
+This Table contains only one row per each unique locus/alleles combination.
+"""
+
 rmc_browser = VersionedTableResource(
     default_version=CURRENT_VERSION,
     versions={

--- a/rmc/resources/basics.py
+++ b/rmc/resources/basics.py
@@ -302,19 +302,6 @@ misbad = VersionedTableResource(
 Table containing all possible amino acid substitutions and their missense badness scores.
 """
 
-polyphen = VersionedTableResource(
-    default_version=CURRENT_VERSION,
-    versions={
-        version: TableResource(path=f"{MPC_PREFIX}/{version}/polyphen.ht")
-        for version in GNOMAD_VERSIONS
-    },
-)
-"""
-Table containing Polyphen-2 (score and prediction), transcript, codons, most severe consequence, and reference and alternate amino acid annotations.
-
-Table contains variants in canonical transcripts only.
-"""
-
 joint_clinvar_gnomad = VersionedTableResource(
     default_version=CURRENT_VERSION,
     versions={

--- a/rmc/resources/basics.py
+++ b/rmc/resources/basics.py
@@ -379,6 +379,19 @@ mpc_release = VersionedTableResource(
 Table containing missense variants in canonical transcripts annotated with MPC.
 """
 
+mpc_release_dedup = VersionedTableResource(
+    default_version=CURRENT_VERSION,
+    versions={
+        version: TableResource(path=f"{MPC_PREFIX}/{version}/mpc_dedup.ht")
+        for version in GNOMAD_VERSIONS
+    },
+)
+"""
+Table containing missense variants in canonical transcripts annotated with MPC.
+
+This Table contains only one row per each unique locus/alleles combination.
+"""
+
 oe_bin_counts_tsv = f"{CONSTRAINT_PREFIX}/{CURRENT_VERSION}/oe_bin.tsv"
 """
 TSV with RMC regions grouped by obs/exp (OE) bin.

--- a/rmc/resources/grch37/gnomad.py
+++ b/rmc/resources/grch37/gnomad.py
@@ -19,7 +19,11 @@ filtered_exomes = TableResource(
 )
 """
 Processed gnomAD exomes Table filtered to missense variants only.
+
+NOTE: This resource is created with `process_vep`, which now filters to non-outlier transcripts by default.
+However, for v2, this resource contains *all* transcripts (including outliers).
 """
+
 processed_genomes = TableResource(path=f"{FLAGSHIP_MODEL_PREFIX}/genomes_processed.ht")
 """
 Processed gnomAD genomes Table.

--- a/rmc/resources/grch37/gnomad.py
+++ b/rmc/resources/grch37/gnomad.py
@@ -21,7 +21,7 @@ filtered_exomes = TableResource(
 Processed gnomAD exomes Table filtered to rare (AF < 0.001) missense variants in canonical transcripts only.
 
 NOTE: This resource is created with `process_vep`, which now filters to non-outlier transcripts by default.
-However, for v2, this resource contains *all* transcripts (including outliers).
+However, for v2, this resource contains *all* canonical transcripts (including outliers).
 """
 
 processed_genomes = TableResource(path=f"{FLAGSHIP_MODEL_PREFIX}/genomes_processed.ht")

--- a/rmc/resources/grch37/gnomad.py
+++ b/rmc/resources/grch37/gnomad.py
@@ -18,7 +18,7 @@ filtered_exomes = TableResource(
     path=f"{RESOURCE_PREFIX}/GRCh37/gnomad/ht/exomes_missense_only.ht"
 )
 """
-Processed gnomAD exomes Table filtered to missense variants only.
+Processed gnomAD exomes Table filtered to rare (AF < 0.001) missense variants in canonical transcripts only.
 
 NOTE: This resource is created with `process_vep`, which now filters to non-outlier transcripts by default.
 However, for v2, this resource contains *all* transcripts (including outliers).

--- a/rmc/resources/grch37/reference_data.py
+++ b/rmc/resources/grch37/reference_data.py
@@ -22,7 +22,7 @@ Used to calculate the cumulative observed and expected missense values per locus
 generate regional missense constraint results.
 
 NOTE: This resource is created with `process_vep`, which now filters to non-outlier transcripts by default.
-However, for v2, this resource contains *all* transcripts (including outliers).
+However, for v2, this resource contains *all* canonical transcripts (including outliers).
 """
 
 gene_model = TableResource(path=f"{RESOURCE_PREFIX}/GRCh37/browser/b37_transcripts.ht")

--- a/rmc/resources/grch37/reference_data.py
+++ b/rmc/resources/grch37/reference_data.py
@@ -6,7 +6,7 @@ from rmc.resources.resource_utils import RESOURCE_PREFIX
 
 
 ## Reference genome related resources
-processed_context = VersionedTableResource(
+filtered_context = VersionedTableResource(
     default_version="v1",
     versions={
         "v1": TableResource(

--- a/rmc/resources/grch37/reference_data.py
+++ b/rmc/resources/grch37/reference_data.py
@@ -20,6 +20,9 @@ probability of mutation for each variant, CpG status, gnomAD exome coverage, and
 
 Used to calculate the cumulative observed and expected missense values per locus and
 generate regional missense constraint results.
+
+NOTE: This resource is created with `process_vep`, which now filters to non-outlier transcripts by default.
+However, for v2, this resource contains *all* transcripts (including outliers).
 """
 
 gene_model = TableResource(path=f"{RESOURCE_PREFIX}/GRCh37/browser/b37_transcripts.ht")

--- a/rmc/resources/grch38/reference_data.py
+++ b/rmc/resources/grch38/reference_data.py
@@ -10,10 +10,11 @@ from rmc.resources.resource_utils import RESOURCE_PREFIX
 
 ## Reference genome related resources
 full_context = VersionedTableResource(
-    default_version="101", versions={"101": vep_context.versions["101"]},
+    default_version="101",
+    versions={"101": vep_context.versions["101"]},
 )
 
-processed_context = VersionedTableResource(
+filtered_context = VersionedTableResource(
     default_version="101",
     versions={
         "101": TableResource(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1531,9 +1531,9 @@ def group_rmc_ht_by_section() -> hl.Table:
         interval=hl.parse_locus_interval(
             hl.format(
                 "[%s:%s-%s]",
-                rmc_ht.locus.contig,
-                rmc_ht.section_start_pos,
-                rmc_ht.section_end_pos,
+                rmc_ht.contig,
+                rmc_ht.start_pos,
+                rmc_ht.end_pos,
             )
         ),
     )

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1512,6 +1512,7 @@ def group_rmc_ht_by_section(overwrite: bool = False) -> hl.Table:
         - Function reads RMC results Table from resource path.
         - Assumes RMC HT is annotated with `locus`, `transcript`, `section`, `section_start_pos`,
         `section_end_pos`, and `section_oe`.
+        - Assumes `transcript` is one of RMC HT's key fields.
 
     :param bool overwrite: Whether to overwrite temporary checkpointed Table if it exists.
         Default is False.

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1504,7 +1504,7 @@ def constraint_flag_expr(
     )
 
 
-def group_rmc_ht_by_section() -> hl.Table:
+def group_rmc_ht_by_section(overwrite: bool = False) -> hl.Table:
     """
     Group RMC results Table by transcript subsection and return interval and section missense o/e.
 
@@ -1513,6 +1513,8 @@ def group_rmc_ht_by_section() -> hl.Table:
         - Assumes RMC HT is annotated with `locus`, `transcript`, `section`, `section_start_pos`,
         `section_end_pos`, and `section_oe`.
 
+    :param bool overwrite: Whether to overwrite temporary checkpointed Table if it exists.
+        Default is False.
     :return: RMC results Table keyed by interval and annotated with transcript and section o/e.
     """
     rmc_ht = (
@@ -1527,7 +1529,11 @@ def group_rmc_ht_by_section() -> hl.Table:
         contig=hl.agg.take(rmc_ht.locus.contig, 1)[0],
         section_oe=hl.agg.take(rmc_ht.section_oe, 1)[0],
     )
-    rmc_ht = rmc_ht.checkpoint(f"{temp_path}/rmc_group_by_section.ht", overwrite=True)
+    rmc_ht = rmc_ht.checkpoint(
+        f"{temp_path}/rmc_group_by_section.ht",
+        _read_if_exists=not overwrite,
+        overwrite=overwrite,
+    )
     rmc_ht = rmc_ht.transmute(
         interval=hl.parse_locus_interval(
             hl.format(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Set, Tuple, Union
 
 import hail as hl
 
+from gnomad.resources.grch37.gnomad import coverage, public_release
 from gnomad.resources.resource_utils import DataException
 from gnomad.utils.file_utils import file_exists
 
@@ -15,11 +16,11 @@ from rmc.resources.basics import (
     rmc_results,
     temp_path,
 )
-from rmc.resources.grch37.gnomad import filtered_exomes
 from rmc.resources.grch37.reference_data import clinvar_path_mis, de_novo, gene_model
 from rmc.utils.generic import (
     get_constraint_transcripts,
     get_coverage_correction_expr,
+    keep_criteria,
     import_clinvar_hi_variants,
     import_de_novo_variants,
     process_vep,
@@ -93,6 +94,7 @@ List of annotations to keep when finalizing release HT.
 
 def add_obs_annotation(
     ht: hl.Table,
+    gnomad_data_type: str = "exomes",
     filter_csq: bool = False,
     csq: str = None,
 ) -> hl.Table:
@@ -102,14 +104,28 @@ def add_obs_annotation(
     Check if locus/allele are present in gnomAD and add as annotation.
 
     :param hl.Table ht: Input Table.
+    :param str gnomad_data_type: gnomAD data type. Used to retrieve public release and coverage resources.
+        Must be one of "exomes" or "genomes" (check is done within `public_release`).
+        Default is "exomes".
     :param bool filter_csq: Whether to filter gnomAD data to a specific consequence. Default is False.
         If True, then only variants that match this consequence in the input Table will be annotated as observed.
     :param str csq: Desired consequence. Default is None. Must be specified if filter_csq is True.
     :return: Table with observed variant annotation.
     """
     logger.info("Adding observed annotation...")
-    gnomad_ht = filtered_exomes.ht()
-
+    gnomad_ht = public_release(gnomad_data_type).ht()
+    gnomad_cov = coverage(gnomad_data_type).ht()
+    gnomad_ht = gnomad_ht.select(
+        "filters",
+        ac=gnomad_ht.freq[0].AC,
+        af=gnomad_ht.freq[0].AF,
+        gnomad_coverage=gnomad_cov[gnomad_ht.locus].median,
+    )
+    gnomad_ht = gnomad_ht.filter(
+        keep_criteria(
+            gnomad_ht.ac, gnomad_ht.af, gnomad_ht.filters, gnomad_ht.gnomad_coverage
+        )
+    )
     if filter_csq:
         gnomad_ht = process_vep(gnomad_ht, filter_csq=filter_csq, csq=csq)
     ht = ht.annotate(_obs=gnomad_ht.index(ht.key))

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1527,6 +1527,7 @@ def group_rmc_ht_by_section() -> hl.Table:
         contig=hl.agg.take(rmc_ht.locus.contig, 1)[0],
         section_oe=hl.agg.take(rmc_ht.section_oe, 1)[0],
     )
+    rmc_ht = rmc_ht.checkpoint(f"{temp_path}/rmc_group_by_section.ht", overwrite=True)
     rmc_ht = rmc_ht.transmute(
         interval=hl.parse_locus_interval(
             hl.format(

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -260,7 +260,7 @@ def get_exome_bases(build: str) -> int:
     )
 
     logger.info("Removing outlier transcripts...")
-    outlier_transcripts = get_constraint_transcripts(outlier=False)
+    outlier_transcripts = get_constraint_transcripts(outlier=True)
     ht = ht.transmute(transcript_consequences=ht.vep.transcript_consequences)
     ht = ht.explode(ht.transcript_consequences)
     ht = ht.filter(

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -272,7 +272,7 @@ def get_exome_bases(build: str) -> int:
     )
     ht = ht.key_by("locus").collect_by_key()
 
-    logger.info("Filtering positions with median coverage < 5...")
+    logger.info("Removing positions with median coverage < 5...")
     # Taking just the first value since the coverage should be the same for all entries at a locus
     ht = ht.filter(ht.values[0].coverage.exomes.median >= 5)
     ht = ht.select()

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -377,19 +377,17 @@ def process_vep(ht: hl.Table, filter_csq: bool = False, csq: str = None) -> hl.T
         ht, vep_root="vep", syn=False, canonical=True, filter_empty=True
     )
 
-    logger.info("Filtering to non-outlier transcripts...")
-    # Keep transcripts used in LoF constraint only (remove all other outlier transcripts)
-    constraint_transcripts = get_constraint_transcripts(outlier=True)
-    ht = ht.transmute(transcript_consequences=ht.vep.transcript_consequences)
-    ht = ht.explode(ht.transcript_consequences)
-    ht = ht.filter(
-        constraint_transcripts.contains(ht.transcript_consequences.transcript_id)
-    )
-
     logger.info("Annotating HT with most severe consequence...")
     ht = add_most_severe_csq_to_tc_within_ht(ht)
     ht = ht.transmute(transcript_consequences=ht.vep.transcript_consequences)
     ht = ht.explode(ht.transcript_consequences)
+
+    logger.info("Filtering to non-outlier transcripts...")
+    # Keep transcripts used in LoF constraint only (remove all other outlier transcripts)
+    constraint_transcripts = get_constraint_transcripts(outlier=True)
+    ht = ht.filter(
+        constraint_transcripts.contains(ht.transcript_consequences.transcript_id)
+    )
 
     if filter_csq:
         if not csq:

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -119,7 +119,6 @@ def get_oe_annotation(ht: hl.Table) -> hl.Table:
     )
     rmc_ht = rmc_ht.key_by("interval", "transcript")
     rmc_ht = rmc_ht.distinct()
-    ht = ht.key_by()
     ht = ht.annotate(
         interval=hl.parse_locus_interval(
             hl.format(

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -119,7 +119,18 @@ def get_oe_annotation(ht: hl.Table) -> hl.Table:
     )
     rmc_ht = rmc_ht.key_by("interval", "transcript")
     rmc_ht = rmc_ht.distinct()
-    ht = ht.annotate(section_oe=rmc_ht[ht.locus, ht.transcript].section_oe)
+    ht = ht.key_by()
+    ht = ht.annotate(
+        interval=hl.parse_locus_interval(
+            hl.format(
+                "[%s:%s-%s]",
+                ht.locus.contig,
+                ht.locus.position,
+                ht.locus.position,
+            )
+        )
+    )
+    ht = ht.annotate(section_oe=rmc_ht[ht.interval, ht.transcript].section_oe)
     return ht.transmute(oe=hl.coalesce(ht.section_oe, ht.transcript_oe))
 
 

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -105,7 +105,13 @@ def get_oe_annotation(ht: hl.Table) -> hl.Table:
     ht = ht.annotate(
         section_oe=rmc_ht.index(ht.locus, all_matches=True)
         .filter(lambda x: x.transcript == ht.transcript)
-        .section_oe[0]
+        .section_oe
+    )
+    ht = ht.annotate(
+        section_oe=hl.or_missing(
+            hl.len(ht.section_oe) > 0,
+            ht.section_oe[0],
+        ),
     )
     return ht.transmute(oe=hl.coalesce(ht.section_oe, ht.transcript_oe))
 

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -72,6 +72,10 @@ def get_oe_annotation(ht: hl.Table) -> hl.Table:
 
     Use regional OE value if available, otherwise use transcript OE value.
 
+    .. note::
+        - Assumes input Table has `locus` and `trancript` annotations
+        - OE values are transcript specific
+
     :param hl.Table ht: Input Table.
     :return: Table with `oe` annotation.
     """

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -315,18 +315,13 @@ def prepare_pop_path_ht(
     )
     ht = ht.annotate(cadd=hl.struct(**cadd_ht[ht.key]))
 
-    logger.info("Getting PolyPhen-2 and codon annotations from VEP context HT...")
+    logger.info(
+        "Getting PolyPhen-2, codon, and regional missense constraint missense o/e from `context_with_oe` resource..."
+    )
     if not file_exists(context_with_oe.path):
         create_context_with_oe(overwrite=True)
     context_ht = context_with_oe.ht()
-
-    logger.info(
-        "Adding PolyPhen-2, codon, and transcript annotations to joint ClinVar/gnomAD HT..."
-    )
     ht = ht.annotate(**context_ht[ht.key])
-
-    logger.info("Getting regional missense constraint missense o/e annotation...")
-    ht = get_oe_annotation(ht)
 
     logger.info("Getting missense badness annotation...")
     mb_ht = misbad.ht()

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -371,6 +371,7 @@ def prepare_pop_path_ht(
 def run_regressions(
     variables: List[str] = ["oe", "misbad", "polyphen"],
     additional_variables: List[str] = ["blosum", "grantham"],
+    overwrite: bool = True,
 ) -> None:
     """
     Run single variable and joint regressions and pick best model.
@@ -393,6 +394,7 @@ def run_regressions(
         Default is ["oe", "misbad", "polyphen"].
     :param List[str] additional_variables: Additional variables to include in single variable regressions only.
         Default is ["blosum", "grantham"].
+    :param bool overwrite: Whether to overwrite gnomAD fitted score table if it already exists. Default is True.
     :return: None; function writes Table with gnomAD fitted scores
         and model coefficients as pickle to resource paths.
     """
@@ -527,7 +529,7 @@ def run_regressions(
     )
     ht = ht.filter(ht.pop_v_path == 1)
     ht = calculate_fitted_scores(ht)
-    ht.write(gnomad_fitted_score.path, overwrite=True)
+    ht.write(gnomad_fitted_score.path, overwrite=overwrite)
 
 
 def calculate_fitted_scores(

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -715,15 +715,15 @@ def create_mpc_release_ht(
     # Checkpoint here to force the binary search to compute
     ht = ht.checkpoint(f"{temp_path}/mpc_temp_binary.ht", overwrite=True)
     ht = ht.annotate(mpc=-(hl.log10(ht.n_less / gnomad_var_count)))
-    ht.write(mpc_release.path, overwrite=overwrite)
+    ht = ht.checkpoint(mpc_release.path, overwrite=overwrite)
 
+    # Create deduplicated MPC release
     ht = ht.select("transcript", "mpc")
     ht = ht.collect_by_key()
-    ht = ht.annotate(mpc=hl.max(ht.values.mpc)))
-    ht = ht.annotate(
-        transcript=ht.values.find(lambda x: x.mpc == ht.mpc).transcript
-    )
+    ht = ht.annotate(mpc=hl.max(ht.values.mpc))
+    ht = ht.annotate(transcript=ht.values.find(lambda x: x.mpc == ht.mpc).transcript)
     ht.write(mpc_release_dedup.path, overwrite=overwrite)
+
 
 def annotate_mpc(
     ht: hl.Table,

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -398,6 +398,7 @@ def run_regressions(
     """
     # Convert HT to pandas dataframe as logistic regression aggregations aren't currently possible in hail
     ht = joint_clinvar_gnomad.ht()
+    ht = ht.transmute(polyphen=ht.polyphen.score)
     df = ht.to_pandas()
 
     def _run_glm(
@@ -572,7 +573,6 @@ def calculate_fitted_scores(
         annotations.append("oe")
 
     if "polyphen" in variables:
-        ht = ht.transmute(polyphen=ht.polyphen.score)
         annotations.append("polyphen")
 
     logger.info("Filtering to defined annotations and checkpointing...")
@@ -672,6 +672,7 @@ def create_mpc_release_ht(
     """
     logger.info("Calculating fitted scores...")
     ht = context_with_oe.ht()
+    ht = ht.transmute(polyphen=ht.polyphen.score)
     ht = calculate_fitted_scores(ht)
 
     logger.info("Aggregating gnomAD fitted scores...")

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -478,7 +478,7 @@ def run_regressions(
     all_model_aic = single_var_aic + [add_model.aic, mult_model.aic, spec_model.aic]
     min_aic = min(all_model_aic)
     logger.info("Lowest model AIC: %f", min_aic)
-    '''if all_model_aic.count(min_aic) > 1:
+    if all_model_aic.count(min_aic) > 1:
         logger.warning(
             """
             There is a tie for minimum AIC.
@@ -516,10 +516,8 @@ def run_regressions(
         )
         logger.info("Coefficients: %s", spec_model.params)
         model = spec_model
-        X = spec_X'''
+        X = spec_X
 
-    model = spec_model
-    X = spec_X
     logger.info("Saving model as pickle...")
     with hl.hadoop_open(mpc_model_pkl_path, "wb") as p:
         pickle.dump(model, p, protocol=pickle.HIGHEST_PROTOCOL)

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -340,7 +340,6 @@ def prepare_pop_path_ht(
     )
 
     logger.info("Getting missense badness annotation...")
-    ht = hl.read_table(f"{temp_path}/joint_clinvar_gnomad_transcript_aa.ht")
     mb_ht = misbad.ht()
     ht = ht.annotate(misbad=mb_ht[ht.ref, ht.alt].misbad)
 

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -540,6 +540,7 @@ def calculate_fitted_scores(
 
     .. note::
         - Assumes model has been written as pickle to `mpc_model_pkl_path`.
+        - Assumes input Table has missense observed/expected (`oe`) and `polyphen` annotations.
 
     :param hl.Table ht: Input Table with variants to be annotated.
     :param str interaction_char: Character representing interactions in MPC model. Must be one of "*", ":".

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -211,7 +211,8 @@ def create_context_with_oe(
     Filter VEP context Table to missense variants in canonical transcripts, and add missense observed/expected.
 
     Function writes two Tables:
-        - `context_with_oe`: Table of all missense variants in canonical transcripts + all annotations (includes duplicate variants, i.e. those in multiple transcripts).
+        - `context_with_oe`: Table of all missense variants in canonical transcripts + all annotations
+            (includes duplicate variants, i.e. those in multiple transcripts).
             Annotations are: transcript, most severe consequence, codons, reference and alternate amino acids,
             Polyphen-2, and SIFT.
         - `context_with_oe_dedup`: Deduplicated version of `context_with_oe` that only contains missense o/e and transcript annotations.

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -331,9 +331,10 @@ def prepare_pop_path_ht(
     logger.info(
         "Getting PolyPhen-2, codon, and regional missense constraint missense o/e annotations..."
     )
-    # Get Polyphen, codon, o/e, amino acid,
+    # Get Polyphen, codon, o/e, amino acid annotations
     context_ht = context_with_oe.ht()
-    ht = ht.annotate(**context_ht[ht.key])
+    context_ht = context_ht.key_by("locus", "alleles", "transcript")
+    ht = ht.annotate(**context_ht[ht.locus, ht.alleles, ht.transcript])
     ht = ht.checkpoint(
         f"{temp_path}/joint_clinvar_gnomad_transcript_aa.ht", overwrite=True
     )

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -276,7 +276,7 @@ def create_context_with_oe(
 
 
 def prepare_pop_path_ht(
-    gnomad_data_type: str = "exomes", af_threshold: float = 0.01
+    gnomad_data_type: str = "exomes", af_threshold: float = 0.001
 ) -> None:
     """
     Prepare Table with 'population' (common gnomAD missense) and 'pathogenic' (ClinVar pathogenic/likely pathogenic missense) variants.
@@ -290,7 +290,7 @@ def prepare_pop_path_ht(
         Default is "exomes".
     :param float af_threshold: Allele frequency cutoff to filter gnomAD public dataset.
         Variants *above* this threshold will be kept.
-        Default is 0.01.
+        Default is 0.001.
     :return: None; function writes Table to resource path.
     """
     logger.info("Reading in ClinVar P/LP missense variants in severe HI genes...")
@@ -339,6 +339,7 @@ def prepare_pop_path_ht(
     )
 
     logger.info("Getting missense badness annotation...")
+    ht = hl.read_table(f"{temp_path}/joint_clinvar_gnomad_transcript_aa.ht")
     mb_ht = misbad.ht()
     ht = ht.annotate(misbad=mb_ht[ht.ref, ht.alt].misbad)
 
@@ -353,6 +354,7 @@ def prepare_pop_path_ht(
         blosum=blosum_ht[ht.ref, ht.alt].score,
         grantham=grantham_ht[ht.ref, ht.alt].score,
     )
+    ht = ht.checkpoint(f"{temp_path}/joint_clinvar_gnomad_full.ht", overwrite=True)
 
     logger.info("Filtering to rows with defined annotations and writing out...")
     ht = ht.filter(

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -398,7 +398,6 @@ def run_regressions(
     """
     # Convert HT to pandas dataframe as logistic regression aggregations aren't currently possible in hail
     ht = joint_clinvar_gnomad.ht()
-    ht = ht.transmute(polyphen=ht.polyphen.score)
     df = ht.to_pandas()
 
     def _run_glm(

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -574,6 +574,7 @@ def create_mpc_release_ht(
         annotations.append("oe")
 
     if "polyphen" in variables:
+        ht = ht.transmute(polyphen=ht.polyphen.score)
         annotations.append("polyphen")
 
     logger.info("Filtering to defined annotations and checkpointing...")

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -683,9 +683,7 @@ def create_mpc_release_ht(
     scores_len = len(scores)
 
     # Get total number of gnomAD common variants
-    common_gnomad_ht = joint_clinvar_gnomad.ht()
-    common_gnomad_ht = common_gnomad_ht.filter(common_gnomad_ht.pop_v_path == 1)
-    gnomad_var_count = common_gnomad_ht.count()
+    gnomad_var_count = gnomad_fitted_score.ht().count()
 
     logger.info("Getting n_less annotation...")
     # Annotate HT with sorted array of gnomAD fitted scores

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -645,7 +645,9 @@ def create_mpc_release_ht(
     scores_len = len(scores)
 
     # Get total number of gnomAD common variants
-    gnomad_var_count = gnomad_fitted_score.ht().count()
+    common_gnomad_ht = joint_clinvar_gnomad.ht()
+    common_gnomad_ht = common_gnomad_ht.filter(common_gnomad_ht.pop_v_path == 1)
+    gnomad_var_count = common_gnomad_ht.count()
 
     logger.info("Getting n_less annotation...")
     # Annotate HT with sorted array of gnomAD fitted scores


### PR DESCRIPTION
This PR contains bug fixes and updates to MPC.

Major changes:
- Updated `get_oe_annotation` to account for duplicate loci in input Table (function now annotates RMC section oe using locus, alleles, and transcript information; rmc/utils/missense_badness.py)
- Moved code creating `context_with_oe` resource (and `context_with_oe_dedup` resource to a new function called `create_context_with_oe`; rmc/utils/mpc.py)
- Updated code creating population/pathogenic variants Table to pull Polyphen-2, transcript, and RMC o/e from `context_with_oe` (rmc/utils/mpc.py)
- Created new function `calculate_fitted_scores` to calculate fitted scores using relationships from MPC regression (rmc/utils/mpc.py)
- Updated gnomAD fitted scores HT creation to use `calculate_fitted_scores` rather than `predict` method (rmc/utils/mpc.py)
- Updated `annotate_mpc` to annotate transcript, a list of MPC values, and MPC float (rmc/utils/mpc.py) 

Minor changes:
- Added `context_with_oe_dedup` resource (rmc/resources/basics.py)
- Added`mpc_dedup` resource (rmc/resources/basics.py)
- Removed `polyphen` resource (rmc/resources/basics.py)
- Added `group_rmc_ht_by_section` utility function to get intervals included in RMC transcript subsections (rmc/utils/constraint.py)
- Fixed typo in `annotate-hts` command call (rmc/pipeline/calculate_mpc.py)
- Removed `n-partitions` argument (no longer used; rmc/pipeline/calculate_mpc.py)
- Added argument and code block to calculate MPC on all gnomAD variants (rmc/pipeline/calculate_mpc.py)
- Added overwrite option to `run_regressions` (rmc/utils/mpc.py)