### PR TITLE
Cumulative obs fix

### DIFF
--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -417,7 +417,7 @@ def get_fwd_exprs(
     logger.info("Getting cumulative observed variant counts...")
     ht = ht.annotate(
         obs_scan=get_cumulative_obs_expr(
-            group_str=group_str,
+            group_str=ht[group_str],
             observed_expr=ht[obs_str],
         )
     )
@@ -425,7 +425,7 @@ def get_fwd_exprs(
         cumulative_obs=adjust_obs_expr(
             cumulative_obs_expr=ht.obs_scan,
             obs_expr=ht[obs_str],
-            group_str=group_str,
+            group_str=ht[group_str],
         )
     ).drop("obs_scan")
 


### PR DESCRIPTION
Added changes to `constraint.py` to fix the error in the `cumulative_obs` field computed during the single break search documented [here](https://github.com/broadinstitute/rmc_production/issues/17).