### PR TITLE
HC pLoF filter for missense badness

### DIFF
--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -11,7 +11,6 @@ from rmc.utils.constraint import add_obs_annotation, get_oe_annotation
 from rmc.utils.generic import (
     annotate_and_filter_codons,
     filter_context_using_gnomad,
-    get_constraint_transcripts,
     process_context_ht,
 )
 
@@ -51,19 +50,11 @@ def prepare_amino_acid_ht(
         Default is "exomes".
     :return: None; writes amino acid Table to resource path.
     """
-    logger.info("Importing set of transcripts to keep...")
-    transcripts = get_constraint_transcripts(outlier=False)
-
     logger.info("Reading in VEP context HT...")
     # NOTE: Keeping all variant types here because need synonymous and nonsense variants to calculate missense badness
     context_ht = process_context_ht(filter_to_missense=False, add_annotations=False)
 
-    logger.info(
-        "Filtering to transcripts to keep and selecting relevant annotations..."
-    )
-    context_ht = context_ht.filter(
-        transcripts.contains(context_ht.transcript_consequences.transcript_id)
-    )
+    logger.info("Selecting relevant annotations...")
     context_ht = context_ht.select(
         transcript=context_ht.transcript_consequences.transcript_id,
         consequence_terms=context_ht.transcript_consequences.consequence_terms,


### PR DESCRIPTION
This PR adds a filter for high confidence predicted loss-of-function (pLoF) variants (as predicted by LOFTEE) prior to generating missense badness.

Minor changes:

- Removed types from params in docstring
- Removed outlier transcript filter (this was a duplicate filter; `process_vep` also removes outlier transcripts)

Major changes:

- Added filter to remove pLoF that are predicted as OS or LC by LOFTEE; filter also removes variants that have LOFTEE flags (e.g., `SINGLE_EXON`)