### PR TITLE
Moved comment in precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,7 @@ repos:
     rev: 6.0.0
     hooks:
       - id: pydocstyle
-  # Using system installation of pylint to support checking python module imports
-  - repo: local
+  - repo: local # Using system installation of pylint to support checking python module imports
     hooks:
       - id: pylint
         name: pylint

--- a/.pylintrc
+++ b/.pylintrc
@@ -17,5 +17,8 @@ disable=
   redefined-outer-name,
   unused-variable,
   unused-wildcard-import,
-  # hail uses unary options
+  # Hail uses unary options
   invalid-unary-operand-type,
+  # Ignore generic import error and slack_cred import error
+  E0401,
+  E0611,


### PR DESCRIPTION
Trying to fix this error: 
```
Run pre-commit run --all
An error has occurred: InvalidConfigError: 
==> File .pre-commit-config.yaml
=====> while parsing a block mapping
  in "<unicode string>", line 1[9](https://github.com/broadinstitute/regional_missense_constraint/actions/runs/4204756469/jobs/7295864041#step:6:10), column 5
did not find expected key
  in "<unicode string>", line 32, column 5
Check the log at /home/runner/.cache/pre-commit/pre-commit.log
Error: Process completed with exit code 1.
```

Also disabled import error warnings and errors regarding `slack_creds`