### PR TITLE
Bugs found at runtime for simul breaks

### DIFF
--- a/rmc/pipeline/two_breaks/merge_hts.py
+++ b/rmc/pipeline/two_breaks/merge_hts.py
@@ -56,7 +56,9 @@ def main(args):
         )
         intermediate_hts = []
         temp_ht_paths = (
-            subprocess.check_output(["gsutil", "ls", f"{raw_path}/"])
+            subprocess.check_output(
+                ["gsutil", "-u", f"{args.google_project}", "ls", f"{raw_path}/"]
+            )
             .decode("utf8")
             .strip()
             .split("\n")
@@ -167,6 +169,13 @@ if __name__ == "__main__":
         with lower chi square significance cutoff).
         """,
         action="store_true",
+    )
+    parser.add_argument(
+        "--google-project",
+        help="""
+            Google cloud project used to read from requester-pays buckets.
+            """,
+        default="broad-mpg-gnomad",
     )
     parser.add_argument(
         "--create-no-breaks-ht",

--- a/rmc/pipeline/two_breaks/merge_hts.py
+++ b/rmc/pipeline/two_breaks/merge_hts.py
@@ -56,6 +56,7 @@ def main(args):
         )
         intermediate_hts = []
         temp_ht_paths = (
+            # Add project because bucket is requester-pays
             subprocess.check_output(
                 ["gsutil", "-u", f"{args.google_project}", "ls", f"{raw_path}/"]
             )

--- a/rmc/pipeline/two_breaks/merge_hts.py
+++ b/rmc/pipeline/two_breaks/merge_hts.py
@@ -88,7 +88,7 @@ def main(args):
                     # This `key_by` should not shuffle because `section` is already the first key for both Tables
                     temp = temp.key_by("section")
                     row_fields = set(temp.row)
-                    if len(ANNOTATIONS.intersection(row_fields)) < 3:
+                    if len(ANNOTATIONS.intersection(row_fields)) < len(ANNOTATIONS):
                         raise DataException(
                             f"The following fields are missing from the temp table: {ANNOTATIONS.difference(row_fields)}!"
                         )

--- a/rmc/pipeline/two_breaks/merge_hts.py
+++ b/rmc/pipeline/two_breaks/merge_hts.py
@@ -64,6 +64,12 @@ def main(args):
         ht_count = 0
         for ht_path in temp_ht_paths:
             ht_path = ht_path.strip("/")
+            # Skip temp HTs checkpointed to raw_results bucket
+            # i.e., HTs written with this line:
+            # `ht = ht.checkpoint(f"{raw_path}/{section_group[0]}.ht", overwrite=True)`
+            # in `process_section_group`
+            if "under" not in ht_path or "dataproc" not in ht_path:
+                continue
             if ht_path.endswith("ht"):
                 ht_count += 1
                 logger.info("Working on %s", ht_path)

--- a/rmc/pipeline/two_breaks/merge_hts.py
+++ b/rmc/pipeline/two_breaks/merge_hts.py
@@ -29,14 +29,16 @@ logger = logging.getLogger("merge_hts")
 logger.setLevel(logging.INFO)
 
 
-ANNOTATIONS = {"max_chisq", "section", "breakpoints"}
+ANNOTATIONS = {"max_chisq", "breakpoints"}
 """
 Set of annotations to keep from two simultaneous breaks search.
 
 `max_chisq`: Chi square value associated with two breaks.
+`breakpoints`: Tuple of breakpoints with adjusted inclusiveness/exclusiveness.
+
+Note that this field will also be kept (`section` is a key field):
 `section`: Transcript section that was searched.
     Format: <transcript>_<start position>_<end position>.
