### PR TITLE
Update missense badness for training/validation/testing

### DIFF
--- a/rmc/pipeline/calculate_missense_badness.py
+++ b/rmc/pipeline/calculate_missense_badness.py
@@ -42,6 +42,8 @@ def main(args):
                 use_exac_oe_cutoffs=args.use_exac_oe_cutoffs,
                 overwrite_temp=args.overwrite_temp,
                 overwrite_output=args.overwrite_output,
+                use_test_transcripts=args.use_test_transcripts,
+                do_k_fold_training=args.do_k_fold_training,
                 freeze=args.freeze,
             )
 

--- a/rmc/pipeline/calculate_missense_badness.py
+++ b/rmc/pipeline/calculate_missense_badness.py
@@ -31,6 +31,8 @@ def main(args):
             prepare_amino_acid_ht(
                 overwrite_temp=args.overwrite_temp,
                 overwrite_output=args.overwrite_output,
+                use_test_transcripts=args.use_test_transcripts,
+                do_k_fold_training=args.do_k_fold_training,
                 freeze=args.freeze,
             )
 
@@ -71,6 +73,19 @@ if __name__ == "__main__":
     parser.add_argument(
         "--slack-channel",
         help="Send message to Slack channel/user.",
+    )
+    parser.add_argument(
+        "--use-test-transcripts",
+        help="Use test transcripts instead of training transcripts in creation of missense badness.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--do-k-fold-training",
+        help="""
+        Generate k-fold missense badness models (one each for training and validation transcripts in each fold)
+        instead of one model for all training transcripts.
+        """,
+        action="store_true",
     )
     parser.add_argument(
         "--use-exac-oe-cutoffs",

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -43,7 +43,7 @@ transcript_ref = TableResource(
 """
 Table containing canonical transcripts with key reference info:
 gene name from gnomAD annotations, gene name from GENCODE v19,
-Ensembl gene ID in GENCODE v19, and overall CDS start and end
+Ensembl gene ID in GENCODE v19, and overall and CDS start and end
 coordinates from gnomAD annotations.
 """
 

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -37,6 +37,21 @@ gene_model = TableResource(path=f"{RESOURCE_BUILD_PREFIX}/browser/b37_transcript
 Table containing transcript start and stop positions displayed in the browser.
 """
 
+transcript_ref = TableResource(
+    path=f"{REF_DATA_PREFIX}/ht/canonical_transcripts_genes_coordinates.ht"
+)
+"""
+Table containing canonical transcripts with key reference info:
+gene name from gnomAD annotations, gene name from GENCODE v19,
+Ensembl gene ID in GENCODE v19, and overall CDS start and end
+coordinates from gnomAD annotations.
+"""
+
+transcript_cds = TableResource(path=f"{REF_DATA_PREFIX}/ht/b37_cds_coords.ht")
+"""
+Table containing coordinates for coding parts of transcripts excluding introns and UTRs.
+"""
+
 
 ######################################################################
 ## Gene/transcript resources

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -70,11 +70,17 @@ def training_transcripts_path(fold: int = None, is_val: bool = False) -> str:
     """
     Return path to HailExpression of transcripts used for model training.
 
-    :param fold:
-    :param is_val: Whether to return the validation transcripts if fold is true.
-        If False, is generated from variants in training transcripts only.
-        If True, is generated from variants in test transcripts only.
+    :param fold: Fold number in training set to select transcripts from.
+        If None, all training transcripts will be returned.
+        If not None, only validation or training transcripts from the specified fold
+            will be returned.
+    :param is_val: Whether to return validation transcripts.
+        If False, training transcripts from the specified fold of the training set
+            will be returned.
+        If True, validation transcripts from the specified fold of the training set
+            will be returned.
         Default is False.
+        NOTE that `fold` must not be None in order to use this parameter.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -74,13 +74,14 @@ def training_transcripts_path(fold: int = None, is_val: bool = False) -> str:
         If None, all training transcripts will be returned.
         If not None, only validation or training transcripts from the specified fold
             will be returned.
+        Default is None.
     :param is_val: Whether to return validation transcripts.
         If False, training transcripts from the specified fold of the training set
             will be returned.
         If True, validation transcripts from the specified fold of the training set
             will be returned.
         Default is False.
-        NOTE that `fold` must not be None in order to use this parameter.
+        NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -82,7 +82,6 @@ def training_transcripts_path(fold: int = None, is_val: bool = False) -> str:
             will be returned.
         Default is False.
         NOTE that `fold` must not be None if `is_val` is True.
-    :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
     if is_val and fold is None:

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -86,7 +86,7 @@ def training_transcripts_path(fold: int = None, is_val: bool = False) -> str:
         )
 
     train_type = "val" if is_val else "train"
-    fold_name = f"_fold{fold}" if fold is not None
+    fold_name = f"_fold{fold}" if fold is not None else ""
     return f"{RESOURCE_BUILD_PREFIX}/{train_type}_transcripts{fold_name}.he"
 
 

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -41,6 +41,16 @@ Table containing transcript start and stop positions displayed in the browser.
 ######################################################################
 ## Gene/transcript resources
 ######################################################################
+training_transcripts_path = f"{RESOURCE_BUILD_PREFIX}/train_transcripts.he"
+"""
+Path to HailExpression of transcripts used for model training.
+"""
+
+test_transcripts_path = f"{RESOURCE_BUILD_PREFIX}/test_transcripts.he"
+"""
+Path to HailExpression of transcripts used for model testing.
+"""
+
 dosage_tsv_path = (
     f"{REF_DATA_PREFIX}/Collins_rCNV_2022.dosage_sensitivity_scores.tsv.gz"
 )

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -1,5 +1,9 @@
 """Script containing reference resources."""
-from gnomad.resources.resource_utils import TableResource, VersionedTableResource
+from gnomad.resources.resource_utils import (
+    DataException,
+    TableResource,
+    VersionedTableResource,
+)
 
 from rmc.resources.basics import AMINO_ACIDS_PREFIX, RESOURCE_BUILD_PREFIX
 from rmc.resources.resource_utils import CURRENT_BUILD
@@ -56,10 +60,35 @@ Table containing coordinates for coding parts of transcripts excluding introns a
 ######################################################################
 ## Gene/transcript resources
 ######################################################################
-training_transcripts_path = f"{RESOURCE_BUILD_PREFIX}/train_transcripts.he"
+fold_k = 5
 """
-Path to HailExpression of transcripts used for model training.
+Number of folds in the training set.
 """
+
+
+def training_transcripts_path(fold: int = None, is_val: bool = False) -> str:
+    """
+    Return path to HailExpression of transcripts used for model training.
+
+    :param fold:
+    :param is_val: Whether to return the validation transcripts if fold is true.
+        If False, is generated from variants in training transcripts only.
+        If True, is generated from variants in test transcripts only.
+        Default is False.
+    :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
+    :return: Path to Table.
+    """
+    if is_val and fold is None:
+        raise DataException("Fold number must be specified for validation transcripts!")
+    if fold not in range(1, fold_k + 1):
+        raise DataException(
+            f"Fold number must be an integer between 1 and {fold_k} inclusive!"
+        )
+
+    train_type = "val" if is_val else "train"
+    fold_name = f"_fold{fold}" if fold is not None
+    return f"{RESOURCE_BUILD_PREFIX}/{train_type}_transcripts{fold_name}.he"
+
 
 test_transcripts_path = f"{RESOURCE_BUILD_PREFIX}/test_transcripts.he"
 """

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -92,7 +92,7 @@ List of triplosensitive genes was determined by filtering to genes with pTriplo 
 ## Assessment related resources
 ####################################################################################
 clinvar = TableResource(
-    path="gs://regional_missense_constraint/resources/GRCh37/reference_data/ht/clinvar.GRCh37.ht",
+    path=f"{REF_DATA_PREFIX}/ht/clinvar.GRCh37.ht",
 )
 """
 
@@ -160,7 +160,7 @@ and phenotypic context of autism (2022)
 """
 
 ndd_de_novo = TableResource(
-    path=f"{RESOURCE_BUILD_PREFIX}/reference_data/ht/ndd_de_novo.ht",
+    path=f"{REF_DATA_PREFIX}/ht/ndd_de_novo.ht",
 )
 """
 De novo missense variants from 46,094 neurodevelopmental disorder (NDD) cases and 5,492 controls.

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -60,7 +60,7 @@ Table containing coordinates for coding parts of transcripts excluding introns a
 ######################################################################
 ## Gene/transcript resources
 ######################################################################
-fold_k = 5
+FOLD_K = 5
 """
 Number of folds in the training set.
 """
@@ -87,9 +87,9 @@ def training_transcripts_path(fold: int = None, is_val: bool = False) -> str:
     """
     if is_val and fold is None:
         raise DataException("Fold number must be specified for validation transcripts!")
-    if fold not in range(1, fold_k + 1):
+    if fold not in range(1, FOLD_K + 1):
         raise DataException(
-            f"Fold number must be an integer between 1 and {fold_k} inclusive!"
+            f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )
 
     train_type = "val" if is_val else "train"

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -515,18 +515,48 @@ def amino_acids_oe_path(
     return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/amino_acid_oe_{transcript_type}{fold_name}.ht"
 
 
-misbad = VersionedTableResource(
-    default_version=CURRENT_FREEZE,
-    versions={
-        freeze: TableResource(
-            path=f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/missense_badness.ht"
+def misbad_path(
+    is_test: bool = False,
+    fold: int = None,
+    is_val: bool = False,
+    freeze: int = CURRENT_FREEZE,
+) -> str:
+    """
+    Table containing all possible amino acid substitutions and their missense badness scores.
+
+    :param bool is_test: Whether the Table is generated from variants in test transcripts.
+        If False, the Table is generated from variants in training transcripts only.
+        If True, the Table is generated from variants in test transcripts only.
+        Default is False.
+    :param int fold: Fold number in training set to select training transcripts from.
+        If not None, the Table is generated from variants in only validation or training transcripts
+            from the specified fold.
+        If None, the Table is generated from variants in test transcripts or from variants in all
+            training transcripts.
+        Default is None.
+        NOTE that `is_test` must be False if `fold` is not None.
+    :param bool is_val: Whether the Table is generated from variants in validation transcripts.
+        If True, the Table is generated from variants in the validation transcripts
+            from the specified fold of the training set.
+        If False, the Table is generated from variants in test transcripts,
+            from variants in all training transcripts, or from variants in
+            training transcripts from the specified fold of the training set.
+        Default is False.
+        NOTE that `fold` must not be None if `is_val` is True.
+    :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
+    :return: Path to Table.
+    """
+    if is_test and fold is not None:
+        raise DataException("Fold number cannot be specified for test set!")
+    if is_val and fold is None:
+        raise DataException("Fold number must be specified for validation set!")
+    if fold not in range(1, fold_k + 1):
+        raise DataException(
+            f"Fold number must be an integer between 1 and {fold_k} inclusive!"
         )
-        for freeze in FREEZES
-    },
-)
-"""
-Table containing all possible amino acid substitutions and their missense badness scores.
-"""
+    transcript_type = "test" if is_test else ("val" if is_val else "train")
+    fold_name = f"_fold{fold}" if fold is not None else ""
+    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/missense_badness_{transcript_type}{fold_name}.ht"
 
 
 ####################################################################################

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -31,7 +31,7 @@ FREEZES = [1, 2, 3, 4, 5, 6, 7]
 RMC/MPC data versions computed with current gnomAD version.
 """
 
-CURRENT_FREEZE = 4
+CURRENT_FREEZE = 5
 """
 Current RMC/MPC data version.
 """

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -23,7 +23,7 @@ from rmc.resources.basics import (
     SINGLE_BREAK_TEMP_PATH,
     TEMP_PATH,
 )
-from rmc.resources.reference_data import fold_k
+from rmc.resources.reference_data import FOLD_K
 from rmc.resources.resource_utils import CURRENT_GNOMAD_VERSION
 
 FREEZES = [1, 2, 3, 4, 5, 6, 7]
@@ -506,9 +506,9 @@ def amino_acids_oe_path(
         raise DataException("Fold number cannot be specified for test set!")
     if is_val and fold is None:
         raise DataException("Fold number must be specified for validation set!")
-    if fold not in range(1, fold_k + 1):
+    if fold not in range(1, FOLD_K + 1):
         raise DataException(
-            f"Fold number must be an integer between 1 and {fold_k} inclusive!"
+            f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )
     transcript_type = "test" if is_test else ("val" if is_val else "train")
     fold_name = f"_fold{fold}" if fold is not None else ""
@@ -550,9 +550,9 @@ def misbad_path(
         raise DataException("Fold number cannot be specified for test set!")
     if is_val and fold is None:
         raise DataException("Fold number must be specified for validation set!")
-    if fold not in range(1, fold_k + 1):
+    if fold not in range(1, FOLD_K + 1):
         raise DataException(
-            f"Fold number must be an integer between 1 and {fold_k} inclusive!"
+            f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )
     transcript_type = "test" if is_test else ("val" if is_val else "train")
     fold_name = f"_fold{fold}" if fold is not None else ""

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -8,7 +8,11 @@ from typing import Set
 
 import hail as hl
 import scipy
-from gnomad.resources.resource_utils import TableResource, VersionedTableResource
+from gnomad.resources.resource_utils import (
+    DataException,
+    TableResource,
+    VersionedTableResource,
+)
 
 from rmc.resources.basics import (
     CONSTRAINT_PREFIX,
@@ -19,6 +23,7 @@ from rmc.resources.basics import (
     SINGLE_BREAK_TEMP_PATH,
     TEMP_PATH,
 )
+from rmc.resources.reference_data import fold_k
 from rmc.resources.resource_utils import CURRENT_GNOMAD_VERSION
 
 FREEZES = [1, 2, 3, 4, 5, 6, 7]
@@ -464,20 +469,51 @@ Contains same information as `rmc_results` but has different formatting for gnom
 ####################################################################################
 ## Missense badness related resources
 ####################################################################################
-amino_acids_oe = VersionedTableResource(
-    default_version=CURRENT_FREEZE,
-    versions={
-        freeze: TableResource(
-            path=f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/amino_acid_oe.ht"
-        )
-        for freeze in FREEZES
-    },
-)
-"""
-Table containing all possible amino acid substitutions and their missense OE ratio.
+def amino_acids_oe_path(
+    is_test: bool = False,
+    fold: int = None,
+    is_val: bool = False,
+    freeze: int = CURRENT_FREEZE,
+) -> str:
+    """
+    Return path to Table containing all possible amino acid substitutions and their missense OE ratio.
 
-Input to missense badness calculations.
-"""
+    Table is input to missense badness calculations.
+
+    :param bool is_test: Whether the Table is generated from variants in test transcripts.
+        If False, the Table is generated from variants in training transcripts only.
+        If True, the Table is generated from variants in test transcripts only.
+        Default is False.
+    :param int fold: Fold number in training set to select training transcripts from.
+        If not None, the Table is generated from variants in only validation or training transcripts
+            from the specified fold.
+        If None, the Table is generated from variants in test transcripts or from variants in all
+            training transcripts.
+        Default is None.
+        NOTE that `is_test` must be False if `fold` is not None.
+    :param bool is_val: Whether the Table is generated from variants in validation transcripts.
+        If True, the Table is generated from variants in the validation transcripts
+            from the specified fold of the training set.
+        If False, the Table is generated from variants in test transcripts,
+            from variants in all training transcripts, or from variants in
+            training transcripts from the specified fold of the training set.
+        Default is False.
+        NOTE that `fold` must not be None if `is_val` is True.
+    :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
+    :return: Path to Table.
+    """
+    if is_test and fold is not None:
+        raise DataException("Fold number cannot be specified for test set!")
+    if is_val and fold is None:
+        raise DataException("Fold number must be specified for validation set!")
+    if fold not in range(1, fold_k + 1):
+        raise DataException(
+            f"Fold number must be an integer between 1 and {fold_k} inclusive!"
+        )
+    transcript_type = "test" if is_test else ("val" if is_val else "train")
+    fold_name = f"_fold{fold}" if fold is not None else ""
+    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/amino_acid_oe_{transcript_type}{fold_name}.ht"
+
 
 misbad = VersionedTableResource(
     default_version=CURRENT_FREEZE,
@@ -491,6 +527,7 @@ misbad = VersionedTableResource(
 """
 Table containing all possible amino acid substitutions and their missense badness scores.
 """
+
 
 ####################################################################################
 ## MPC related resources

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Tuple
 
 import hail as hl
 from gnomad.resources.grch37.gnomad import coverage, public_release

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -314,13 +314,13 @@ def get_annotations_from_context_ht_vep(
 
 
 def filter_context_to_transcript_cds(
-    context_ht: hl.Table, transcripts: Set[str]
+    context_ht: hl.Table, transcripts: hl.expr.SetExpression
 ) -> hl.Table:
     """
     Filter VEP context Table to coding sites in the input transcripts.
 
     :param hl.Table context_ht: VEP context Table.
-    :param Set[str] transcripts: Transcripts to filter to.
+    :param hl.expr.SetExpression transcripts: Transcripts to filter to.
     :return: VEP context Table with rows filtered to only coding sites in the input transcripts.
     """
     # Get coordinate intervals of coding sequences of transcripts

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -48,7 +48,9 @@ logger = logging.getLogger("regional_missense_constraint_generic")
 logger.setLevel(logging.INFO)
 
 
+####################################################################################
 ## ExAC mutational model-related utils
+####################################################################################
 def get_mutation_rate() -> Dict[str, Tuple[str, float]]:
     """
     Read in mutation rate table and store as dict.
@@ -84,7 +86,9 @@ def get_divergence_scores() -> Dict[str, float]:
     return div_scores
 
 
+####################################################################################
 ## Codon and amino acid utils
+####################################################################################
 def get_codon_lookup() -> hl.expr.DictExpression:
     """
     Read in codon lookup table and return as dictionary (key: codon, value: amino acid).
@@ -155,7 +159,9 @@ def annotate_and_filter_codons(ht: hl.Table) -> hl.Table:
     return ht.filter((ht.ref != "Unk") & (ht.alt != "Unk"))
 
 
-## Functions to process reference genome related resources
+####################################################################################
+## Reference genome processing-related utils
+####################################################################################
 def process_context_ht(
     filter_to_missense: bool = True,
     missense_str: str = MISSENSE,
@@ -306,7 +312,9 @@ def get_annotations_from_context_ht_vep(
     return annotate_and_filter_codons(ht)
 
 
-## Functions for obs/exp related resources
+####################################################################################
+## Observed and expected-related utils
+####################################################################################
 def get_exome_bases() -> int:
     """
     Get number of bases in the exome.
@@ -527,7 +535,9 @@ def get_plateau_model(
     )
 
 
-## Outlier transcript util
+####################################################################################
+## Outlier transcript utils
+####################################################################################
 def get_constraint_transcripts(outlier: bool = True) -> hl.expr.SetExpression:
     """
     Read in LoF constraint HT results to get set of transcripts.
@@ -568,7 +578,9 @@ def get_constraint_transcripts(outlier: bool = True) -> hl.expr.SetExpression:
     )
 
 
+####################################################################################
 ## Assessment utils
+####################################################################################
 def import_dosage(
     overwrite: bool,
     haplo_threshold: float = 0.86,

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -113,8 +113,7 @@ def prepare_amino_acid_ht(
 
     logger.info("Checkpointing HT before joining with gnomAD data...")
     context_ht = context_ht.checkpoint(
-        # TODO: Change the name of this table as it is a duplicate
-        f"{TEMP_PATH_WITH_FAST_DEL}/codons_filt.ht",
+        f"{TEMP_PATH_WITH_FAST_DEL}/codons_hc.ht",
         _read_if_exists=not overwrite_temp,
         overwrite=overwrite_temp,
     )

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -171,8 +171,6 @@ def prepare_amino_acid_ht(
             amino_acids_oe_path(is_test=use_test_transcripts, freeze=freeze),
             overwrite=overwrite_output,
         )
-        # TODO: Remove these output lines — was added for freeze 2 and can now be removed
-        logger.info("Output amino acid OE HT fields: %s", set(context_ht.row))
     else:
         logger.info(
             "Creating an amino acid OE HT for each of the %i-fold training and validation sets...",
@@ -195,7 +193,6 @@ def prepare_amino_acid_ht(
                     ),
                     overwrite=overwrite_output,
                 )
-                logger.info("Output amino acid OE HT fields: %s", set(context_ht.row))
 
 
 def variant_csq_expr(

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -6,7 +6,7 @@ from gnomad.utils.file_utils import file_exists
 
 from rmc.resources.basics import TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.reference_data import (
-    fold_k,
+    FOLD_K,
     test_transcripts_path,
     training_transcripts_path,
 )
@@ -174,9 +174,9 @@ def prepare_amino_acid_ht(
     else:
         logger.info(
             "Writing out amino acid OE HT for each of the %i-fold training and validation sets...",
-            fold_k,
+            FOLD_K,
         )
-        for i in range(1, fold_k + 1):
+        for i in range(1, FOLD_K + 1):
             for is_val in [True, False]:
                 logger.info("Writing out amino acid OE HT for fold %i...", i)
                 filter_transcripts = hl.experimental.read_expression(
@@ -336,7 +336,7 @@ def calculate_misbad(
                         freeze=freeze,
                     )
                 )
-                for i in range(1, fold_k + 1)
+                for i in range(1, FOLD_K + 1)
                 for is_val in [True, False]
             ]
         ):
@@ -433,7 +433,7 @@ def calculate_misbad(
             temp_label=f"_{transcript_type}",
         )
     else:
-        for i in range(1, fold_k + 1):
+        for i in range(1, FOLD_K + 1):
             for is_val in [True, False]:
                 transcript_type = "val" if is_val else "train"
                 fold_name = f"_fold{i}" if i is not None else ""

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -422,8 +422,6 @@ def calculate_misbad(
         )
 
         mb_ht.write(mb_path, overwrite=overwrite_output)
-        # TODO: Remove this line
-        logger.info("Output missense badness HT fields: %s", set(mb_ht.row))
 
     if use_test_transcripts or not do_k_fold_training:
         _create_misbad_model(

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -43,8 +43,9 @@ def prepare_amino_acid_ht(
         - Import VEP context Table and filter to keep every possible amino acid substitution
         (every codon > codon change).
         - Filter Table to rows that aren't present in gnomAD or are rare in gnomAD (using `keep_criteria`).
-        - Add observed and OE annotation
-        - Write to `amino_acids_oe_path` resource path
+        - Add observed and OE annotation.
+        - Filter to specified transcript set(s).
+        - Write to `amino_acids_oe_path` resource path(s).
 
     :param overwrite_temp: Whether to overwrite intermediate temporary (OE-independent) data if it already exists.
         If False, will read existing intermediate temporary data rather than overwriting.
@@ -68,7 +69,6 @@ def prepare_amino_acid_ht(
     :param loftee_hc_str: String indicating that LOFTEE a loss-of-function variant is predcited to cause
     :return: None; writes amino acid Table to resource path.
     """
-    # Check for valid arguments
     if use_test_transcripts and do_k_fold_training:
         raise DataException("Cannot generate k-fold models with test transcripts!")
 
@@ -158,7 +158,7 @@ def prepare_amino_acid_ht(
 
     if use_test_transcripts or not do_k_fold_training:
         logger.info(
-            "Filtering to %s transcripts only...",
+            "Writing out HT for %s transcripts only...",
             "test" if use_test_transcripts else "training",
         )
         filter_transcripts = hl.experimental.read_expression(
@@ -173,11 +173,12 @@ def prepare_amino_acid_ht(
         )
     else:
         logger.info(
-            "Creating an amino acid OE HT for each of the %i-fold training and validation sets...",
+            "Writing out amino acid OE HT for each of the %i-fold training and validation sets...",
             fold_k,
         )
         for i in range(1, fold_k + 1):
             for is_val in [True, False]:
+                logger.info("Writing out amino acid OE HT for fold %i...", i)
                 filter_transcripts = hl.experimental.read_expression(
                     training_transcripts_path(fold=i, is_val=is_val)
                 )

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -10,7 +10,7 @@ from rmc.resources.reference_data import (
     test_transcripts_path,
     training_transcripts_path,
 )
-from rmc.resources.rmc import CURRENT_FREEZE, amino_acids_oe_path, misbad
+from rmc.resources.rmc import CURRENT_FREEZE, amino_acids_oe_path, misbad_path
 from rmc.utils.constraint import add_obs_annotation, get_oe_annotation
 from rmc.utils.generic import (
     annotate_and_filter_codons,
@@ -37,7 +37,7 @@ def prepare_amino_acid_ht(
     loftee_hc_str: str = "HC",
 ) -> None:
     """
-    Prepare Table with all possible amino acid substitutions and their missense observed to expected (OE) ratio.
+    Prepare Table(s) with all possible amino acid substitutions and their missense observed to expected (OE) ratio.
 
     Steps:
         - Import VEP context Table and filter to keep every possible amino acid substitution
@@ -67,7 +67,7 @@ def prepare_amino_acid_ht(
         Must be one of "exomes" or "genomes" (check is done within `public_release`).
         Default is "exomes".
     :param loftee_hc_str: String indicating that LOFTEE a loss-of-function variant is predcited to cause
-    :return: None; writes amino acid Table to resource path.
+    :return: None; writes amino acid Table(s) to resource path(s).
     """
     if use_test_transcripts and do_k_fold_training:
         raise DataException("Cannot generate k-fold models with test transcripts!")


### PR DESCRIPTION
This PR adds changes to allow the missense badness models to be generated with variant data in the following sets of transcripts: all training transcripts, all test transcripts, or k-folds of the training transcript set. These transcript sets were defined in the notebook: `gs://regional_missense_constraint/notebooks/train_test_split_transcripts.ipynb`

Major changes:

- Added two reference tables for ease of working with transcripts to `reference_data.py`: `transcript_ref` and `transcript_cds`
- Added a utility function to filter a VEP context table to coding sites in a given set of transcripts
- Added resource paths for the training, validation, and test sets of transcripts generated in `gs://regional_missense_constraint/notebooks/train_test_split_transcripts.ipynb`
- Added a constant for the number of folds in the training set
- Added capability to create and write out the missense badness models and associated resources/temporary tables on the aforementioned sets of transcripts-

Minor changes:

- Updated `CURRENT_FREEZE` to RMC freeze 5
- Updated a couple of resource paths to use existing variables for path prefixes
- Updated format of section headings in `generic.py`
- Fixed a bug introduced in https://github.com/broadinstitute/regional_missense_constraint/pull/284 that caused reading and writing from the same path

Analogous changes to MPC-related code will be forthcoming in another PR.