### PR TITLE
Fix2

### DIFF
--- a/rmc/pipeline/calculate_missense_badness.py
+++ b/rmc/pipeline/calculate_missense_badness.py
@@ -64,7 +64,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--slack-channel",
         help="Send message to Slack channel/user.",
-        default="@kc (she/her)",
     )
 
     # Create subparsers for each step

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -442,7 +442,7 @@ def process_section_group(
     hl.init(
         spark_conf={
             "spark.hadoop.fs.gs.requester.pays.mode": "CUSTOM",
-            "spark.hadoop.fs.gs.requester.pays.buckets": f"{requester_pays_bucket.lstrip('gs://')}",
+            "spark.hadoop.fs.gs.requester.pays.buckets": f"{requester_pays_bucket.lstrip('gs:/')}",
             "spark.hadoop.fs.gs.requester.pays.project.id": f"{google_project}",
         },
         tmp_dir=TEMP_PATH_WITH_FAST_DEL,
@@ -568,7 +568,7 @@ def main(args):
     hl.init(
         spark_conf={
             "spark.hadoop.fs.gs.requester.pays.mode": "CUSTOM",
-            "spark.hadoop.fs.gs.requester.pays.buckets": f"{RMC_PREFIX.lstrip('gs://')}",
+            "spark.hadoop.fs.gs.requester.pays.buckets": f"{RMC_PREFIX.lstrip('gs:/')}",
             "spark.hadoop.fs.gs.requester.pays.project.id": f"{args.google_project}",
         },
         log="search_for_two_breaks_run_batches.log",

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -827,7 +827,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--batch-bucket",
         help="Bucket provided to hail batch for temporary storage.",
-        default="gs://gnomad-tmp/kc/",
+        default=TEMP_PATH_WITH_FAST_DEL,
     )
     parser.add_argument(
         "--google-project",

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -566,7 +566,13 @@ def process_section_group(
 def main(args):
     """Search for two simultaneous breaks in transcripts without evidence of a single significant break."""
     hl.init(
-        log="search_for_two_breaks_run_batches.log", tmp_dir=TEMP_PATH_WITH_FAST_DEL
+        spark_conf={
+            "spark.hadoop.fs.gs.requester.pays.mode": "CUSTOM",
+            "spark.hadoop.fs.gs.requester.pays.buckets": f"{RMC_PREFIX.lstrip('gs://')}",
+            "spark.hadoop.fs.gs.requester.pays.project.id": f"{args.google_project}",
+        },
+        log="search_for_two_breaks_run_batches.log",
+        tmp_dir=TEMP_PATH_WITH_FAST_DEL,
     )
 
     # Make sure custom machine wasn't specified with under threshold

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -827,7 +827,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--batch-bucket",
         help="Bucket provided to hail batch for temporary storage.",
-        default=TEMP_PATH_WITH_FAST_DEL,
+        default=f"{TEMP_PATH_WITH_FAST_DEL}/rmc/",
     )
     parser.add_argument(
         "--google-project",

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -121,6 +121,7 @@ def main(args):
                 split_list_len=args.split_list_len,
                 read_if_exists=args.read_if_exists,
                 save_chisq_ht=args.save_chisq_ht,
+                freeze=args.freeze,
             )
 
     finally:

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -791,6 +791,7 @@ def create_no_breaks_he(freeze: int, overwrite: bool) -> None:
     simul_results_path = simul_search_round_bucket_path(
         search_num=1,
         bucket_type="final_results",
+        freeze=freeze,
     )
     simul_ht = hl.read_table(
         f"{simul_results_path}/merged.ht",
@@ -803,6 +804,7 @@ def create_no_breaks_he(freeze: int, overwrite: bool) -> None:
             search_num=1,
             is_break_found=False,
             is_breakpoint_only=False,
+            freeze=freeze,
         )
     )
     ht = ht.filter(~hl.literal(simul_sections).contains(ht.section))

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -542,6 +542,7 @@ def process_section_group(
         chisq_threshold=chisq_threshold,
         min_num_exp_mis=min_num_exp_mis,
         save_chisq_ht=save_chisq_ht,
+        freeze=freeze,
     )
 
     # If over threshold, checkpoint HT and check if there were any breaks


### PR DESCRIPTION
This PR adds further fixes to the RMC break search code, most importantly missing freeze arguments. It also adds configs for requester-pays to the batch script and removes references to specific users (e.g. directs the batch temp directory to a more general bucket). Minor change: removal of duplicate characters in `lstrip` calls.