### PR TITLE
Add mypy to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: pydocstyle
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961
+    rev: v1.0.1
     hooks:
       - id: mypy
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,9 @@ repos:
             --install-types,
             --non-interactive,
           ]
+    - repo: https://github.com/pycqa/isort
+      rev: 5.10.1 # This should be kept in sync with the version in requirements-dev.in
+      hooks:
+        - id: isort
+          args: ["--profile", "black", "--filter-files"]
+          files: rmc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,17 @@ repos:
     rev: 6.0.0
     hooks:
       - id: pydocstyle
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.961
+    hooks:
+      - id: mypy
+        args:
+          [
+            --pretty,
+            --show-error-codes,
+            --no-strict-optional,
+            --ignore-missing-imports,
+            --install-types,
+            --non-interactive,
+          ]


### PR DESCRIPTION
Feel free to close if not desired, but we find it handy internally to use mypy as it's better at catching type errors.