-`breakpoints`: Tuple of breakpoints with adjusted inclusiveness/exclusiveness.
 """
 
 

--- a/rmc/pipeline/two_breaks/merge_hts.py
+++ b/rmc/pipeline/two_breaks/merge_hts.py
@@ -71,7 +71,7 @@ def main(args):
             # i.e., HTs written with this line:
             # `ht = ht.checkpoint(f"{raw_path}/{section_group[0]}.ht", overwrite=True)`
             # in `process_section_group`
-            if "under" not in ht_path or "dataproc" not in ht_path:
+            if "under" not in ht_path and "dataproc" not in ht_path:
                 continue
             if ht_path.endswith("ht"):
                 ht_count += 1

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -437,7 +437,8 @@ def process_section_group(
             "spark.hadoop.fs.gs.requester.pays.mode": "CUSTOM",
             "spark.hadoop.fs.gs.requester.pays.buckets": f"{requester_pays_bucket.lstrip('gs://')}",
             "spark.hadoop.fs.gs.requester.pays.project.id": f"{google_project}",
-        }
+        },
+        tmp_dir=TEMP_PATH_WITH_DEL,
     )
     ht = hl.read_table(ht_path)
     ht = ht.filter(hl.literal(section_group).contains(ht.section))

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -365,15 +365,15 @@ def search_for_two_breaks(
             group_ht.positions[group_ht.best_break.j],
         ),
     )
-    section_name = "_".join(section_group)
+    section_name = "_".join(section_group[0])
     if save_chisq_ht:
         group_ht = group_ht.checkpoint(
-            f"{SIMUL_BREAK_TEMP_PATH}/batch_temp_chisq_over_threshold_{section_name}.ht",
+            f"{SIMUL_BREAK_TEMP_PATH}/batch_temp_chisq{section_name}.ht",
             overwrite=True,
         )
     else:
         group_ht = group_ht.checkpoint(
-            f"{TEMP_PATH_WITH_DEL}/batch_temp_chisq_over_threshold_{section_name}.ht",
+            f"{TEMP_PATH_WITH_DEL}/batch_temp_chisq{section_name}.ht",
             overwrite=True,
         )
     # Remove rows with maximum chi square values below the threshold

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -365,15 +365,16 @@ def search_for_two_breaks(
             group_ht.positions[group_ht.best_break.j],
         ),
     )
+    section_name = "_".join(section_group)
     if save_chisq_ht:
-        section_name = "_".join(section_group)
         group_ht = group_ht.checkpoint(
-            f"{SIMUL_BREAK_TEMP_PATH}/temp_chisq_over_threshold_{section_name}.ht",
+            f"{SIMUL_BREAK_TEMP_PATH}/batch_temp_chisq_over_threshold_{section_name}.ht",
             overwrite=True,
         )
     else:
         group_ht = group_ht.checkpoint(
-            f"{TEMP_PATH_WITH_DEL}/temp_chisq_over_threshold.ht", overwrite=True
+            f"{TEMP_PATH_WITH_DEL}/batch_temp_chisq_over_threshold_{section_name}.ht",
+            overwrite=True,
         )
     # Remove rows with maximum chi square values below the threshold
     group_ht = group_ht.filter(group_ht.max_chisq >= chisq_threshold)

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -591,6 +591,7 @@ def main(args):
         name="simul_breaks",
         backend=backend,
         default_python_image=args.docker_image,
+        requester_pays_project=args.google_project,
     )
 
     if args.under_threshold:
@@ -719,7 +720,10 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--google-project",
-        help="Google cloud project provided to hail batch for storage objects access.",
+        help="""
+            Google cloud project provided to hail batch for storage objects access.
+            Also used to read and write to requester-pays buckets.
+            """,
         default="broad-mpg-gnomad",
     )
     parser.add_argument(

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -302,7 +302,6 @@ def search_for_two_breaks(
         and expected missense values. HT is filtered to contain only transcript/sections without
         a single significant breakpoint.
     :param count: Which transcript group is being run (based on counter generated in `main`).
-    :param section_group: List of transcripts or transcript sections to process.
     :param chisq_threshold:  Chi-square significance threshold. Default is 9.2.
         This value corresponds to a p-value of 0.01 with 2 degrees of freedom.
         (https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm)

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -417,8 +417,8 @@ def process_section_group(
     hl.init(
         spark_conf={
             "spark.hadoop.fs.gs.requester.pays.mode": "CUSTOM",
-            "spark.hadoop.fs.gs.requester.pays.buckets": f"{requester_pays_bucket}",
-            "spark.hadoop.fs.gs.requester.pays.project.id": f"{google_project}",
+            "spark.hadoop.fs.gs.requester.pays.buckets": "gs://regional_missense_constraint",
+            "spark.hadoop.fs.gs.requester.pays.project.id": "broad-mpg-gnomad",
         }
     )
     ht = hl.read_table(ht_path)

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -301,6 +301,7 @@ def search_for_two_breaks(
     :param group_ht: Input Table aggregated by transcript/transcript section with lists of cumulative observed
         and expected missense values. HT is filtered to contain only transcript/sections without
         a single significant breakpoint.
+    :param count: Which transcript group is being run (based on counter generated in `main`).
     :param section_group: List of transcripts or transcript sections to process.
     :param chisq_threshold:  Chi-square significance threshold. Default is 9.2.
         This value corresponds to a p-value of 0.01 with 2 degrees of freedom.

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -417,8 +417,8 @@ def process_section_group(
     hl.init(
         spark_conf={
             "spark.hadoop.fs.gs.requester.pays.mode": "CUSTOM",
-            "spark.hadoop.fs.gs.requester.pays.buckets": "gs://regional_missense_constraint",
-            "spark.hadoop.fs.gs.requester.pays.project.id": "broad-mpg-gnomad",
+            "spark.hadoop.fs.gs.requester.pays.buckets": f"{requester_pays_bucket.lstrip('gs://')}",
+            "spark.hadoop.fs.gs.requester.pays.project.id": f"{google_project}",
         }
     )
     ht = hl.read_table(ht_path)

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -287,7 +287,7 @@ def calculate_window_chisq(
 
 def search_for_two_breaks(
     group_ht: hl.Table,
-    section_group: List[str],
+    count: int,
     chisq_threshold: float = 9.2,
     min_num_exp_mis: float = 10,
     min_chisq_threshold: float = 7.4,
@@ -365,15 +365,14 @@ def search_for_two_breaks(
             group_ht.positions[group_ht.best_break.j],
         ),
     )
-    section_name = "_".join(section_group[0])
     if save_chisq_ht:
         group_ht = group_ht.checkpoint(
-            f"{SIMUL_BREAK_TEMP_PATH}/batch_temp_chisq{section_name}.ht",
+            f"{SIMUL_BREAK_TEMP_PATH}/batch_temp_chisq_group{count}.ht",
             overwrite=True,
         )
     else:
         group_ht = group_ht.checkpoint(
-            f"{TEMP_PATH_WITH_DEL}/batch_temp_chisq{section_name}.ht",
+            f"{TEMP_PATH_WITH_DEL}/batch_temp_chisq_group{count}.ht",
             overwrite=True,
         )
     # Remove rows with maximum chi square values below the threshold
@@ -384,6 +383,7 @@ def search_for_two_breaks(
 def process_section_group(
     ht_path: str,
     section_group: List[str],
+    count: int,
     is_rescue: bool,
     search_num: int,
     over_threshold: bool,
@@ -403,6 +403,7 @@ def process_section_group(
 
     :param str ht_path: Path to input Table (Table written using `group_no_single_break_found_ht`).
     :param List[str] section_group: List of transcripts or transcript sections to process.
+    :param count: Which transcript group is being run (based on counter generated in `main`).
     :param is_rescue: Whether to return path to HT created in rescue pathway.
     :param search_num: Search iteration number
         (e.g., second round of searching for single break would be 2).
@@ -515,7 +516,7 @@ def process_section_group(
     # Search for two simultaneous breaks
     ht = search_for_two_breaks(
         group_ht=ht,
-        section_group=section_group,
+        count=count,
         chisq_threshold=chisq_threshold,
         min_num_exp_mis=min_num_exp_mis,
         save_chisq_ht=save_chisq_ht,
@@ -651,6 +652,7 @@ def main(args):
                     args.is_rescue, args.search_num
                 ),
                 section_group=group,
+                count=count,
                 is_rescue=args.is_rescue,
                 search_num=args.search_num,
                 over_threshold=False,
@@ -682,6 +684,7 @@ def main(args):
                     args.is_rescue, args.search_num
                 ),
                 section_group=group,
+                count=count,
                 is_rescue=args.is_rescue,
                 search_num=args.search_num,
                 over_threshold=True,

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -54,6 +54,14 @@ Adding this constant here to avoid ModuleNotFound errors in the
 PythonJobs. See `rmc.resources.basics` for full docstring.
 """
 
