### PR TITLE
Rearrange RMC and generic code

### DIFF
--- a/rmc/pipeline/calculate_missense_badness.py
+++ b/rmc/pipeline/calculate_missense_badness.py
@@ -11,6 +11,7 @@ import hail as hl
 from gnomad.utils.slack import slack_notifications
 
 from rmc.resources.basics import LOGGING_PATH, TEMP_PATH_WITH_FAST_DEL
+from rmc.resources.rmc import CURRENT_FREEZE
 from rmc.slack_creds import slack_token
 from rmc.utils.missense_badness import calculate_misbad, prepare_amino_acid_ht
 
@@ -32,6 +33,7 @@ def main(args):
             prepare_amino_acid_ht(
                 overwrite_temp=args.overwrite_temp,
                 overwrite_output=args.overwrite_output,
+                freeze=args.freeze,
             )
 
         if args.command == "create-misbad":
@@ -40,6 +42,7 @@ def main(args):
                 use_exac_oe_cutoffs=args.use_exac_oe_cutoffs,
                 overwrite_temp=args.overwrite_temp,
                 overwrite_output=args.overwrite_output,
+                freeze=args.freeze,
             )
 
     finally:
@@ -60,6 +63,12 @@ if __name__ == "__main__":
         "--overwrite-output",
         help="Completely overwrite existing final output data, for use in functions with option to modify existing final output data.",
         action="store_true",
