### PR TITLE
Adding freeze argument and allowing for easier re-runs

### DIFF
--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -606,6 +606,8 @@ if __name__ == "__main__":
         for all possible loci. Note that chi square values will be missing for
         any loci that would divide a transcript into subsections with fewer than
         `MIN_EXP_MIS` expected missense variants.
+
+        NOTE that this temporary Table should only get saved once.
         """,
         action="store_true",
     )

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -8,6 +8,7 @@ from gnomad.utils.file_utils import file_exists
 
 from rmc.resources.basics import (
     LOGGING_PATH,
+    SINGLE_BREAK_TEMP_PATH,
     TEMP_PATH_WITH_FAST_DEL,
     TEMP_PATH_WITH_SLOW_DEL,
 )
@@ -34,6 +35,7 @@ from rmc.utils.constraint import (
     calculate_exp_per_transcript,
     calculate_observed,
     check_break_search_round_nums,
+    get_max_chisq_per_group,
     GROUPINGS,
     merge_rmc_hts,
     process_sections,
@@ -134,7 +136,9 @@ def main(args):
                 plateau_x_models,
                 plateau_y_models,
             ) = generate_models(
-                coverage_ht, coverage_x_ht, coverage_y_ht, trimers=args.trimers
+                coverage_ht,
+                coverage_x_ht,
+                coverage_y_ht,
             )
 
             context_ht = context_ht.annotate_globals(

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -370,6 +370,7 @@ def main(args):
                     search_num=args.search_num,
                     is_break_found=False,
                     is_breakpoint_only=False,
+                    freeze=args.freeze,
                 )
             )
 
@@ -440,6 +441,7 @@ def main(args):
                 search_num=args.search_num,
                 is_break_found=True,
                 is_breakpoint_only=False,
+                freeze=args.freeze,
             )
 
             if file_exists(single_break_path):
@@ -509,7 +511,7 @@ def main(args):
             )
 
             logger.info("Checking round paths...")
-            round_nums = check_break_search_round_nums()
+            round_nums = check_break_search_round_nums(args.freeze)
 
             logger.info("Finalizing section-level RMC table...")
             rmc_ht = merge_rmc_hts(round_nums=round_nums)

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -278,9 +278,7 @@ def main(args):
             )
             if args.search_num == 1:
 
-                all_loci_chisq_ht_path = (
-                    f"{SINGLE_BREAK_TEMP_PATH}/round{args.search_num}_all_loci_chisq.ht"
-                )
+                all_loci_chisq_ht_path = f"{SINGLE_BREAK_TEMP_PATH}/all_loci_chisq.ht"
                 if file_exists(all_loci_chisq_ht_path):
                     ht = hl.read_table(all_loci_chisq_ht_path)
                     ht = get_max_chisq_per_group(ht, "section", "chisq")

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -62,7 +62,11 @@ def main(args):
     """Call functions from `constraint.py` to calculate regional missense constraint."""
     try:
         if args.pre_process_data:
-            hl.init(log="/RMC_pre_process.log", tmp_dir=TEMP_PATH_WITH_FAST_DEL)
+            hl.init(
+                log="/RMC_pre_process.log",
+                tmp_dir=TEMP_PATH_WITH_FAST_DEL,
+                quiet=args.quiet,
+            )
             # TODO: Add code to create annotations necessary for constraint_flag_expr and filter transcripts prior to running constraint
             logger.warning("Code currently only processes b37 data!")
 
@@ -104,7 +108,11 @@ def main(args):
             logger.info("Done preprocessing files")
 
         if args.prep_for_constraint:
-            hl.init(log="/RMC_prep_for_constraint.log", tmp_dir=TEMP_PATH_WITH_FAST_DEL)
+            hl.init(
+                log="/RMC_prep_for_constraint.log",
+                tmp_dir=TEMP_PATH_WITH_FAST_DEL,
+                quiet=args.quiet,
+            )
             logger.info("Reading in exome HT...")
             exome_ht = filtered_exomes.ht()
 
@@ -256,6 +264,7 @@ def main(args):
             hl.init(
                 log=f"/round{args.search_num}_single_break_search.log",
                 tmp_dir=TEMP_PATH_WITH_FAST_DEL,
+                quiet=args.quiet,
             )
 
             logger.info(
@@ -353,6 +362,7 @@ def main(args):
             hl.init(
                 log=f"/round{args.search_num}_merge_single_simul.log",
                 tmp_dir=TEMP_PATH_WITH_FAST_DEL,
+                quiet=args.quiet,
             )
             # Get locus input to this simultaneous break search round from single search no-break HT
             single_no_break_ht = hl.read_table(
@@ -492,7 +502,11 @@ def main(args):
             # DONE: 4. Create and write final no break found ht for this round number
 
         if args.finalize:
-            hl.init(log="/RMC_finalize.log", tmp_dir=TEMP_PATH_WITH_FAST_DEL)
+            hl.init(
+                log="/RMC_finalize.log",
+                tmp_dir=TEMP_PATH_WITH_FAST_DEL,
+                quiet=args.quiet,
+            )
 
             logger.info("Checking round paths...")
             round_nums = check_break_search_round_nums()
@@ -605,6 +619,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--slack-channel",
         help="Send message to Slack channel/user.",
+    )
+    parser.add_argument(
+        "--quiet",
+        help="Initialize Hail with `quiet=True` to print fewer log messages",
+        action="store_true",
     )
     args = parser.parse_args()
 

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -557,7 +557,7 @@ def main(args):
             rmc_ht.write(rmc_results.versions[args.freeze].path)
 
             logger.info("Getting transcripts without evidence of RMC...")
-            create_no_breaks_he(overwrrite=args.overwrite)
+            create_no_breaks_he(overwrite=args.overwrite)
 
     finally:
         logger.info("Copying hail log to logging bucket...")

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -281,7 +281,7 @@ def main(args):
                 all_loci_chisq_ht_path = f"{SINGLE_BREAK_TEMP_PATH}/all_loci_chisq.ht"
                 if file_exists(all_loci_chisq_ht_path) and not args.save_chisq_ht:
                     ht = hl.read_table(all_loci_chisq_ht_path)
-                    ht = get_max_chisq_per_group(ht, "section", "chisq")
+                    ht = get_max_chisq_per_group(ht, "section", "chisq", args.freeze)
                     ht = ht.annotate(
                         is_break=(
                             (ht.chisq == ht.section_max_chisq)
@@ -321,11 +321,12 @@ def main(args):
                 ht = process_sections(
                     ht=ht,
                     search_num=args.search_num,
+                    freeze=args.freeze,
                     chisq_threshold=chisq_threshold,
                     save_chisq_ht=args.save_chisq_ht,
                 )
                 ht = ht.checkpoint(
-                    f"{TEMP_PATH_WITH_FAST_DEL}/round{args.search_num}_temp.ht",
+                    f"{TEMP_PATH_WITH_FAST_DEL}/freeze{args.freeze}_round{args.search_num}_temp.ht",
                     overwrite=True,
                 )
 
@@ -539,7 +540,7 @@ def main(args):
             logger.info("Finalizing section-level RMC table...")
             rmc_ht = merge_rmc_hts(round_nums=round_nums, freeze=args.freeze)
             rmc_ht = rmc_ht.checkpoint(
-                f"{TEMP_PATH_WITH_SLOW_DEL}/rmc_results.ht",
+                f"{TEMP_PATH_WITH_SLOW_DEL}/freeze{freeze}_rmc_results.ht",
                 overwrite=args.overwrite,
                 _read_if_exists=not args.overwrite,
             )

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -35,6 +35,7 @@ from rmc.utils.constraint import (
     calculate_exp_per_transcript,
     calculate_observed,
     check_break_search_round_nums,
+    create_no_breaks_he,
     get_max_chisq_per_group,
     GROUPINGS,
     merge_rmc_hts,
@@ -554,6 +555,9 @@ def main(args):
 
             logger.info("Writing out RMC results...")
             rmc_ht.write(rmc_results.versions[args.freeze].path)
+
+            logger.info("Getting transcripts without evidence of RMC...")
+            create_no_breaks_he(overwrrite=args.overwrite)
 
     finally:
         logger.info("Copying hail log to logging bucket...")

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -540,7 +540,7 @@ def main(args):
             logger.info("Finalizing section-level RMC table...")
             rmc_ht = merge_rmc_hts(round_nums=round_nums, freeze=args.freeze)
             rmc_ht = rmc_ht.checkpoint(
-                f"{TEMP_PATH_WITH_SLOW_DEL}/freeze{freeze}_rmc_results.ht",
+                f"{TEMP_PATH_WITH_SLOW_DEL}/freeze{args.freeze}_rmc_results.ht",
                 overwrite=args.overwrite,
                 _read_if_exists=not args.overwrite,
             )

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -555,7 +555,7 @@ def main(args):
             rmc_ht.write(rmc_results.versions[args.freeze].path)
 
             logger.info("Getting transcripts without evidence of RMC...")
-            create_no_breaks_he(overwrite=args.overwrite)
+            create_no_breaks_he(freeze=args.freeze, overwrite=args.overwrite)
 
     finally:
         logger.info("Copying hail log to logging bucket...")

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -537,7 +537,7 @@ def main(args):
             round_nums = check_break_search_round_nums(args.freeze)
 
             logger.info("Finalizing section-level RMC table...")
-            rmc_ht = merge_rmc_hts(round_nums=round_nums)
+            rmc_ht = merge_rmc_hts(round_nums=round_nums, freeze=args.freeze)
             rmc_ht = rmc_ht.checkpoint(
                 f"{TEMP_PATH_WITH_SLOW_DEL}/rmc_results.ht",
                 overwrite=args.overwrite,

--- a/rmc/pipeline/two_breaks/merge_hts.py
+++ b/rmc/pipeline/two_breaks/merge_hts.py
@@ -11,7 +11,7 @@ import hail as hl
 from gnomad.utils.slack import slack_notifications
 
 from rmc.resources.basics import LOGGING_PATH, TEMP_PATH_WITH_FAST_DEL
-from rmc.resources.rmc import simul_search_round_bucket_path
+from rmc.resources.rmc import CURRENT_FREEZE, simul_search_round_bucket_path
 from rmc.slack_creds import slack_token
 from rmc.utils.constraint import merge_simul_break_temp_hts
 

--- a/rmc/pipeline/two_breaks/merge_hts.py
+++ b/rmc/pipeline/two_breaks/merge_hts.py
@@ -36,10 +36,12 @@ def main(args):
         raw_path = simul_search_round_bucket_path(
             search_num=args.search_num,
             bucket_type="raw_results",
+            freeze=args.freeze,
         )
         results_path = simul_search_round_bucket_path(
             search_num=args.search_num,
             bucket_type="final_results",
+            freeze=args.freeze,
         )
         merge_simul_break_temp_hts(
             input_hts_path=raw_path,
@@ -80,6 +82,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="This regional missense constraint script merges all intermediate simultaneous breaks results Tables into a single Table.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--freeze",
+        help="RMC data freeze number",
+        default=CURRENT_FREEZE,
     )
     parser.add_argument(
         "--overwrite", help="Overwrite existing data.", action="store_true"

--- a/rmc/pipeline/two_breaks/prepare_transcripts.py
+++ b/rmc/pipeline/two_breaks/prepare_transcripts.py
@@ -38,7 +38,8 @@ def main(args):
     """Prepare input Table for two simultaneous breaks search."""
     try:
         grouped_ht_path = grouped_single_no_break_ht_path(
-            args.search_num,
+            search_num=args.search_num,
+            freeze=args.freeze,
         )
 
         if args.command == "create-grouped-ht":

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -316,7 +316,7 @@ def search_for_two_breaks(
         which corresponds to a p-value of 0.025 with 2 degrees of freedom.
     :param save_chisq_ht: Whether to save HT with chi square values annotated for every locus
         (as long as chi square value is >= min_chisq_threshold).
-        This saves a lot of extra data and should only occur during the initial search round.
+        This saves a lot of extra data and should only occur once.
         Default is False.
     :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
     :return: Table filtered to transcript/sections with significant simultaneous breakpoints
@@ -434,7 +434,7 @@ def process_section_group(
         Default is False.
     :param save_chisq_ht: Whether to save HT with chi square values annotated for every locus
         (as long as chi square value is >= min_chisq_threshold).
-        This saves a lot of extra data and should only occur during the initial search round.
+        This saves a lot of extra data and should only occur once.
         Default is False.
     :param google_project: Google project used to read and write data to requester-pays bucket.
     :return: None; processes Table and writes to path. Also writes success TSV to path.
@@ -575,10 +575,6 @@ def main(args):
             "Do not specify --use-custom-machine when transcripts/sections are --under-threshold size!"
         )
 
-    save_chisq_ht = False
-    if args.search_num == 1:
-        save_chisq_ht = True
-
     logger.info("Importing SetExpression with transcripts or transcript sections...")
     sections_to_run = get_sections_to_run(
         sections=(
@@ -688,7 +684,7 @@ def main(args):
                 output_n_partitions=args.output_n_partitions,
                 chisq_threshold=args.chisq_threshold,
                 split_list_len=args.group_size,
-                save_chisq_ht=save_chisq_ht,
+                save_chisq_ht=args.save_chisq_ht,
                 google_project=args.google_project,
                 freeze=args.freeze,
             )
@@ -726,7 +722,7 @@ def main(args):
                 output_n_partitions=args.output_n_partitions,
                 chisq_threshold=args.chisq_threshold,
                 split_list_len=args.group_size,
-                save_chisq_ht=save_chisq_ht,
+                save_chisq_ht=args.save_chisq_ht,
                 google_project=args.google_project,
                 freeze=args.freeze,
             )
@@ -776,6 +772,16 @@ if __name__ == "__main__":
         "--freeze",
         help="RMC data freeze number",
         default=CURRENT_FREEZE,
+    )
+    parser.add_argument(
+        "--save-chisq-ht",
+        help="""
+        Save temporary Table that contains chi square significance values
+        for all possible loci. Note that chi square values will be missing for
+        any loci that would divide a transcript into subsections with fewer than
+        `MIN_EXP_MIS` expected missense variants.
+        """,
+        action="store_true",
     )
 
     section_size = parser.add_mutually_exclusive_group(required=True)

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -780,6 +780,9 @@ if __name__ == "__main__":
         for all possible loci. Note that chi square values will be missing for
         any loci that would divide a transcript into subsections with fewer than
         `MIN_EXP_MIS` expected missense variants.
+
+        NOTE that this temporary Table should only get saved once per gnomAD version,
+        (save when running RMC pipeline at strictest p-value threshold).
         """,
         action="store_true",
     )

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -33,6 +33,7 @@ from rmc.resources.rmc import (
     CHISQ_THRESHOLDS,
     CURRENT_FREEZE,
     grouped_single_no_break_ht_path,
+    MIN_EXP_MIS,
     simul_sections_split_by_len_path,
 )
 from rmc.slack_creds import slack_token