+TEMP_PATH_WITH_DEL = "gs://gnomad-tmp-4day/rmc/"
+"""
+Path to bucket for temporary files.
+
+Adding this constant here to avoid ModuleNotFound errors in the
+PythonJobs. See `rmc.resources.basics` for full docstring.
+"""
+
 SIMUL_BREAK_TEMP_PATH = f"{RMC_PREFIX}/temp/simul_breaks"
 """
 Path to bucket to store temporary results for simultaneous searches.
@@ -279,6 +287,7 @@ def calculate_window_chisq(
 
 def search_for_two_breaks(
     group_ht: hl.Table,
+    section_group: List[str],
     chisq_threshold: float = 9.2,
     min_num_exp_mis: float = 10,
     min_chisq_threshold: float = 7.4,
@@ -292,6 +301,7 @@ def search_for_two_breaks(
     :param group_ht: Input Table aggregated by transcript/transcript section with lists of cumulative observed
         and expected missense values. HT is filtered to contain only transcript/sections without
         a single significant breakpoint.
+    :param section_group: List of transcripts or transcript sections to process.
     :param chisq_threshold:  Chi-square significance threshold. Default is 9.2.
         This value corresponds to a p-value of 0.01 with 2 degrees of freedom.
         (https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm)
@@ -356,8 +366,14 @@ def search_for_two_breaks(
         ),
     )
     if save_chisq_ht:
+        section_name = "_".join(section_group)
         group_ht = group_ht.checkpoint(
-            f"{SIMUL_BREAK_TEMP_PATH}/temp_chisq_over_threshold.ht", overwrite=True
+            f"{SIMUL_BREAK_TEMP_PATH}/temp_chisq_over_threshold_{section_name}.ht",
+            overwrite=True,
+        )
+    else:
+        group_ht = group_ht.checkpoint(
+            f"{TEMP_PATH_WITH_DEL}/temp_chisq_over_threshold.ht", overwrite=True
         )
     # Remove rows with maximum chi square values below the threshold
     group_ht = group_ht.filter(group_ht.max_chisq >= chisq_threshold)
@@ -498,6 +514,7 @@ def process_section_group(
     # Search for two simultaneous breaks
     ht = search_for_two_breaks(
         group_ht=ht,
+        section_group=section_group,
         chisq_threshold=chisq_threshold,
         min_num_exp_mis=min_num_exp_mis,
         save_chisq_ht=save_chisq_ht,

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -42,9 +42,6 @@ def main(args):
             log=f"/round{args.search_num}search_for_two_breaks_run_batches_dataproc.log",
             tmp_dir=TEMP_PATH_WITH_DEL,
         )
-        save_chisq_ht = False
-        if args.search_num == 1 and not args.is_rescue:
-            save_chisq_ht = True
 
         if args.run_ttn:
             section_groups = [[args.ttn_id]]
@@ -101,7 +98,6 @@ def main(args):
                 chisq_threshold=args.chisq_threshold,
                 split_list_len=args.split_list_len,
                 read_if_exists=args.read_if_exists,
-                save_chisq_ht=save_chisq_ht,
             )
 
     finally:

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -48,7 +48,8 @@ def main(args):
 
         if args.run_ttn:
             section_groups = [[args.ttn_id]]
-        else:
+
+        if args.run_sections_over_threshold:
             sections_to_run = list(
                 hl.eval(
                     hl.experimental.read_expression(

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -85,9 +85,20 @@ def main(args):
                 else f"{raw_path}/simul_break_dataproc_{counter}.ht"
             )
             if file_exists(output_ht_path):
-                raise DataException(
-                    f"Output already exists at {output_ht_path}! Double check before running script again."
+                # raise DataException(
+                #    f"Output already exists at {output_ht_path}! Double check before running script again."
+                # )
+                tmp_ht = hl.read_table(
+                    f"gs://regional_missense_constraint/temp/simul_breaks/dataproc_temp_chisq_group{counter}.ht"
                 )
+                prev_sections = tmp_ht.aggregate(hl.agg.collect_as_set(tmp_ht.section))
+                if len(set(group).difference(prev_sections)) != 0:
+                    print(
+                        f"{output_ht_path} exists but sections are different! Will overwrite"
+                    )
+                else:
+                    print(f"{output_ht_path} exists, continuing")
+                    continue
 
             process_section_group(
                 ht_path=grouped_single_no_break_ht_path(

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -55,7 +55,7 @@ def main(args):
                         simul_sections_split_by_len_path(
                             is_rescue=args.is_rescue,
                             search_num=args.search_num,
-                            is_over_threshold=False,
+                            is_over_threshold=True,
                         )
                     )
                 )

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -94,6 +94,7 @@ def main(args):
                     args.is_rescue, args.search_num
                 ),
                 section_group=group,
+                count=counter,
                 is_rescue=args.is_rescue,
                 search_num=args.search_num,
                 over_threshold=True,

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -89,20 +89,9 @@ def main(args):
                 else f"{raw_path}/simul_break_dataproc_{counter}.ht"
             )
             if file_exists(output_ht_path):
-                # raise DataException(
-                #    f"Output already exists at {output_ht_path}! Double check before running script again."
-                # )
-                tmp_ht = hl.read_table(
-                    f"gs://regional_missense_constraint/temp/simul_breaks/dataproc_temp_chisq_group{counter}.ht"
+                raise DataException(
+                    f"Output already exists at {output_ht_path}! Double check before running script again."
                 )
-                prev_sections = tmp_ht.aggregate(hl.agg.collect_as_set(tmp_ht.section))
-                if len(set(group).difference(prev_sections)) != 0:
-                    print(
-                        f"{output_ht_path} exists but sections are different! Will overwrite"
-                    )
-                else:
-                    print(f"{output_ht_path} exists, continuing")
-                    continue
 
             process_section_group(
                 ht_path=grouped_single_no_break_ht_path(

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -79,6 +79,10 @@ def main(args):
             bucket_type="raw_results",
         )
         for counter, group in enumerate(section_groups):
+            # Double check TTN has been removed
+            if args.ttn_id in group:
+                group.remove(args.ttn_id)
+
             output_ht_path = (
                 f"{raw_path}/simul_break_dataproc_ttn.ht"
                 if args.run_ttn

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -42,6 +42,9 @@ def main(args):
             log=f"/round{args.search_num}search_for_two_breaks_run_batches_dataproc.log",
             tmp_dir=TEMP_PATH_WITH_DEL,
         )
+        save_chisq_ht = False
+        if args.search_num == 1 and not args.is_rescue:
+            save_chisq_ht = True
 
         if args.run_ttn:
             section_groups = [[args.ttn_id]]
@@ -98,6 +101,7 @@ def main(args):
                 chisq_threshold=args.chisq_threshold,
                 split_list_len=args.split_list_len,
                 read_if_exists=args.read_if_exists,
+                save_chisq_ht=save_chisq_ht,
             )
 
     finally:

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -383,6 +383,7 @@ def search_for_two_breaks(
             group_ht.positions[group_ht.best_break.j],
         ),
     )
+    # TODO: remove over_threshold
     if save_chisq_ht:
         section_name = "_".join(section_group)
         group_ht = group_ht.checkpoint(

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -5,7 +5,7 @@ from typing import List
 import hail as hl
 
 from gnomad.utils.file_utils import file_exists, parallel_file_exists
-from rmc.resources.basics import SIMUL_BREAK_TEMP_PATH
+from rmc.resources.basics import TEMP_PATH_WITH_DEL
 
 from rmc.resources.rmc import (
     simul_sections_split_by_len_path,
@@ -308,7 +308,6 @@ def search_for_two_breaks(
     chisq_threshold: float = 9.2,
     min_num_exp_mis: float = 10,
     min_chisq_threshold: float = 7.4,
-    save_chisq_ht: bool = False,
 ) -> hl.Table:
     """
     Search for transcripts/transcript sections with simultaneous breaks.
