### PR TITLE
Use pre-commit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install wheel
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
-      - name: Check formatting
-        run: black --check **/*.py
-      - name: Check docstrings
-        run: pydocstyle **/*.py
-      - name: Run Pylint
-        run: pylint **/*.py
+          pip install -r requirements.txt -r requirements-dev.txt
+      - name: Run pre-commit
+        run: |
+          pre-commit run --all


### PR DESCRIPTION
Keeps up to date with all pre-commit hooks without having to run the tools separately