### PR TITLE
Missense badness and MPC fixes

### DIFF
--- a/rmc/pipeline/calculate_mpc.py
+++ b/rmc/pipeline/calculate_mpc.py
@@ -36,7 +36,7 @@ def main(args):
     try:
         if args.command == "prepare-ht":
             hl.init(log="/write_pop_path_ht.log", tmp_dir=temp_dir)
-            prepare_pop_path_ht()
+            prepare_pop_path_ht(overwrite=args.overwrite)
 
         if args.command == "run-glm":
             hl.init(log="/run_regressions_using_glm.log", tmp_dir=temp_dir)

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -322,7 +322,7 @@ def process_vep(ht: hl.Table, filter_csq: bool = False, csq: str = None) -> hl.T
 
     logger.info("Filtering to non-outlier transcripts...")
     # Keep transcripts used in LoF constraint only (remove all other outlier transcripts)
-    constraint_transcripts = get_constraint_transcripts(outlier=True)
+    constraint_transcripts = get_constraint_transcripts(outlier=False)
     ht = ht.filter(
         constraint_transcripts.contains(ht.transcript_consequences.transcript_id)
     )

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -25,7 +25,7 @@ from rmc.resources.basics import (
     CODON_TABLE_PATH,
     hi_genes,
 )
-from rmc.resources.gnomad import constraint_ht, filtered_exomes, mutation_rate
+from rmc.resources.gnomad import constraint_ht, mutation_rate
 from rmc.resources.rmc import (
     DIVERGENCE_SCORES_TSV_PATH,
     MUTATION_RATE_TABLE_PATH,

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -20,6 +20,7 @@ from rmc.resources.basics import (
     grantham,
     grantham_txt_path,
     TEMP_PATH,
+    TEMP_PATH_WITH_DEL,
 )
 from rmc.resources.reference_data import cadd, clinvar_path_mis
 from rmc.resources.rmc import (
@@ -313,9 +314,11 @@ def prepare_pop_path_ht(
     ht = clinvar_ht.select("pop_v_path").union(gnomad_ht.select("pop_v_path"))
     # Remove variants that are in both the benign and pathogenic set
     counts = ht.group_by(*ht.key).aggregate(n=hl.agg.count())
-    counts = counts.checkpoint(f"{TEMP_PATH_WITH_DEL}/clinvar_gnomad_counts.ht", overwrite=True)
+    counts = counts.checkpoint(
+        f"{TEMP_PATH_WITH_DEL}/clinvar_gnomad_counts.ht", overwrite=True
+    )
     overlap = counts.filter(counts.n > 1)
-    logger.info("%i ClinVar P/LP variants are common in gnomAD", overlap.count()) 
+    logger.info("%i ClinVar P/LP variants are common in gnomAD", overlap.count())
     ht = ht.anti_join(overlap)
     ht = ht.checkpoint(
         f"{TEMP_PATH_WITH_DEL}/joint_clinvar_gnomad.ht",

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -315,7 +315,7 @@ def prepare_pop_path_ht(
     counts = ht.group_by(*ht.key).aggregate(n=hl.agg.count())
     ht = ht.anti_join(counts.filter(counts.n > 1))
     ht = ht.checkpoint(
-        f"{TEMP_PATH}/joint_clinvar_gnomad.ht",
+        f"{TEMP_PATH_WITH_DEL}/joint_clinvar_gnomad.ht",
         _read_if_exists=not overwrite,
         overwrite=overwrite,
     )
@@ -339,7 +339,7 @@ def prepare_pop_path_ht(
     context_ht = context_with_oe_dedup.ht()
     ht = ht.annotate(transcript=context_ht[ht.key].transcript)
     ht = ht.checkpoint(
-        f"{TEMP_PATH}/joint_clinvar_gnomad_transcript.ht",
+        f"{TEMP_PATH_WITH_DEL}/joint_clinvar_gnomad_transcript.ht",
         _read_if_exists=not overwrite,
         overwrite=overwrite,
     )
@@ -352,7 +352,7 @@ def prepare_pop_path_ht(
     context_ht = context_ht.key_by("locus", "alleles", "transcript")
     ht = ht.annotate(**context_ht[ht.locus, ht.alleles, ht.transcript])
     ht = ht.checkpoint(
-        f"{TEMP_PATH}/joint_clinvar_gnomad_transcript_aa.ht",
+        f"{TEMP_PATH_WITH_DEL}/joint_clinvar_gnomad_transcript_aa.ht",
         _read_if_exists=not overwrite,
         overwrite=overwrite,
     )
@@ -373,7 +373,7 @@ def prepare_pop_path_ht(
         grantham=grantham_ht[ht.ref, ht.alt].score,
     )
     ht = ht.checkpoint(
-        f"{TEMP_PATH}/joint_clinvar_gnomad_full.ht",
+        f"{TEMP_PATH_WITH_DEL}/joint_clinvar_gnomad_full.ht",
         _read_if_exists=not overwrite,
         overwrite=overwrite,
     )

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -432,6 +432,7 @@ def run_regressions(
     # for int and float fields, which patsy cannot handle
     # These must be converted to non-nullable standard numpy dtypes
     # prior to working with patsy
+    # See: https://github.com/hail-is/hail/commit/da557655ef1da99ddd1887bd32b33f4b5adcec9f
     for column in df.columns:
         if df[column].dtype == "Int32":
             df[column] = df[column].astype(np.int32)


### PR DESCRIPTION
Major changes:
- Fixed [bug](https://github.com/broadinstitute/rmc_production/issues/39) in `process_vep` that was filtering the dataset to outlier-only transcripts instead of filtering outlier transcripts out
- Filter out variants in preparation of the MPC training set that overlap between the benign vs. pathogenic sets
- Fix [compatibility issue](https://github.com/broadinstitute/rmc_production/issues/40) with patsy and nullable dtypes by casting back down to non-nullable dtypes

Minor changes:
- Fixed another bug in `create_context_with_oe`
- Added an overwrite option to `prepare_pop_path_ht`