### PR TITLE
MPC variants update

### DIFF
--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -79,7 +79,8 @@ def main(args):
                 "Filtering context HT to all covered sites not found or rare in gnomAD exomes"
             )
             context_ht = filter_context_using_gnomad(
-                context_ht, "exomes", filter_context_using_cov=True
+                context_ht,
+                "exomes",
             )
             context_ht.write(filtered_context.path, overwrite=args.overwrite)
 

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -371,12 +371,12 @@ def keep_criteria(
     :param cov_threshold: Remove rows at or below this median coverage threshold. Default is 0.
     :param filter_to_rare: Whether to filter to keep rare variants only.
         If True, only variants with AF < `af_threshold` will be kept.
-        If False, only variants with AF > `af_threshold` will be kept.
+        If False, only variants with AF >= `af_threshold` will be kept.
         Default is True.
     :return: Boolean expression used to filter variants.
     """
     af_filter_expr = (
-        (af_expr < af_threshold) if filter_to_rare else (af_expr > af_threshold)
+        (af_expr < af_threshold) if filter_to_rare else (af_expr >= af_threshold)
     )
     return (
         (ac_expr > 0)

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -246,7 +246,6 @@ def filter_context_using_gnomad(
     context_ht: hl.Table,
     gnomad_data_type: str = "exomes",
     adj_freq_index: int = 0,
-    filter_context_using_cov: bool = True,
     cov_threshold: int = 0,
 ) -> hl.Table:
     """
@@ -258,10 +257,7 @@ def filter_context_using_gnomad(
         Default is "exomes".
     :param adj_freq_index: Index of frequency array that contains global population filtered calculated on
         high quality (adj) genotypes. Default is 0.
-    :param filter_context_using_cov: Whether to also filter sites in context Table using gnomAD coverage.
-        Default is True.
-    :param cov_threshold: Coverage threshold used to filter context Table if `filter_context_using_cov` is True.
-        Default is 0.
+    :param cov_threshold: Coverage threshold used to filter context Table. Default is 0.
     :return: Filtered VEP context Table.
     """
     gnomad = get_gnomad_public_release(gnomad_data_type, adj_freq_index)
@@ -278,18 +274,6 @@ def filter_context_using_gnomad(
             cov_threshold=cov_threshold,
         )
     )
-
-    # Optionally also filter context HT using gnomAD coverage
-    if filter_context_using_cov:
-        gnomad_cov = coverage(gnomad_data_type).ht()
-        context_ht = context_ht.annotate(
-            gnomad_coverage=gnomad_cov[context_ht.locus].median
-        )
-        context_ht = context_ht.filter(context_ht.gnomad_coverage > cov_threshold)
-        # Drop coverage annotation here for consistency
-        # (This annotation is only added if `filter_context_using_cov` is True)
-        context_ht = context_ht.drop("gnomad_coverage")
-
     return context_ht
 
 

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -228,6 +228,8 @@ def get_gnomad_public_release(
     :param gnomad_data_type: gnomAD data type. Used to retrieve public release and coverage resources.
         Must be one of "exomes" or "genomes" (check is done within `public_release`).
         Default is "exomes".
+    :param adj_freq_index: Index of frequency array that contains global population filtered calculated on
+        high quality (adj) genotypes. Default is 0.
     :return: gnomAD public sites HT annotated with coverage and filtered to select fields.
     """
     gnomad = public_release(gnomad_data_type).ht().select_globals()

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -228,8 +228,8 @@ def get_gnomad_public_release(
     :param gnomad_data_type: gnomAD data type. Used to retrieve public release and coverage resources.
         Must be one of "exomes" or "genomes" (check is done within `public_release`).
         Default is "exomes".
-    :param adj_freq_index: Index of frequency array that contains global population calculated on
-        high quality (adj) genotypes. Default is 0.
+    :param adj_freq_index: Index of frequency array that contains frequency information calculated on
+        high quality (adj) genotypes across all genetic ancestry groups. Default is 0.
     :return: gnomAD public sites HT annotated with coverage and filtered to select fields.
     """
     gnomad = public_release(gnomad_data_type).ht().select_globals()
@@ -255,8 +255,8 @@ def filter_context_using_gnomad(
     :param gnomad_data_type: gnomAD data type. Used to retrieve public release and coverage resources.
         Must be one of "exomes" or "genomes" (check is done within `public_release`).
         Default is "exomes".
-    :param adj_freq_index: Index of frequency array that contains global population calculated on
-        high quality (adj) genotypes. Default is 0.
+    :param adj_freq_index: Index of frequency array that contains frequency information calculated on
+        high quality (adj) genotypes across all genetic ancestry groups. Default is 0.
     :param cov_threshold: Remove variants below this median coverage threshold. Default is 0.
     :return: Filtered VEP context Table.
     """

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -257,7 +257,7 @@ def filter_context_using_gnomad(
         Default is "exomes".
     :param adj_freq_index: Index of frequency array that contains global population calculated on
         high quality (adj) genotypes. Default is 0.
-    :param cov_threshold: Coverage threshold used to filter context Table. Default is 0.
+    :param cov_threshold: Median coverage threshold below which variants are removed. Default is 0.
     :return: Filtered VEP context Table.
     """
     gnomad = get_gnomad_public_release(gnomad_data_type, adj_freq_index)

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -228,7 +228,7 @@ def get_gnomad_public_release(
     :param gnomad_data_type: gnomAD data type. Used to retrieve public release and coverage resources.
         Must be one of "exomes" or "genomes" (check is done within `public_release`).
         Default is "exomes".
-    :param adj_freq_index: Index of frequency array that contains global population filtered calculated on
+    :param adj_freq_index: Index of frequency array that contains global population calculated on
         high quality (adj) genotypes. Default is 0.
     :return: gnomAD public sites HT annotated with coverage and filtered to select fields.
     """
@@ -255,7 +255,7 @@ def filter_context_using_gnomad(
     :param gnomad_data_type: gnomAD data type. Used to retrieve public release and coverage resources.
         Must be one of "exomes" or "genomes" (check is done within `public_release`).
         Default is "exomes".
-    :param adj_freq_index: Index of frequency array that contains global population filtered calculated on
+    :param adj_freq_index: Index of frequency array that contains global population calculated on
         high quality (adj) genotypes. Default is 0.
     :param cov_threshold: Coverage threshold used to filter context Table. Default is 0.
     :return: Filtered VEP context Table.

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -257,7 +257,7 @@ def filter_context_using_gnomad(
         Default is "exomes".
     :param adj_freq_index: Index of frequency array that contains frequency information calculated on
         high quality (adj) genotypes across all genetic ancestry groups. Default is 0.
-    :param cov_threshold: Remove variants below this median coverage threshold. Default is 0.
+    :param cov_threshold: Remove variants at or below this median coverage threshold. Default is 0.
     :return: Filtered VEP context Table.
     """
     gnomad = get_gnomad_public_release(gnomad_data_type, adj_freq_index)

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -349,23 +349,28 @@ def keep_criteria(
     cov_expr: hl.expr.Int32Expression,
     af_threshold: float = 0.001,
     cov_threshold: int = 0,
+    filter_to_rare: bool = True,
 ) -> hl.expr.BooleanExpression:
     """
     Return Boolean expression to filter variants in input Table.
 
     Default values will filter to rare variants (AC > 0, AF < 0.001) that pass filters and have median coverage greater than 0.
 
-    :param hl.expr.Int32Expression ac_expr: Allele count Int32Expression.
-    :param hl.expr.Float64Expression af_expr: Allele frequency (AF) Float64Expression.
-    :param hl.expr.SetExpression filters_expr: Filters SetExpression.
-    :param hl.expr.Int32Expression cov_expr: gnomAD median coverage Int32Expression.
-    :param float af_threshold: Remove rows above this AF threshold. Default is 0.001.
-    :param int cov_threshold: Remove rows below this median coverage threshold. Default is 0.
+    :param ac_expr: Allele count Int32Expression.
+    :param af_expr: Allele frequency (AF) Float64Expression.
+    :param filters_expr: Filters SetExpression.
+    :param cov_expr: gnomAD median coverage Int32Expression.
+    :param af_threshold: Remove rows above this AF threshold. Default is 0.001.
+    :param cov_threshold: Remove rows below this median coverage threshold. Default is 0.
+    :param filter_to_rare: Whether to filter to keep rare variants only. Default is True.
     :return: Boolean expression used to filter variants.
     """
+    af_filter_expr = (
+        (af_expr < af_threshold) if filter_to_rare else (af_expr > af_threshold)
+    )
     return (
         (ac_expr > 0)
-        & (af_expr < af_threshold)
+        & (af_filter_expr)
         & (hl.len(filters_expr) == 0)
         & (cov_expr > cov_threshold)
     )

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -257,7 +257,7 @@ def filter_context_using_gnomad(
         Default is "exomes".
     :param adj_freq_index: Index of frequency array that contains global population calculated on
         high quality (adj) genotypes. Default is 0.
-    :param cov_threshold: Median coverage threshold below which variants are removed. Default is 0.
+    :param cov_threshold: Remove variants below this median coverage threshold. Default is 0.
     :return: Filtered VEP context Table.
     """
     gnomad = get_gnomad_public_release(gnomad_data_type, adj_freq_index)
@@ -367,8 +367,8 @@ def keep_criteria(
     :param af_expr: Allele frequency (AF) Float64Expression.
     :param filters_expr: Filters SetExpression.
     :param cov_expr: gnomAD median coverage Int32Expression.
-    :param af_threshold: Remove rows above this AF threshold. Default is 0.001.
-    :param cov_threshold: Remove rows below this median coverage threshold. Default is 0.
+    :param af_threshold: Remove variants above this AF threshold. Default is 0.001.
+    :param cov_threshold: Remove variants below this median coverage threshold. Default is 0.
     :param filter_to_rare: Whether to filter to keep rare variants only. Default is True.
     :return: Boolean expression used to filter variants.
     """

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -223,7 +223,7 @@ def get_gnomad_public_release(
         - ac
         - af
         - filters
-        - coverage
+        - gnomad_coverage
 
     :param gnomad_data_type: gnomAD data type. Used to retrieve public release and coverage resources.
         Must be one of "exomes" or "genomes" (check is done within `public_release`).

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -201,7 +201,7 @@ def prepare_pop_path_ht(
         and the population/pathogenic variant Table.
         Default is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
-    :param adj_freq_index: Index of frequency array that contains frequency information calculated on
+    :param adj_freq_index: Index of array that contains allele frequency information calculated on
         high quality (adj) genotypes across all genetic ancestry groups. Default is 0.
     :param cov_threshold: Coverage threshold used to filter context Table. Default is 0.
     :return: None; function writes Table to resource path.

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -189,7 +189,7 @@ def prepare_pop_path_ht(
         Must be one of "exomes" or "genomes" (check is done within `public_release`).
         Default is "exomes".
     :param float af_threshold: Allele frequency cutoff to filter gnomAD public dataset.
-        Variants greater than or equal to this threshold will be kept.
+        Variants at frequencies greater than or equal to this threshold will be kept.
         Default is 0.001.
     :param bool overwrite_temp: Whether to overwrite intermediate temporary data if it already exists.
         If False, will read existing intermediate temporary data rather than overwriting.

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -201,7 +201,7 @@ def prepare_pop_path_ht(
         and the population/pathogenic variant Table.
         Default is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
-    :param adj_freq_index: Index of frequency array that contains global population filtered calculated on
+    :param adj_freq_index: Index of frequency array that contains global population calculated on
         high quality (adj) genotypes. Default is 0.
     :param cov_threshold: Coverage threshold used to filter context Table. Default is 0.
     :return: None; function writes Table to resource path.

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -203,8 +203,7 @@ def prepare_pop_path_ht(
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :param adj_freq_index: Index of frequency array that contains global population filtered calculated on
         high quality (adj) genotypes. Default is 0.
-    :param cov_threshold: Coverage threshold used to filter context Table if `filter_context_using_cov` is True.
-        Default is 0.
+    :param cov_threshold: Coverage threshold used to filter context Table. Default is 0.
     :return: None; function writes Table to resource path.
     """
     logger.info("Reading in ClinVar P/LP missense variants in severe HI genes...")

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -189,7 +189,7 @@ def prepare_pop_path_ht(
         Must be one of "exomes" or "genomes" (check is done within `public_release`).
         Default is "exomes".
     :param float af_threshold: Allele frequency cutoff to filter gnomAD public dataset.
-        Variants *above* this threshold will be kept.
+        Variants greater than or equal to this threshold will be kept.
         Default is 0.001.
     :param bool overwrite_temp: Whether to overwrite intermediate temporary data if it already exists.
         If False, will read existing intermediate temporary data rather than overwriting.

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -201,8 +201,8 @@ def prepare_pop_path_ht(
         and the population/pathogenic variant Table.
         Default is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
-    :param adj_freq_index: Index of frequency array that contains global population calculated on
-        high quality (adj) genotypes. Default is 0.
+    :param adj_freq_index: Index of frequency array that contains frequency information calculated on
+        high quality (adj) genotypes across all genetic ancestry groups. Default is 0.
     :param cov_threshold: Coverage threshold used to filter context Table. Default is 0.
     :return: None; function writes Table to resource path.
     """

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -220,7 +220,7 @@ def prepare_pop_path_ht(
             ac_expr=gnomad_ht.ac,
             af_expr=gnomad_ht.af,
             filters_expr=gnomad_ht.filters,
-            cov_expr=gnomad_ht.coverage,
+            cov_expr=gnomad_ht.gnomad_coverage,
             af_threshold=af_threshold,
             cov_threshold=cov_threshold,
             filter_to_rare=False,

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -31,7 +31,12 @@ from rmc.resources.rmc import (
     mpc_release,
     mpc_release_dedup,
 )
-from rmc.utils.generic import get_aa_map, get_gnomad_public_release, keep_criteria
+from rmc.utils.generic import (
+    get_aa_map,
+    get_constraint_transcripts,
+    get_gnomad_public_release,
+    keep_criteria,
+)
 
 logging.basicConfig(
     format="%(asctime)s (%(name)s %(lineno)s): %(message)s",
@@ -299,7 +304,10 @@ def prepare_pop_path_ht(
         overwrite=overwrite_temp,
     )
 
-    logger.info("Filtering to rows with defined annotations and writing out...")
+    logger.info(
+        "Filtering to rows with defined annotations in transcripts to keep and writing out..."
+    )
+    transcripts = get_constraint_transcripts(outlier=False)
     ht = ht.filter(
         hl.is_defined(ht.cadd.phred)
         & hl.is_defined(ht.blosum)
@@ -307,6 +315,7 @@ def prepare_pop_path_ht(
         & hl.is_defined(ht.oe)
         & hl.is_defined(ht.polyphen.score)
         & hl.is_defined(ht.misbad)
+        & transcripts.contains(ht.transcript)
     )
     ht.write(joint_clinvar_gnomad.versions[freeze].path, overwrite=overwrite_output)
 


### PR DESCRIPTION
Major changes:
- Update `prepare_pop_path_ht` function to filter gnomAD public release to high quality, common variants (previously only filtered gnomAD public release HT on AF)
- Update `prepare_pop_path_ht` function to filter joint ClinVar/gnomAD HT to set of transcripts to keep (previously kept variants in all transcripts)

Minor changes:
- Created `get_gnomad_public_release` function (moved code getting gnomAD public release HT and annotating with coverage to a function)
- Added `filter_to_rare` option to `keep_criteria` function