### PR TITLE
Reference data bug fixes

### DIFF
--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -98,7 +98,6 @@ Table of ClinVar variants maintained by the seqr team.
 Last version of this HT accessed by RMC team corresponds to 20230121 ClinVar release.
 """
 
-# TODO: Move HT at `clinvar_pathogenic_missense.ht` to this path
 clinvar_plp_mis_haplo = TableResource(
     path=f"{REF_DATA_PREFIX}/ht/clinvar_pathogenic_missense_haplo.ht",
 )

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -157,7 +157,6 @@ Fu et al. Rare coding variation provides insight into the genetic architecture
 and phenotypic context of autism (2022)
 """
 
-# TODO: Move HT at `ddd_autism_de_novo.ht` to this path
 ndd_de_novo = TableResource(
     path=f"{RESOURCE_BUILD_PREFIX}/reference_data/ht/ndd_de_novo.ht",
 )

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -727,20 +727,13 @@ def import_de_novo_variants(overwrite: bool, n_partitions: int = 5000) -> None:
 
     # Union sample types (DD, ASD, control)
     ht = ht.transmute(
-        role_str=hl.str(",").join(ht.role),
-        case_control_str=hl.str(",").join(ht.case_control),
-    )
-    ht = ht.transmute(
         sample_set=hl.case()
         .when(
-            hl.is_defined(ht.case_control_str) & hl.is_defined(ht.role_str),
-            ht.case_control_str + ht.role_str,
+            hl.is_defined(ht.case_control) & hl.is_defined(ht.role),
+            ht.case_control.extend(ht.role),
         )
-        .when(
-            hl.is_defined(ht.case_control_str) & hl.is_missing(ht.role_str),
-            ht.case_control_str,
-        )
-        .default(ht.role_str)
+        .when(hl.is_defined(ht.case_control), ht.case_control)
+        .when(hl.is_defined(ht.role), ht.role)
+        .or_missing()
     )
-    ht = ht.transmute(sample_set=ht.sample_set.split(","))
     ht.write(ndd_de_novo.path, overwrite=overwrite)

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -718,12 +718,13 @@ def import_de_novo_variants(overwrite: bool, n_partitions: int = 5000) -> None:
     kaplanis_ht_path = f"{TEMP_PATH_WITH_FAST_DEL}/kaplanis_dn.ht"
     if not file_exists(fu_ht_path) or overwrite:
         import_fu_data(overwrite=overwrite)
-        fu_ht = hl.read_table(fu_ht_path, _n_partitions=n_partitions)
     if not file_exists(kaplanis_ht_path) or overwrite:
         import_kaplanis_data(overwrite=overwrite)
-        kap_ht = hl.read_table(kaplanis_ht_path, _n_partitions=n_partitions)
 
+    fu_ht = hl.read_table(fu_ht_path, _n_partitions=n_partitions)
+    kap_ht = hl.read_table(kaplanis_ht_path, _n_partitions=n_partitions)
     ht = kap_ht.join(fu_ht, how="outer")
+
     # Union sample types (DD, ASD, control)
-    ht = ht.transmute(sample_set=ht.case_control.union(ht.role))
+    ht = ht.transmute(sample_set=ht.case_control.extend(ht.role))
     ht.write(ndd_de_novo.path, overwrite=overwrite)

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -714,7 +714,6 @@ def import_de_novo_variants(overwrite: bool, n_partitions: int = 5000) -> None:
         Will also help determine number of partitions in final Table.
     :return: None; writes HT to resource path.
     """
-    # TODO: Re-import this HT with samples collected into lists rather than sets
     fu_ht_path = f"{TEMP_PATH_WITH_FAST_DEL}/fu_dn.ht"
     kaplanis_ht_path = f"{TEMP_PATH_WITH_FAST_DEL}/kaplanis_dn.ht"
     if not file_exists(fu_ht_path) or overwrite:

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -671,7 +671,7 @@ def import_fu_data(overwrite: bool) -> None:
     # Rename 'Proband' > 'ASD' and 'Sibling' > 'control'
     fu_ht = fu_ht.transmute(role=hl.if_else(fu_ht.Role == "Proband", "ASD", "control"))
     fu_ht = fu_ht.group_by("locus", "alleles").aggregate(
-        role=hl.agg.collect(fu_ht.Role),
+        role=hl.agg.collect(fu_ht.role),
     )
     fu_ht.write(f"{TEMP_PATH_WITH_FAST_DEL}/fu_dn.ht", overwrite=overwrite)
 


### PR DESCRIPTION
This PR removes TODOs left in reference data import code (after paths were fixed in https://github.com/broadinstitute/rmc_production/issues/89) and adds minor fixes to the NDD de novo dataset import code

- Removed TODOs around NDD de novo and ClinVar P/LP haplo HT paths
- Added accidentally missed annotations in function to import Fu Data
- Added accidentally missed not (`~`) in import Fu data function
- Fixed sample set join in import de novo function
^I know this last one is ugly, but using [`extend`](https://hail.is/docs/0.2/hail.expr.ArrayExpression.html#hail.expr.ArrayExpression.extend) to concatenate the arrays wasn't working, so I picked an uglier method. Very open to suggestions here