@@ -326,10 +325,6 @@ def search_for_two_breaks(
         simultaneous breaks.
     :param min_chisq_threshold: Minimum chi square value to emit from search.
         Default is 7.4, which corresponds to a p-value of 0.025 with 2 degrees of freedom.
-    :param save_chisq_ht: Whether to save HT with chi square values annotated for every locus
-        (as long as chi square value is >= min_chisq_threshold).
-        This saves a lot of extra data and should only occur during the initial search round.
-        Default is False.
     :return: Table filtered to transcript/sections with significant simultaneous breakpoints
         and annotated with breakpoint information.
     """
@@ -381,10 +376,9 @@ def search_for_two_breaks(
             group_ht.positions[group_ht.best_break.j],
         ),
     )
-    if save_chisq_ht:
-        group_ht = group_ht.checkpoint(
-            f"{SIMUL_BREAK_TEMP_PATH}/temp_chisq_over_threshold.ht", overwrite=True
-        )
+    group_ht = group_ht.checkpoint(
+        f"{TEMP_PATH_WITH_DEL}/temp_chisq_over_threshold.ht", overwrite=True
+    )
     # Remove rows with maximum chi square values below the threshold
     group_ht = group_ht.filter(group_ht.max_chisq >= chisq_threshold)
     return group_ht

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -383,9 +383,6 @@ def search_for_two_breaks(
             group_ht.positions[group_ht.best_break.j],
         ),
     )
-    # NOTE: freeze 2 round 1 path was:
-    # section_name = "_".join(section_group)
-    # f"{SIMUL_BREAK_TEMP_PATH}/temp_chisq_over_threshold_{section_name}.ht",
     if save_chisq_ht:
         group_ht = group_ht.checkpoint(
             f"{SIMUL_BREAK_TEMP_PATH}/dataproc_temp_chisq_group{count}.ht",

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -5,7 +5,7 @@ from typing import List
 import hail as hl
 
 from gnomad.utils.file_utils import file_exists, parallel_file_exists
-from rmc.resources.basics import SIMUL_BREAK_TEMP_PATH, TEMP_PATH, TEMP_PATH_WITH_DEL
+from rmc.resources.basics import SIMUL_BREAK_TEMP_PATH, TEMP_PATH_WITH_DEL
 
 from rmc.resources.rmc import (
     simul_sections_split_by_len_path,
@@ -319,6 +319,7 @@ def search_for_two_breaks(
     :param group_ht: Input Table aggregated by transcript/transcript section with lists of cumulative observed
         and expected missense values. HT is filtered to contain only transcript/sections without
         a single significant breakpoint.
+    :param section_group: List of transcripts or transcript sections to process.
     :param chisq_threshold:  Chi-square significance threshold. Default is 9.2.
         This value corresponds to a p-value of 0.01 with 2 degrees of freedom.
         (https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm)

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -319,7 +319,7 @@ def search_for_two_breaks(
     :param group_ht: Input Table aggregated by transcript/transcript section with lists of cumulative observed
         and expected missense values. HT is filtered to contain only transcript/sections without
         a single significant breakpoint.
-    :param count: Which transcript group is being run (based on counter generated in `main`).
+    :param count: Which transcript or transcript section group is being run (based on counter generated in `main`).
     :param chisq_threshold:  Chi-square significance threshold. Default is 9.2.
         This value corresponds to a p-value of 0.01 with 2 degrees of freedom.
         (https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm)

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -390,7 +390,7 @@ def search_for_two_breaks(
         )
     else:
         group_ht = group_ht.checkpoint(
-            f"{TEMP_PATH_WITH_DEL}/dataproc_temp_chisq.ht", overwrite=True
+            f"{TEMP_PATH_WITH_DEL}/dataproc_temp_chisq_group{count}.ht", overwrite=True
         )
     # Remove rows with maximum chi square values below the threshold
     group_ht = group_ht.filter(group_ht.max_chisq >= chisq_threshold)

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -383,7 +383,7 @@ def search_for_two_breaks(
             group_ht.positions[group_ht.best_break.j],
         ),
     )
-    # NOTE: freeze 1 round 1 path was:
+    # NOTE: freeze 2 round 1 path was:
     # section_name = "_".join(section_group)
     # f"{SIMUL_BREAK_TEMP_PATH}/temp_chisq_over_threshold_{section_name}.ht",
     if save_chisq_ht:


### PR DESCRIPTION
This PR fixes bugs found when running simul breaks search round 1

`rmc/pipeline/regional_constraint.py`: some BLACK reformatting

`rmc/pipeline/two_breaks/merge_hts.py`:
- removed key field from `ANNOTATIONS` and updated line checking length
- added options required to read from requester-pays buckets
- added change to make sure only HTs with results get merged

`rmc/pipeline/two_breaks/run_batches.py`:

- added options required to read from requester-pays buckets
- added missing required imports
- added changes to write all chi square HTs

`rmc/pipeline/two_breaks/run_batches_dataproc.py`:
- added code to avoid specifying sections to run on command line
- added code to make sure TTN was not being included

`rmc/utils/simultaneous_breaks.py`:
- added changes to write all chi square HTs