+    )
+    parser.add_argument(
+        "--freeze",
+        help="RMC data freeze number",
+        type=int,
+        default=CURRENT_FREEZE,
     )
     parser.add_argument(
         "--slack-channel",

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -552,13 +552,13 @@ def main(args):
             rmc_ht = rmc_ht.filter(constraint_transcripts.contains(rmc_ht.transcript))
 
             logger.info("Writing out RMC results...")
-            rmc_ht.write(rmc_results.versions[int(args.freeze)].path)
+            rmc_ht.write(rmc_results.versions[args.freeze].path)
 
             logger.info("Getting transcripts without evidence of RMC...")
             create_no_breaks_he(freeze=args.freeze, overwrite=args.overwrite)
 
             logger.info("Creating OE-annotated context table...")
-            create_context_with_oe(freeze=int(args.freeze), overwrite_output=args.overwrite)
+            create_context_with_oe(freeze=args.freeze, overwrite_output=args.overwrite)
 
     finally:
         logger.info("Copying hail log to logging bucket...")
@@ -644,6 +644,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--freeze",
         help="RMC data freeze number",
+        type=int,
         default=CURRENT_FREEZE,
     )
     parser.add_argument(

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -35,6 +35,7 @@ from rmc.utils.constraint import (
     calculate_exp_per_transcript,
     calculate_observed,
     check_break_search_round_nums,
+    create_context_with_oe,
     create_no_breaks_he,
     get_max_chisq_per_group,
     GROUPINGS,
@@ -555,6 +556,11 @@ def main(args):
 
             logger.info("Getting transcripts without evidence of RMC...")
             create_no_breaks_he(freeze=args.freeze, overwrite=args.overwrite)
+
+            logger.info("Creating OE-annotated context table")
+            create_context_with_oe(
+                overwrite_temp=args.overwrite, overwrite_output=args.overwrite
+            )
 
     finally:
         logger.info("Copying hail log to logging bucket...")

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -557,7 +557,7 @@ def main(args):
             logger.info("Getting transcripts without evidence of RMC...")
             create_no_breaks_he(freeze=args.freeze, overwrite=args.overwrite)
 
-            logger.info("Creating OE-annotated context table")
+            logger.info("Creating OE-annotated context table...")
             create_context_with_oe(freeze=args.freeze, overwrite_output=args.overwrite)
 
     finally:

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -558,7 +558,7 @@ def main(args):
             create_no_breaks_he(freeze=args.freeze, overwrite=args.overwrite)
 
             logger.info("Creating OE-annotated context table...")
-            create_context_with_oe(freeze=args.freeze, overwrite_output=args.overwrite)
+            create_context_with_oe(freeze=int(args.freeze), overwrite_output=args.overwrite)
 
     finally:
         logger.info("Copying hail log to logging bucket...")

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -558,9 +558,7 @@ def main(args):
             create_no_breaks_he(freeze=args.freeze, overwrite=args.overwrite)
 
             logger.info("Creating OE-annotated context table")
-            create_context_with_oe(
-                overwrite_temp=args.overwrite, overwrite_output=args.overwrite
-            )
+            create_context_with_oe(freeze=args.freeze, overwrite_output=args.overwrite)
 
     finally:
         logger.info("Copying hail log to logging bucket...")

--- a/rmc/pipeline/two_breaks/merge_hts.py
+++ b/rmc/pipeline/two_breaks/merge_hts.py
@@ -86,6 +86,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--freeze",
         help="RMC data freeze number",
+        type=int,
         default=CURRENT_FREEZE,
     )
     parser.add_argument(

--- a/rmc/pipeline/two_breaks/prepare_transcripts.py
+++ b/rmc/pipeline/two_breaks/prepare_transcripts.py
@@ -103,6 +103,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--freeze",
         help="RMC data freeze number",
+        type=int,
         default=CURRENT_FREEZE,
     )
     # Create subparsers for each step

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -782,6 +782,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--freeze",
         help="RMC data freeze number",
+        type=int,
         default=CURRENT_FREEZE,
     )
     parser.add_argument(

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -141,6 +141,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--freeze",
         help="RMC data freeze number",
+        type=int,
         default=CURRENT_FREEZE,
     )
     parser.add_argument(

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -497,48 +497,55 @@ Table containing all possible amino acid substitutions and their missense badnes
 ####################################################################################
 ## MPC related resources
 ####################################################################################
-CURRENT_MPC_PREFIX = f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{CURRENT_FREEZE}"
+joint_clinvar_gnomad = VersionedTableResource(
+    default_version=CURRENT_FREEZE,
+    versions={
+        freeze: TableResource(
+            path=f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/joint_clinvar_gnomad.ht"
+        )
+        for freeze in FREEZES
+    },
+)
+"""
+Table containing "population" and "pathogenic" variants.
+
+Table contains common (AF > 0.001) gnomAD variants ("population") and
+ClinVar pathogenic/likely pathogenic missense variants in haploinsufficient genes
+that cause severe disease ("pathogenic") with defined CADD, BLOSUM, Grantham, missense observed/expected ratios,
+missense badness, and PolyPhen-2 scores.
+
+Table is input to MPC (missense badness, polyphen-2, and constraint) calculations.
+"""
 
 
-def joint_clinvar_gnomad_path() -> str:
-    """
-    Return path to Table containing "population" and "pathogenic" variants.
-
-    Table contains common (AF > 0.001) gnomAD variants ("population") and
-    ClinVar pathogenic/likely pathogenic missense variants in haploinsufficient genes
-    that cause severe disease ("pathogenic") with defined CADD, BLOSUM, Grantham, missense observed/expected ratios,
-    missense badness, and PolyPhen-2 scores.
-
-    Table is input to MPC (missense badness, polyphen-2, and constraint) calculations.
-
-    :return: Path to Table.
-    """
-    # TODO: convert back into TableResource
-    return f"{CURRENT_MPC_PREFIX}/joint_clinvar_gnomad.ht"
-
-
-def mpc_model_pkl_path() -> str:
+def mpc_model_pkl_path(freeze: int = CURRENT_FREEZE) -> str:
     """
     Return path to model (stored as pickle) that contains relationship of MPC variables.
 
     Model created using logistic regression.
 
+    :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to model.
     """
-    return f"{CURRENT_MPC_PREFIX}/mpc_model.pkl"
+    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/mpc_model.pkl"
 
 
-def gnomad_fitted_score_path(is_grouped: bool = False) -> str:
+def gnomad_fitted_score_path(
+    is_grouped: bool = False, freeze: int = CURRENT_FREEZE
+) -> str:
     """
     Return path to fitted scores (from MPC model regression) of common (AF > 0.001) gnomAD variants.
 
     Table is input to MPC (missense badness, polyphen-2, and constraint) calculations on other datasets.
 
     :param bool is_grouped: Whether the Table is grouped by score. Default is False.
+    :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
     group = "_group" if is_grouped else ""
-    return f"{CURRENT_MPC_PREFIX}/gnomad_fitted_scores{group}.ht"
+    return (
+        f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/gnomad_fitted_scores{group}.ht"
+    )
 
 
 mpc_release = VersionedTableResource(

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -507,11 +507,11 @@ joint_clinvar_gnomad = VersionedTableResource(
     },
 )
 """
-Table containing "population" and "pathogenic" variants.
+Table containing 'population' and 'pathogenic' variants.
 
-Table contains common (AF > 0.001) gnomAD variants ("population") and
+Table contains common (AF > 0.001) gnomAD variants ('population') and
 ClinVar pathogenic/likely pathogenic missense variants in haploinsufficient genes
-that cause severe disease ("pathogenic") with defined CADD, BLOSUM, Grantham, missense observed/expected ratios,
+that cause severe disease ('pathogenic') with defined CADD, BLOSUM, Grantham, missense observed/expected ratios,
 missense badness, and PolyPhen-2 scores.
 
 Table is input to MPC (missense badness, polyphen-2, and constraint) calculations.

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -287,6 +287,7 @@ def get_annotations_from_context_ht_vep(
 
     :param hl.Table ht: Input VEP context Table.
     :param List[str] annotations: Additional annotations to extract from context HT's VEP field.
+        Default is ["polyphen", "sift"].
     :return: VEP context Table with rows filtered to remove loci that are non-coding and retain only those with informative amino acids
         and columns filtered to keep only specified annotations.
     """

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -5,10 +5,7 @@ import hail as hl
 from gnomad.resources.resource_utils import DataException
 from gnomad.utils.file_utils import file_exists
 
-from rmc.resources.basics import (
-    TEMP_PATH,
-    TEMP_PATH_WITH_FAST_DEL,
-)
+from rmc.resources.basics import TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.rmc import amino_acids_oe, CURRENT_FREEZE, misbad
 from rmc.utils.constraint import add_obs_annotation, get_oe_annotation
 from rmc.utils.generic import (
@@ -241,7 +238,7 @@ def calculate_misbad(
     logger.info("Creating high missense OE (OE > %s) HT...", oe_threshold)
     high_ht = aggregate_aa_and_filter_oe(ht, keep_high_oe=True)
     high_ht = high_ht.checkpoint(
-        f"{TEMP_PATH}/amino_acids_high_oe.ht",
+        f"{TEMP_PATH_WITH_FAST_DEL}/amino_acids_high_oe.ht",
         _read_if_exists=not overwrite_temp,
         overwrite=overwrite_temp,
     )
@@ -249,7 +246,7 @@ def calculate_misbad(
     logger.info("Creating low missense OE (OE <= %s) HT...", oe_threshold)
     low_ht = aggregate_aa_and_filter_oe(ht, keep_high_oe=False)
     low_ht = low_ht.checkpoint(
-        f"{TEMP_PATH}/amino_acids_low_oe.ht",
+        f"{TEMP_PATH_WITH_FAST_DEL}/amino_acids_low_oe.ht",
         _read_if_exists=not overwrite_temp,
         overwrite=overwrite_temp,
     )

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -9,7 +9,7 @@ from rmc.resources.basics import (
     TEMP_PATH,
     TEMP_PATH_WITH_FAST_DEL,
 )
-from rmc.resources.rmc import amino_acids_oe, misbad
+from rmc.resources.rmc import amino_acids_oe, CURRENT_FREEZE, misbad
 from rmc.utils.constraint import add_obs_annotation, get_oe_annotation
 from rmc.utils.generic import (
     annotate_and_filter_codons,
@@ -30,6 +30,7 @@ def prepare_amino_acid_ht(
     overwrite_temp: bool,
     overwrite_output: bool,
     gnomad_data_type: str = "exomes",
+    freeze: int = CURRENT_FREEZE,
 ) -> None:
     """
     Prepare Table with all possible amino acid substitutions and their missense observed to expected (OE) ratio.
@@ -41,6 +42,7 @@ def prepare_amino_acid_ht(
         - Add observed and OE annotation
         - Write to `amino_acids_oe` resource path
 
+    :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
     :param bool overwrite_temp: Whether to overwrite intermediate temporary (OE-independent) data if it already exists.
         If False, will read existing intermediate temporary data rather than overwriting.
     :param bool overwrite_output: Whether to entirely overwrite final output (OE-dependent) data if it already exists.
@@ -105,7 +107,7 @@ def prepare_amino_acid_ht(
         "Getting observed to expected ratio, rekeying Table, and writing to output path..."
     )
     # Note that `get_oe_annotation` is pulling the missense OE ratio
-    context_ht = get_oe_annotation(context_ht)
+    context_ht = get_oe_annotation(context_ht, freeze)
     context_ht = context_ht.key_by("locus", "alleles", "transcript")
     context_ht = context_ht.select(
         "ref",

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -48,7 +48,7 @@ def prepare_amino_acid_ht(
         If False, will read and modify existing output data by adding or modifying columns rather than overwriting entirely.
         If True, will clear existing output data and write new output data.
         The output Table is the amino acid Table.
-    :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
+    :param int freeze: RMC freeze number. Default is CURRENT_FREEZE.
     :param str gnomad_data_type: gnomAD data type. Used to retrieve public release and coverage resources.
         Must be one of "exomes" or "genomes" (check is done within `public_release`).
         Default is "exomes".
@@ -117,7 +117,7 @@ def prepare_amino_acid_ht(
         "amino_acids",
         "oe",
     )
-    context_ht.write(amino_acids_oe.path, overwrite=overwrite_output)
+    context_ht.write(amino_acids_oe.versions[freeze].path, overwrite=overwrite_output)
     logger.info("Output amino acid OE HT fields: %s", set(context_ht.row))
 
 
@@ -203,6 +203,7 @@ def calculate_misbad(
     overwrite_temp: bool,
     overwrite_output: bool,
     oe_threshold: float = 0.6,
+    freeze: int = CURRENT_FREEZE,
 ) -> None:
     """
     Calculate missense badness score using Table with all amino acid substitutions and their missense observed/expected (OE) ratio.
@@ -220,14 +221,15 @@ def calculate_misbad(
         Rows with OE less or equal to this threshold will be considered "low" OE, and
         rows with OE greater than this threshold will considered "high" OE.
         Default is 0.6.
+    :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
     :return: None; writes Table with missense badness score to resource path.
     """
-    if not file_exists(amino_acids_oe.path):
+    if not file_exists(amino_acids_oe.versions[freeze].path):
         raise DataException(
             "Table with all amino acid substitutions and missense OE doesn't exist!"
         )
 
-    ht = amino_acids_oe.ht()
+    ht = amino_acids_oe.versions[freeze].ht()
 
     if use_exac_oe_cutoffs:
         logger.info("Removing rows with OE greater than 0.6 and less than 0.8...")
@@ -296,5 +298,5 @@ def calculate_misbad(
         ),
     )
 
-    mb_ht.write(misbad.path, overwrite=overwrite_output)
+    mb_ht.write(misbad.versions[freeze].path, overwrite=overwrite_output)
     logger.info("Output missense badness HT fields: %s", set(mb_ht.row))

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -29,8 +29,8 @@ logger.setLevel(logging.INFO)
 def prepare_amino_acid_ht(
     overwrite_temp: bool,
     overwrite_output: bool,
-    gnomad_data_type: str = "exomes",
     freeze: int = CURRENT_FREEZE,
+    gnomad_data_type: str = "exomes",
 ) -> None:
     """
     Prepare Table with all possible amino acid substitutions and their missense observed to expected (OE) ratio.
@@ -42,13 +42,13 @@ def prepare_amino_acid_ht(
         - Add observed and OE annotation
         - Write to `amino_acids_oe` resource path
 
-    :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
     :param bool overwrite_temp: Whether to overwrite intermediate temporary (OE-independent) data if it already exists.
         If False, will read existing intermediate temporary data rather than overwriting.
     :param bool overwrite_output: Whether to entirely overwrite final output (OE-dependent) data if it already exists.
         If False, will read and modify existing output data by adding or modifying columns rather than overwriting entirely.
         If True, will clear existing output data and write new output data.
         The output Table is the amino acid Table.
+    :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
     :param str gnomad_data_type: gnomAD data type. Used to retrieve public release and coverage resources.
         Must be one of "exomes" or "genomes" (check is done within `public_release`).
         Default is "exomes".

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -207,6 +207,9 @@ def calculate_misbad(
 
     If `use_exac_oe_cutoffs` is set, will remove all rows with 0.6 < OE <= 0.8.
 
+    .. note::
+        Assumes table containing all possible amino acid substitutions and their missense OE ratio exists.
+
     :param bool use_exac_oe_cutoffs: Whether to use the same missense OE cutoffs as in ExAC missense badness calculation.
     :param bool overwrite_temp: Whether to overwrite intermediate temporary data if it already exists.
         If False, will read existing intermediate temporary data rather than overwriting.

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -178,8 +178,10 @@ def prepare_pop_path_ht(
     Prepare Table with 'population' (common gnomAD missense) and 'pathogenic' (ClinVar pathogenic/likely pathogenic missense) variants.
 
     .. note::
-        This function reads in data from a requester-pays bucket and will fail if requester-pays
+        - This function reads in data from a requester-pays bucket and will fail if requester-pays
         is not enabled on the cluster.
+        - Assumes tables containing all variants in canonical transcripts and their
+        missense O/E exist (both duplicated and dedup versions).
 
     :param str gnomad_data_type: gnomAD data type. Used to retrieve public release Table.
         Must be one of "exomes" or "genomes" (check is done within `public_release`).

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -178,7 +178,6 @@ def prepare_pop_path_ht(
     Prepare Table with 'population' (common gnomAD missense) and 'pathogenic' (ClinVar pathogenic/likely pathogenic missense) variants.
 
     .. note::
-        - This function reads in data from a requester-pays bucket and will fail if requester-pays
         is not enabled on the cluster.
         - Assumes tables containing all variants in canonical transcripts and their
         missense O/E exist (both duplicated and dedup versions).

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -178,8 +178,7 @@ def prepare_pop_path_ht(
     Prepare Table with 'population' (common gnomAD missense) and 'pathogenic' (ClinVar pathogenic/likely pathogenic missense) variants.
 
     .. note::
-        is not enabled on the cluster.
-        - Assumes tables containing all variants in canonical transcripts and their
+        Assumes tables containing all variants in canonical transcripts and their
         missense O/E exist (both duplicated and dedup versions).
 
     :param str gnomad_data_type: gnomAD data type. Used to retrieve public release Table.

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -13,10 +13,7 @@ from gnomad.resources.grch37.gnomad import public_release
 from gnomad.resources.resource_utils import DataException
 from gnomad.utils.file_utils import file_exists
 
-from rmc.resources.basics import (
-    TEMP_PATH,
-    TEMP_PATH_WITH_FAST_DEL,
-)
+from rmc.resources.basics import TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.reference_data import (
     blosum,
     blosum_txt_path,
@@ -536,7 +533,9 @@ def calculate_fitted_scores(
         filter_expr &= hl.is_defined(ht[field])
     ht = ht.filter(filter_expr)
     # Checkpoint here to force missense badness join and filter to complete
-    ht = ht.checkpoint(f"{TEMP_PATH}/fitted_score_temp_join.ht", overwrite=True)
+    ht = ht.checkpoint(
+        f"{TEMP_PATH_WITH_FAST_DEL}/fitted_score_temp_join.ht", overwrite=True
+    )
 
     logger.info("Annotating fitted scores...")
     variable_dict = {
@@ -662,7 +661,7 @@ def create_mpc_release_ht(
     ht = ht.annotate_globals(gnomad_scores=scores)
     # Checkpoint here to force the gnomAD join to complete
     ht = ht.checkpoint(
-        f"{TEMP_PATH}/mpc_temp_gnomad.ht",
+        f"{TEMP_PATH_WITH_FAST_DEL}/mpc_temp_gnomad.ht",
         _read_if_exists=not overwrite_temp,
         overwrite=overwrite_temp,
     )
@@ -688,7 +687,7 @@ def create_mpc_release_ht(
     )
     # Checkpoint here to force the binary search to compute
     ht = ht.checkpoint(
-        f"{TEMP_PATH}/mpc_temp_binary.ht",
+        f"{TEMP_PATH_WITH_FAST_DEL}/mpc_temp_binary.ht",
         _read_if_exists=not overwrite_temp,
         overwrite=overwrite_temp,
     )


### PR DESCRIPTION
This PR moves the code to generate the OE-annotated VEP context table into the RMC utils file and moves the code calling it into the `finalize` section of the RMC pipeline file (originally located in the MPC pipeline file). It also moves a few other functions out of the missense badness and MPC utils files and into the RMC or generic utils files where they more appropriately belong.