### PR TITLE
Update globals of final RMC HT

### DIFF
--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -540,6 +540,8 @@ def main(args):
 
             logger.info("Finalizing section-level RMC table...")
             rmc_ht = merge_rmc_hts(round_nums=round_nums, freeze=args.freeze)
+            # Drop any unnecessary global fields
+            rmc_ht = rmc_ht.select_globals()
             rmc_ht = rmc_ht.checkpoint(
                 f"{TEMP_PATH_WITH_SLOW_DEL}/freeze{args.freeze}_rmc_results.ht",
                 overwrite=args.overwrite,
@@ -549,6 +551,16 @@ def main(args):
             logger.info("Removing outlier transcripts...")
             constraint_transcripts = get_constraint_transcripts(outlier=False)
             rmc_ht = rmc_ht.filter(constraint_transcripts.contains(rmc_ht.transcript))
+
+            # Add p-value threshold to globals
+            if not args.p_value:
+                logger.warning(
+                    "p-value threshold not specified! Defaulting to value stored in `P_VALUE` constant..."
+                )
+                p_value = P_VALUE
+            else:
+                p_value = args.p_value
+            rmc_ht = rmc_ht.annotate_globals(p_value=p_value)
 
             logger.info("Writing out RMC results...")
             rmc_ht.write(rmc_results.versions[int(args.freeze)].path)
@@ -631,6 +643,9 @@ if __name__ == "__main__":
         help="""
         p-value significance threshold for single break search.
         Used to determine chi square threshold for likelihood ratio test.
+
+        Also used to annotate globals of final RMC HT with p-value associated
+        with RMC results.
 
         If not specified, script will default to threshold set
         in `P_VALUE`.


### PR DESCRIPTION
This PR adds minor changes to the schema of the final regional missense constraint (RMC) results Hail Table (HT).

The current schema is:
```
----------------------------------------
Global fields:
    'plateau_models': struct {
        'total': dict<bool, array<float64>>
    }
    'plateau_x_models': struct {
        'total': dict<bool, array<float64>>
    }
    'plateau_y_models': struct {
        'total': dict<bool, array<float64>>
    }
    'coverage_model': tuple<float64, float64>
----------------------------------------
Row fields:
    'section_obs': int64
    'section_exp': float64
    'section_oe': float64
    'section_chisq': float64
    'transcript': str
    'interval': interval<locus<grch37>>
----------------------------------------
Key: ['interval', 'transcript']
----------------------------------------
```

This PR removes the models from the globals (they do not need to be stored on the results HT and are taking up unnecessary space) and adds the p-value threshold associated with RMC region search/the resulting regions to the final RMC HT.