@@ -287,8 +288,8 @@ def calculate_window_chisq(
 def search_for_two_breaks(
     group_ht: hl.Table,
     count: int,
-    chisq_threshold: float = 9.2,
-    min_num_exp_mis: float = 10,
+    chisq_threshold: float = CHISQ_THRESHOLDS["simul"],
+    min_num_exp_mis: float = MIN_EXP_MIS,
     min_chisq_threshold: float = 7.4,
     save_chisq_ht: bool = False,
     freeze: int = CURRENT_FREEZE,
@@ -302,10 +303,11 @@ def search_for_two_breaks(
         and expected missense values. HT is filtered to contain only transcript/sections without
         a single significant breakpoint.
     :param count: Which transcript group is being run (based on counter generated in `main`).
-    :param chisq_threshold:  Chi-square significance threshold. Default is 9.2.
-        This value corresponds to a p-value of 0.01 with 2 degrees of freedom.
+    :param chisq_threshold: Chi-square significance threshold. Default is
+        CHISQ_THRESHOLDS['simul'].
+        Default value used in ExAC was 13.8, which corresponds to a p-value of 0.001
+        with 2 degrees of freedom.
         (https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm)
-        Default value used in ExAC was 13.8, which corresponds to a p-value of 0.001.
     :param min_num_exp_mis: Minimum expected missense value for all three windows defined by two possible
         simultaneous breaks.
     :param min_chisq_threshold: Minimum chi square value to emit from search.
@@ -389,8 +391,8 @@ def process_section_group(
     over_threshold: bool,
     output_ht_path: str,
     output_n_partitions: int = 10,
-    chisq_threshold: float = 9.2,
-    min_num_exp_mis: float = 10,
+    chisq_threshold: float = CHISQ_THRESHOLDS["simul"],
+    min_num_exp_mis: float = MIN_EXP_MIS,
     split_list_len: int = 500,
     read_if_exists: bool = False,
     save_chisq_ht: bool = False,
@@ -413,10 +415,11 @@ def process_section_group(
     :param str output_ht_path: Path to output results Table.
     :param output_n_partitions: Desired number of partitions for output Table.
         Default is 10.
-    :param float chisq_threshold: Chi-square significance threshold. Default is 9.2.
-        This value corresponds to a p-value of 0.01 with 2 degrees of freedom.
+    :param chisq_threshold: Chi-square significance threshold. Default is
+        CHISQ_THRESHOLDS['simul'].
+        Default value used in ExAC was 13.8, which corresponds to a p-value of 0.001
+        with 2 degrees of freedom.
         (https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm)
-        Default value used in ExAC was 13.8, which corresponds to a p-value of 0.001.
     :param float min_num_exp_mis: Minimum expected missense value for all three windows defined by two possible
         simultaneous breaks.
     :param int split_list_len: Max length to divide transcript/sections observed or expected missense and position lists into.

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -802,7 +802,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--billing-project",
         help="Billing project to use with hail batch.",
-        default="gnomad-production",
+        default="rmc-production",
     )
     parser.add_argument(
         "--batch-bucket",

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -370,16 +370,15 @@ def search_for_two_breaks(
             group_ht.positions[group_ht.best_break.j],
         ),
     )
+    group_ht_path = (
+        f"{TEMP_PATH_WITH_FAST_DEL}/freeze{freeze}_batch_temp_chisq_group{count}.ht"
+    )
     if save_chisq_ht:
-        group_ht = group_ht.checkpoint(
-            f"{SIMUL_BREAK_TEMP_PATH}/freeze{freeze}_batch_temp_chisq_group{count}.ht",
-            overwrite=True,
+        group_ht_path = (
+            f"{SIMUL_BREAK_TEMP_PATH}/freeze{freeze}_batch_temp_chisq_group{count}.ht"
         )
-    else:
-        group_ht = group_ht.checkpoint(
-            f"{TEMP_PATH_WITH_FAST_DEL}/freeze{freeze}_batch_temp_chisq_group{count}.ht",
-            overwrite=True,
-        )
+    group_ht = group_ht.checkpoint(group_ht_path, overwrite=True)
+
     # Remove rows with maximum chi square values below the threshold
     group_ht = group_ht.filter(group_ht.max_chisq >= chisq_threshold)
     return group_ht

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -375,7 +375,7 @@ def search_for_two_breaks(
     )
     if save_chisq_ht:
         group_ht_path = (
-            f"{SIMUL_BREAK_TEMP_PATH}/freeze{freeze}_batch_temp_chisq_group{count}.ht"
+            f"{SIMUL_BREAK_TEMP_PATH}/freeze{freeze}/batch_temp_chisq_group{count}.ht"
         )
     group_ht = group_ht.checkpoint(group_ht_path, overwrite=True)
 

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -33,6 +33,7 @@ from rmc.resources.rmc import (
     CHISQ_THRESHOLDS,
     CURRENT_FREEZE,
     grouped_single_no_break_ht_path,
+    MIN_CHISQ_THRESHOLD,
     MIN_EXP_MIS,
     simul_sections_split_by_len_path,
 )
@@ -290,7 +291,7 @@ def search_for_two_breaks(
     count: int,
     chisq_threshold: float = CHISQ_THRESHOLDS["simul"],
     min_num_exp_mis: float = MIN_EXP_MIS,
-    min_chisq_threshold: float = 7.4,
+    min_chisq_threshold: float = MIN_CHISQ_THRESHOLD,
     save_chisq_ht: bool = False,
     freeze: int = CURRENT_FREEZE,
 ) -> hl.Table:
@@ -311,7 +312,8 @@ def search_for_two_breaks(
     :param min_num_exp_mis: Minimum expected missense value for all three windows defined by two possible
         simultaneous breaks.
     :param min_chisq_threshold: Minimum chi square value to emit from search.
-        Default is 7.4, which corresponds to a p-value of 0.025 with 2 degrees of freedom.
+        Default is MIN_CHISQ_THRESHOLD,
+        which corresponds to a p-value of 0.025 with 2 degrees of freedom.
     :param save_chisq_ht: Whether to save HT with chi square values annotated for every locus
         (as long as chi square value is >= min_chisq_threshold).
         This saves a lot of extra data and should only occur during the initial search round.

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -19,6 +19,8 @@ from gnomad.utils.slack import slack_notifications
 
 from rmc.resources.basics import LOGGING_PATH, TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.rmc import (
+    CHISQ_THRESHOLDS,
+    CURRENT_FREEZE,
     grouped_single_no_break_ht_path,
     simul_search_round_bucket_path,
     simul_sections_split_by_len_path,

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -195,6 +195,9 @@ if __name__ == "__main__":
         for all possible loci. Note that chi square values will be missing for
         any loci that would divide a transcript into subsections with fewer than
         `MIN_EXP_MIS` expected missense variants.
+
+        NOTE that this temporary Table should only get saved once per gnomAD version,
+        (save when running RMC pipeline at strictest p-value threshold).
         """,
         action="store_true",
     )

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -141,12 +141,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--chisq-threshold",
-        help="""
-        Chi-square significance threshold.
-        Defaut is 9.2 (p = 0.01).
-        """,
+        help="Chi-square significance threshold. Default is `CHISQ_THRESHOLDS['simul']`.",
         type=float,
-        default=9.2,
+        default=CHISQ_THRESHOLDS["simul"],
     )
     parser.add_argument(
         "--output-n-partitions",

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -53,6 +53,7 @@ def main(args):
                         simul_sections_split_by_len_path(
                             search_num=args.search_num,
                             is_over_threshold=True,
+                            freeze=args.freeze,
                         )
                     )
                 )
@@ -65,6 +66,7 @@ def main(args):
                         simul_sections_split_by_len_path(
                             search_num=args.search_num,
                             is_over_threshold=False,
+                            freeze=args.freeze,
                         )
                     )
                 )
@@ -91,6 +93,7 @@ def main(args):
         raw_path = simul_search_round_bucket_path(
             search_num=args.search_num,
             bucket_type="raw_results",
+            freeze=args.freeze,
         )
         for counter, group in enumerate(section_groups):
 
@@ -101,7 +104,10 @@ def main(args):
                 )
 
             process_section_group(
-                ht_path=grouped_single_no_break_ht_path(args.search_num),
+                ht_path=grouped_single_no_break_ht_path(
+                    args.search_num,
+                    args.freeze,
+                ),
                 section_group=group,
                 count=counter,
                 search_num=args.search_num,
@@ -127,6 +133,11 @@ if __name__ == "__main__":
         """,
         # Add default values for args to help message
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--freeze",
+        help="RMC data freeze number",
+        default=CURRENT_FREEZE,
     )
     parser.add_argument(
         "--chisq-threshold",

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -44,9 +44,6 @@ def main(args):
             log=f"/round{args.search_num}search_for_two_breaks_run_batches_dataproc.log",
             tmp_dir=TEMP_PATH_WITH_FAST_DEL,
         )
-        save_chisq_ht = False
-        if args.search_num == 1:
-            save_chisq_ht = True
 
         if args.run_sections_over_threshold:
             sections_to_run = list(
@@ -119,7 +116,7 @@ def main(args):
                 chisq_threshold=args.chisq_threshold,
                 split_list_len=args.split_list_len,
                 read_if_exists=args.read_if_exists,
-                save_chisq_ht=save_chisq_ht,
+                save_chisq_ht=args.save_chisq_ht,
             )
 
     finally:
@@ -189,6 +186,16 @@ if __name__ == "__main__":
     parser.add_argument(
         "--read-if-exists",
         help="Use temporary Tables if they already exist.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--save-chisq-ht",
+        help="""
+        Save temporary Table that contains chi square significance values
+        for all possible loci. Note that chi square values will be missing for
+        any loci that would divide a transcript into subsections with fewer than
+        `MIN_EXP_MIS` expected missense variants.
+        """,
         action="store_true",
     )
 

--- a/rmc/plotting/expected_vs_significance.R
+++ b/rmc/plotting/expected_vs_significance.R
@@ -1,0 +1,37 @@
+library(ggplot2)
+
+# Start with the following scenario:
+# O/E = 0 on side A, O/E = 1 on side B
+# Side A and side B have the same number of expected variants
+
+# Calculate chi-square value in the above scenario with a specified
+# expected number of variants in side A (equal to the expected in side B)
+get_chisq_single_break = function(obs1, exp1, obs2, exp2) {
+    return(
+        -2 *
+            (
+                log(dpois(obs1, exp1 * (obs1 + obs2) / (exp1 + exp2))) +
+                    log(dpois(obs2, exp2 * (obs1 + obs2) / (exp1 + exp2))) -
+                    log(dpois(obs1, obs1)) -
+                    log(dpois(obs2, obs2))
+            )
+    )
+}
+
+# Plot p-values of LRT in the above scenario, varying over
+# expected number of variants in side A (equal to the expected in side B)
+df_lrt = data.frame(exp = seq(1, 50))
+df_lrt$chisq = sapply(df_lrt$exp, function(x) {
+    get_chisq_single_break(0, x, x, x)
+})
+df_lrt$pval = sapply(df_lrt$chisq, function(x) 1 - pchisq(x, df = 1))
+df_lrt$nlog10_pval = -log10(df_lrt$pval)
+
+p = ggplot(df_lrt, aes(x = exp, y = nlog10_pval)) +
+    geom_smooth(se = FALSE, method = "gam", formula = y ~ s(log(x))) +
+    geom_point(size = 0.5) +
+    ggtitle("Single break: O/E=0 vs. O/E=1\nEqual # of expected vars per section") +
+    xlab("Expected number of variants per section") +
+    ylab("-log10(p)") +
+    scale_y_continuous(breaks = seq(0, round(max(df_lrt$nlog10_pval), 1), 2)) +
+    theme_bw()

--- a/rmc/plotting/expected_vs_significance.R
+++ b/rmc/plotting/expected_vs_significance.R
@@ -10,15 +10,15 @@ get_chisq_single_break = function(obs1, exp1, obs2, exp2) {
     return(
         -2 *
             (
-                log(dpois(obs1, exp1 * (obs1 + obs2) / (exp1 + exp2))) +
-                    log(dpois(obs2, exp2 * (obs1 + obs2) / (exp1 + exp2))) -
-                    log(dpois(obs1, obs1)) -
-                    log(dpois(obs2, obs2))
+                dpois(obs1, exp1 * (obs1 + obs2) / (exp1 + exp2), log = TRUE) +
+                    dpois(obs2, exp2 * (obs1 + obs2) / (exp1 + exp2), log = TRUE) -
+                    dpois(obs1, obs1, log = TRUE) -
+                    dpois(obs2, obs2, log = TRUE)
             )
     )
 }
 
-# Plot p-values of LRT in the above scenario, varying over
+# Plot p-values of likelihood ratio test in the above scenario, varying over
 # expected number of variants in side A (equal to the expected in side B)
 df_lrt = data.frame(exp = seq(1, 50))
 df_lrt$chisq = sapply(df_lrt$exp, function(x) {

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -32,15 +32,29 @@ CURRENT_FREEZE = 4
 Current RMC/MPC data version.
 """
 
-CHISQ_THRESHOLDS = {"single": 6.6, "simul": 9.2}
+P_VALUE = 0.001
+"""
+Default p-value significance threshold.
+
+Used to determine whether chi square values determining RMC breakpoints
+are significant.
+
+Default is 0.001.
+"""
+
+CHISQ_THRESHOLDS = {
+    "single": hl.eval(hl.qchisqtail(P_VALUE, 1)),
+    "simul": hl.qchisqtail(P_VALUE, 2),
+}
 """
 Default chi square significance thresholds for each search type.
 
 Thresholds are set for break search type ('single' or 'simul').
 
-Defaults correspond to p = 0.01.
-
-Reference: https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm
+Hail reference:
+https://hail.is/docs/0.2/functions/stats.html#hail.expr.functions.qchisqtail
+Look-up table reference:
+https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm
 """
 
 

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -393,12 +393,22 @@ def merged_search_ht_path(
     return f"{TEMP_PATH}/freeze{freeze}_round{search_num}_no_break_found.he"
 
 
-no_breaks = (
-    f"{CONSTRAINT_PREFIX}/{CURRENT_GNOMAD_VERSION}/{CURRENT_FREEZE}/no_breaks.he"
-)
-"""
-SetExpression containing transcripts with no significant breaks.
-"""
+def no_breaks_he_path(
+    freeze: int = CURRENT_FREEZE,
+    gnomad_ver: str = CURRENT_GNOMAD_VERSION,
+    constraint_prefix: str = CONSTRAINT_PREFIX,
+) -> str:
+    """
+    Return path to HailExpression containing transcripts with no evidence of RMC.
+
+    :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
+    :param gnomad_ver: gnomAD version. Default is CURRENT_GNOMAD_VERSION.
+    :param constraint_prefix: Constraint bucket path prefix.
+        Default is CONSTRAINT_PREFIX.
+    :return: Path to no break transcripts HailExpression.
+    """
+    return f"{constraint_prefix}/{gnomad_ver}/{freeze}/no_breaks.he"
+
 
 rmc_results = VersionedTableResource(
     default_version=CURRENT_FREEZE,

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -389,8 +389,8 @@ def merged_search_ht_path(
     :return: Path to merged break found HT or no break found HailExpression.
     """
     if is_break_found:
-        return f"{TEMP_PATH}/freeze{freeze}_round{search_num}_merged_break_found.ht"
-    return f"{TEMP_PATH}/freeze{freeze}_round{search_num}_no_break_found.he"
+        return f"{TEMP_PATH}/freeze{freeze}/round{search_num}_merged_break_found.ht"
+    return f"{TEMP_PATH}/freeze{freeze}/round{search_num}_no_break_found.he"
 
 
 def no_breaks_he_path(

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -44,7 +44,7 @@ Default is 0.001.
 
 CHISQ_THRESHOLDS = {
     "single": hl.eval(hl.qchisqtail(P_VALUE, 1)),
-    "simul": hl.qchisqtail(P_VALUE, 2),
+    "simul": hl.eval(hl.qchisqtail(P_VALUE, 2)),
 }
 """
 Default chi square significance thresholds for each search type.

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -74,8 +74,7 @@ Minimum number of expected missense variants within each RMC section.
 Sections that have fewer than this number of expected missense variants
 will not be computed (chi square will be annotated as a missing value).
 
-Calculated using a power curve with code at
-https://github.com/broadinstitute/gnomad_lof/blob/master/R/efig7_constraint.R.
+# TODO: add code description here
 
 Default is 16.
 

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -57,6 +57,15 @@ Look-up table reference:
 https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm
 """
 
+MIN_CHISQ_THRESHOLD = hl.eval(hl.qchisqtail(0.025, 2))
+"""
+Minimum chi square significance.
+
+Used only in two simultaneous breaks search.
+Any breakpoint combinations with a chi square value less than this threshold
+will not be emitted.
+"""
+
 MIN_EXP_MIS = 16.0
 """
 Minimum number of expected missense variants within each RMC section.

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -398,19 +398,14 @@ def merged_search_ht_path(
 
 def no_breaks_he_path(
     freeze: int = CURRENT_FREEZE,
-    gnomad_ver: str = CURRENT_GNOMAD_VERSION,
-    constraint_prefix: str = CONSTRAINT_PREFIX,
 ) -> str:
     """
     Return path to HailExpression containing transcripts with no evidence of RMC.
 
     :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
-    :param gnomad_ver: gnomAD version. Default is CURRENT_GNOMAD_VERSION.
-    :param constraint_prefix: Constraint bucket path prefix.
-        Default is CONSTRAINT_PREFIX.
     :return: Path to no break transcripts HailExpression.
     """
-    return f"{constraint_prefix}/{gnomad_ver}/{freeze}/no_breaks.he"
+    return f"{CONSTRAINT_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/no_breaks.he"
 
 
 rmc_results = VersionedTableResource(

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -74,8 +74,6 @@ Minimum number of expected missense variants within each RMC section.
 Sections that have fewer than this number of expected missense variants
 will not be computed (chi square will be annotated as a missing value).
 
-# TODO: add code description here
-
 Default is 16.
 
 This number was chosen as it corresponds to the minimum number
@@ -87,6 +85,11 @@ with one side having an O/E value of 0 and the other having an O/E value of 1.
 
 Exome-wide significance here is 2.7e-6,
 calculated based on testing 18,629 transcripts total.
+
+Calculated using a power curve with code at `plotting/expected_vs_significance.R`.
+
+The same minimum expected value is used in both the single breaks and
+simultaneous breaks searches.
 """
 
 

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -57,6 +57,25 @@ Look-up table reference:
 https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm
 """
 
+MIN_EXP_MIS = 16
+"""
+Minimum number of expected missense variants within each RMC section.
+
+
+Sections that have fewer than this number of expected missense variants
+will not be computed (chi square will be annotated as a missing value).
+
+Calculated using a power curve with code at
+https://github.com/broadinstitute/gnomad_lof/blob/master/R/efig7_constraint.R.
+
+Default is 16.
+
+For gnomAD v2, this number was calculated with using 18,629 transcripts.
+18,629 transcripts corresponds to an exome wide significance level of 2.7e-6.
+On the power curve, this significance threshold corresponds to a minimum
+number of expected missense equal to 16.
+"""
+
 
 ####################################################################################
 ## Original regional missense constraint resource files

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -231,7 +231,7 @@ def single_search_round_ht_path(
     """
     break_status = "break_found" if is_break_found else "no_break_found"
     breakpoint_status = "_breakpoint_only" if is_breakpoint_only else ""
-    return f"{SINGLE_BREAK_TEMP_PATH}/{freeze}/round{search_num}/{break_status}{breakpoint_status}.ht"
+    return f"{single_search_bucket_path(search_num, freeze)}/{break_status}{breakpoint_status}.ht"
 
 
 SIMUL_SEARCH_BUCKET_NAMES = {"prep", "raw_results", "final_results", "success_files"}

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -57,7 +57,7 @@ Look-up table reference:
 https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm
 """
 
-MIN_EXP_MIS = 16
+MIN_EXP_MIS = 16.0
 """
 Minimum number of expected missense variants within each RMC section.
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -29,7 +29,7 @@ from rmc.resources.rmc import (
     CURRENT_FREEZE,
     FINAL_ANNOTATIONS,
     MIN_EXP_MIS,
-    no_breaks,
+    no_breaks_he_path,
     oe_bin_counts_tsv,
     simul_search_bucket_path,
     SIMUL_SEARCH_ANNOTATIONS,
@@ -770,10 +770,11 @@ def process_sections(
     return ht
 
 
-def create_no_breaks_he(overwrite: bool) -> None:
+def create_no_breaks_he(freeze: int, overwrite: bool) -> None:
     """
     Write final no breaks HailExpression.
 
+    :param freeze: RMC freeze number.
     :param overwrite: Whether to overwrite output data if it exists.
     :return: None; function writes HailExpression to resource path.
     """
@@ -802,7 +803,7 @@ def create_no_breaks_he(overwrite: bool) -> None:
     )
     no_break_transcripts = hl.map(lambda x: x.split("_")[0], no_break_sections)
     hl.experimental.write_expression(
-        no_break_transcripts, no_breaks, overwrite=overwrite
+        no_break_transcripts, no_breaks_he_path(freeze), overwrite=overwrite
     )
 
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -25,6 +25,7 @@ from rmc.utils.generic import (
 from rmc.resources.rmc import (
     CHISQ_THRESHOLDS,
     CONSTRAINT_ANNOTATIONS,
+    CURRENT_FREEZE,
     FINAL_ANNOTATIONS,
     no_breaks,
     oe_bin_counts_tsv,
@@ -898,7 +899,7 @@ def get_break_search_round_nums(
     return sorted(round_nums)
 
 
-def check_break_search_round_nums() -> List[int]:
+def check_break_search_round_nums(freeze: int = CURRENT_FREEZE) -> List[int]:
     """
     Check for valid single and simultaneous break search round number outputs.
 
@@ -908,11 +909,16 @@ def check_break_search_round_nums() -> List[int]:
     .. note::
         Assumes there is a folder for each search round run, regardless of whether there were breaks discovered
 
+    :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
     :return: Sorted list of round numbers.
     """
     # Get sorted round numbers
-    single_search_round_nums = get_break_search_round_nums(single_search_bucket_path())
-    simul_search_round_nums = get_break_search_round_nums(simul_search_bucket_path())
+    single_search_round_nums = get_break_search_round_nums(
+        single_search_bucket_path(freeze)
+    )
+    simul_search_round_nums = get_break_search_round_nums(
+        simul_search_bucket_path(freeze)
+    )
     logger.info(
         "Single search round numbers: %s\nSimultaneous search round numbers: %s",
         ",".join(map(str, single_search_round_nums)),

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -646,7 +646,7 @@ def search_for_break(
         overwrite=True,
     )
 
-    ht = get_max_chisq_per_group(ht, group_str, "chisq")
+    ht = get_max_chisq_per_group(ht, group_str, "chisq", freeze)
     return ht.annotate(
         is_break=((ht.chisq == ht.section_max_chisq) & (ht.chisq >= chisq_threshold))
     )

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -28,6 +28,7 @@ from rmc.resources.rmc import (
     CONSTRAINT_ANNOTATIONS,
     CURRENT_FREEZE,
     FINAL_ANNOTATIONS,
+    MIN_EXP_MIS,
     no_breaks,
     oe_bin_counts_tsv,
     simul_search_bucket_path,
@@ -529,9 +530,8 @@ def search_for_break(
     search_num: int,
     chisq_threshold: float = CHISQ_THRESHOLDS["single"],
     group_str: str = "section",
-    min_num_exp_mis: float = 10.0,
+    min_num_exp_mis: float = MIN_EXP_MIS,
     save_chisq_ht: bool = False,
-    min_chisq_threshold: float = 2.7,
 ) -> hl.Table:
     """
     Search for breakpoints in a transcript or within a transcript subsection.
@@ -561,11 +561,14 @@ def search_for_break(
         (e.g., second round of searching for single break would be 2).
     :param chisq_threshold: Chi-square significance threshold.
         Default is CHISQ_THRESHOLDS['single'].
+        Default value used in ExAC was 10.8, which corresponds to a p-value of 0.001
+        with 1 degree of freedom.
+        (https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm)
     :param group_str: Field used to group Table observed and expected values. Default is 'section'.
     :param min_num_exp_mis: Minimum number of expected missense per transcript/transcript section.
         Sections that have fewer than this number of expected missense variants will not
         be computed (chi square will be annotated as a missing value).
-        Default is 10.
+        Default is MIN_EXP_MIS.
     :param save_chisq_ht: Whether to save HT with chi square values annotated for every locus.
         This saves a lot of extra data and should only occur during the initial search round.
         Default is False.
@@ -723,6 +726,9 @@ def process_sections(
         (e.g., second round of searching for single break would be 2).
     :param chisq_threshold: Chi-square significance threshold.
         Default is CHISQ_THRESHOLDS['single'].
+        Default value used in ExAC was 10.8, which corresponds to a p-value of 0.001
+        with 1 degree of freedom.
+        (https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm)
     :param group_str: Field used to group observed and expected values. Default is 'section'.
     :param save_chisq_ht: Whether to save HT with chi square values annotated for every locus.
         This saves a lot of extra data and should only occur during the initial search round.

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -531,6 +531,7 @@ def search_for_break(
     group_str: str = "section",
     min_num_exp_mis: float = 10.0,
     save_chisq_ht: bool = False,
+    min_chisq_threshold: float = 2.7,
 ) -> hl.Table:
     """
     Search for breakpoints in a transcript or within a transcript subsection.
@@ -565,8 +566,7 @@ def search_for_break(
         Sections that have fewer than this number of expected missense variants will not
         be computed (chi square will be annotated as a missing value).
         Default is 10.
-    :param save_chisq_ht: Whether to save HT with chi square values annotated for every locus
-        (as long as chi square value is >= min_chisq_threshold).
+    :param save_chisq_ht: Whether to save HT with chi square values annotated for every locus.
         This saves a lot of extra data and should only occur during the initial search round.
         Default is False.
     :return: Table annotated with whether position is a breakpoint (`is_break`).
@@ -724,8 +724,7 @@ def process_sections(
     :param chisq_threshold: Chi-square significance threshold.
         Default is CHISQ_THRESHOLDS['single'].
     :param group_str: Field used to group observed and expected values. Default is 'section'.
-    :param save_chisq_ht: Whether to save HT with chi square values annotated for every locus
-        (as long as chi square value is >= min_chisq_threshold).
+    :param save_chisq_ht: Whether to save HT with chi square values annotated for every locus.
         This saves a lot of extra data and should only occur during the initial search round.
         Default is False.
     :return: Table annotated with whether position is a breakpoint.

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -570,7 +570,7 @@ def search_for_break(
         be computed (chi square will be annotated as a missing value).
         Default is MIN_EXP_MIS.
     :param save_chisq_ht: Whether to save HT with chi square values annotated for every locus.
-        This saves a lot of extra data and should only occur during the initial search round.
+        This saves a lot of extra data and should only occur once.
         Default is False.
     :return: Table annotated with whether position is a breakpoint (`is_break`).
     """

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -123,10 +123,6 @@ def process_context_ht(
     Filter to missense variants in canonical protein coding transcripts.
     Also annotate with probability of mutation for each variant, CpG status, and methylation level.
 
-    .. note::
-        `trimers` needs to be True for gnomAD v2.
-
-    :param bool trimers: Whether to filter to trimers (if set to True) or heptamers. Default is True.
     :param bool filter_to_missense: Whether to filter Table to missense variants only. Default is True.
     :param bool add_annotations: Whether to add ref, alt, methylation_level, exome_coverage, cpg, transition,
         and mutation_type annotations. Default is True.
@@ -357,7 +353,6 @@ def generate_models(
     coverage_ht: hl.Table,
     coverage_x_ht: hl.Table,
     coverage_y_ht: hl.Table,
-    trimers: bool,
     weighted: bool = True,
 ) -> Tuple[
     Tuple[float, float],
@@ -371,7 +366,6 @@ def generate_models(
     :param hl.Table coverage_ht: Table with proportion of variants observed by coverage (autosomes/PAR only).
     :param hl.Table coverage_x_ht: Table with proportion of variants observed by coverage (chrX only).
     :param hl.Table coverage_y_ht: Table with proportion of variants observed by coverage (chrY only).
-    :param bool trimers: Whether to use trimers instead of heptamers.
     :param bool weighted: Whether to use weighted least squares when building models. Default is True.
     :return: Coverage model, plateau models for autosomes, plateau models for chrX, plateau models for chrY.
     :rtype: Tuple[Tuple[float, float], hl.expr.DictExpression, hl.expr.DictExpression, hl.expr.DictExpression]
@@ -385,12 +379,8 @@ def generate_models(
     logger.info("Building plateau models for chrX and chrY...")
     # TODO: make half_cutoff (for coverage cutoff) True for X/Y?
     # This would also mean saving new coverage model for allosomes
-    _, plateau_x_models = build_models(
-        coverage_x_ht, trimers=trimers, weighted=weighted
-    )
-    _, plateau_y_models = build_models(
-        coverage_y_ht, trimers=trimers, weighted=weighted
-    )
+    _, plateau_x_models = build_models(coverage_x_ht, weighted=weighted)
+    _, plateau_y_models = build_models(coverage_y_ht, weighted=weighted)
     return (coverage_model, plateau_models, plateau_x_models, plateau_y_models)
 
 

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -8,6 +8,8 @@ from gnomad.utils.file_utils import file_exists, parallel_file_exists
 
 from rmc.resources.basics import SIMUL_BREAK_TEMP_PATH, TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.rmc import (
+    CHISQ_THRESHOLDS,
+    MIN_EXP_MIS,
     simul_search_round_bucket_path,
     simul_sections_split_by_len_path,
 )
@@ -310,7 +312,7 @@ def calculate_window_chisq(
 def search_for_two_breaks(
     group_ht: hl.Table,
     count: int,
-    chisq_threshold: float = 9.2,
+    chisq_threshold: float = CHISQ_THRESHOLDS["simul"],
     min_num_exp_mis: float = 10,
     min_chisq_threshold: float = 7.4,
     save_chisq_ht: bool = False,
@@ -325,10 +327,11 @@ def search_for_two_breaks(
         and expected missense values. HT is filtered to contain only transcript/sections without
         a single significant breakpoint.
     :param count: Which transcript or transcript section group is being run (based on counter generated in `main`).
-    :param chisq_threshold:  Chi-square significance threshold. Default is 9.2.
-        This value corresponds to a p-value of 0.01 with 2 degrees of freedom.
+    :param chisq_threshold: Chi-square significance threshold. Default is
+        CHISQ_THRESHOLDS['simul'].
+        Default value used in ExAC was 13.8, which corresponds to a p-value of 0.001
+        with 2 degrees of freedom.
         (https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm)
-        Default value used in ExAC was 13.8, which corresponds to a p-value of 0.001.
     :param min_num_exp_mis: Minimum expected missense value for all three windows defined by two possible
         simultaneous breaks.
     :param min_chisq_threshold: Minimum chi square value to emit from search.
@@ -412,8 +415,8 @@ def process_section_group(
     over_threshold: bool,
     output_ht_path: str,
     output_n_partitions: int = 10,
-    chisq_threshold: float = 9.2,
-    min_num_exp_mis: float = 10,
+    chisq_threshold: float = CHISQ_THRESHOLDS["simul"],
+    min_num_exp_mis: float = MIN_EXP_MIS,
     split_list_len: int = 500,
     read_if_exists: bool = False,
     save_chisq_ht: bool = False,
@@ -434,12 +437,14 @@ def process_section_group(
     :param output_ht_path: Path to output results Table.
     :param output_n_partitions: Desired number of partitions for output Table.
         Default is 10.
-    :param chisq_threshold: Chi-square significance threshold. Default is 9.2.
-        This value corresponds to a p-value of 0.01 with 2 degrees of freedom.
+    :param chisq_threshold: Chi-square significance threshold. Default is
+        CHISQ_THRESHOLDS['simul'].
+        Default value used in ExAC was 13.8, which corresponds to a p-value of 0.001
+        with 2 degrees of freedom.
         (https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm)
-        Default value used in ExAC was 13.8, which corresponds to a p-value of 0.001.
     :param min_num_exp_mis: Minimum expected missense value for all three windows defined by two possible
         simultaneous breaks.
+        Default is MIN_EXP_MIS.
     :param split_list_len: Max length to divide transcript/sections observed or expected missense and position lists into.
         E.g., if split_list_len is 500, and the list lengths are 998, then the transcript/section will be
         split into two rows with lists of length 500 and 498.

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -458,7 +458,7 @@ def process_section_group(
         Default is False.
     :param save_chisq_ht: Whether to save HT with chi square values annotated for every locus
         (as long as chi square value is >= min_chisq_threshold).
-        This saves a lot of extra data and should only occur during the initial search round.
+        This saves a lot of extra data and should only occur once.
         Default is False.
     :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
     :return: None; processes Table and writes to path. Also writes success TSV to path.

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -395,16 +395,13 @@ def search_for_two_breaks(
             group_ht.positions[group_ht.best_break.j],
         ),
     )
+    group_ht_path = (
+        f"{TEMP_PATH_WITH_FAST_DEL}/freeze{freeze}_dataproc_temp_chisq_group{count}.ht"
+    )
     if save_chisq_ht:
-        group_ht = group_ht.checkpoint(
-            f"{SIMUL_BREAK_TEMP_PATH}/freeze{freeze}_dataproc_temp_chisq_group{count}.ht",
-            overwrite=True,
-        )
-    else:
-        group_ht = group_ht.checkpoint(
-            f"{TEMP_PATH_WITH_FAST_DEL}/freeze{freeze}_dataproc_temp_chisq_group{count}.ht",
-            overwrite=True,
-        )
+        group_ht_path = f"{SIMUL_BREAK_TEMP_PATH}/freeze{freeze}/dataproc_temp_chisq_group{count}.ht"
+    group_ht = group_ht.checkpoint(group_ht_path, overwrite=True)
+
     # Remove rows with maximum chi square values below the threshold
     group_ht = group_ht.filter(group_ht.max_chisq >= chisq_threshold)
     return group_ht

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -9,6 +9,7 @@ from gnomad.utils.file_utils import file_exists, parallel_file_exists
 from rmc.resources.basics import SIMUL_BREAK_TEMP_PATH, TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.rmc import (
     CHISQ_THRESHOLDS,
+    MIN_CHISQ_THRESHOLD,
     MIN_EXP_MIS,
     simul_search_round_bucket_path,
     simul_sections_split_by_len_path,
@@ -314,7 +315,7 @@ def search_for_two_breaks(
     count: int,
     chisq_threshold: float = CHISQ_THRESHOLDS["simul"],
     min_num_exp_mis: float = 10,
-    min_chisq_threshold: float = 7.4,
+    min_chisq_threshold: float = MIN_CHISQ_THRESHOLD,
     save_chisq_ht: bool = False,
     freeze: int = CURRENT_FREEZE,
 ) -> hl.Table:
@@ -335,7 +336,8 @@ def search_for_two_breaks(
     :param min_num_exp_mis: Minimum expected missense value for all three windows defined by two possible
         simultaneous breaks.
     :param min_chisq_threshold: Minimum chi square value to emit from search.
-        Default is 7.4, which corresponds to a p-value of 0.025 with 2 degrees of freedom.
+        Default is MIN_CHISQ_THRESHOLD,
+        which corresponds to a p-value of 0.025 with 2 degrees of freedom.
     :param save_chisq_ht: Whether to save HT with chi square values annotated for every locus
         (as long as chi square value is >= min_chisq_threshold).
         This saves a lot of extra data and should only occur during the initial search round.

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -557,7 +557,7 @@ def process_section_group(
         # If any rows had a significant breakpoint,
         # find the one "best" breakpoint (breakpoint with largest chi square value)
         if ht.count() > 0:
-            ht = get_max_chisq_per_group(ht, "section", "max_chisq")
+            ht = get_max_chisq_per_group(ht, "section", "max_chisq", freeze)
             ht = ht.filter(ht.max_chisq == ht.section_max_chisq)
 
     ht = ht.annotate_globals(chisq_threshold=chisq_threshold)

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -9,6 +9,7 @@ from gnomad.utils.file_utils import file_exists, parallel_file_exists
 from rmc.resources.basics import SIMUL_BREAK_TEMP_PATH, TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.rmc import (
     CHISQ_THRESHOLDS,
+    CURRENT_FREEZE,
     MIN_CHISQ_THRESHOLD,
     MIN_EXP_MIS,
     simul_search_round_bucket_path,

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -315,7 +315,7 @@ def search_for_two_breaks(
     group_ht: hl.Table,
     count: int,
     chisq_threshold: float = CHISQ_THRESHOLDS["simul"],
-    min_num_exp_mis: float = 10,
+    min_num_exp_mis: float = MIN_EXP_MIS,
     min_chisq_threshold: float = MIN_CHISQ_THRESHOLD,
     save_chisq_ht: bool = False,
     freeze: int = CURRENT_FREEZE,


### PR DESCRIPTION
Major changes:

- Re-added save chi square HT option for single break search to allow for easier re-runs (avoid needing to re-run round 1 of single break search)
- Added freeze argument to pipeline and utility scripts missed last round

Minor changes:

- Added option to initialize Hail quietly (I want to test how how this looks)