### PR TITLE
Fixes for missense badness training/validation/testing

### DIFF
--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -86,7 +86,7 @@ def training_transcripts_path(fold: int = None, is_val: bool = False) -> str:
     """
     if is_val and fold is None:
         raise DataException("Fold number must be specified for validation transcripts!")
-    if fold not in range(1, FOLD_K + 1):
+    if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
             f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -550,7 +550,7 @@ def misbad_path(
         raise DataException("Fold number cannot be specified for test set!")
     if is_val and fold is None:
         raise DataException("Fold number must be specified for validation set!")
-    if fold not in range(1, FOLD_K + 1):
+    if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
             f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -506,7 +506,7 @@ def amino_acids_oe_path(
         raise DataException("Fold number cannot be specified for test set!")
     if is_val and fold is None:
         raise DataException("Fold number must be specified for validation set!")
-    if fold not in range(1, FOLD_K + 1):
+    if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
             f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -35,7 +35,6 @@ from rmc.resources.reference_data import (
     haplo_genes_path,
     ndd_de_novo,
     ndd_de_novo_2020_tsv_path,
-    transcript_cds,
     triplo_genes_path,
 )
 from rmc.resources.resource_utils import MISSENSE

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -262,8 +262,8 @@ def filter_context_using_gnomad(
     :param gnomad_data_type: gnomAD data type. Used to retrieve public release and coverage resources.
         Must be one of "exomes" or "genomes" (check is done within `public_release`).
         Default is "exomes".
-    :param adj_freq_index: Index of frequency array that contains frequency information calculated on
-        high quality (adj) genotypes across all genetic ancestry groups. Default is 0.
+    :param adj_freq_index: Index of array that contains allele frequency information calculated on
+        high quality (adj) genotypes across genetic ancestry groups. Default is 0.
     :param cov_threshold: Remove variants at or below this median coverage threshold. Default is 0.
     :return: Filtered VEP context Table.
     """

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -320,65 +320,65 @@ def get_annotations_from_context_ht_vep(
     return annotate_and_filter_codons(ht)
 
 
-def filter_context_to_transcript_cds(
-    context_ht: hl.Table, transcripts: hl.expr.SetExpression
-) -> hl.Table:
-    """
-    Filter VEP context Table to coding sites in the input transcripts.
+# def filter_context_to_transcript_cds(
+#     context_ht: hl.Table, transcripts: hl.expr.SetExpression
+# ) -> hl.Table:
+#     """
+#     Filter VEP context Table to coding sites in the input transcripts.
 
-    :param hl.Table context_ht: VEP context Table.
-    :param hl.expr.SetExpression transcripts: Transcripts to filter to.
-    :return: VEP context Table with rows filtered to only coding sites in the input transcripts.
-    """
-    # Get coordinate intervals of coding sequences of transcripts
-    cds_ht = transcript_cds.ht()
-    filter_intervals = cds_ht.aggregate(
-        hl.agg.filter(
-            transcripts.contains(cds_ht.transcript),
-            hl.agg.collect(cds_ht.interval),
-        ),
-        _localize=False,
-    )
-    # Filter context HT to sites in these intervals
-    return hl.filter_intervals(context_ht, filter_intervals)
+#     :param hl.Table context_ht: VEP context Table.
+#     :param hl.expr.SetExpression transcripts: Transcripts to filter to.
+#     :return: VEP context Table with rows filtered to only coding sites in the input transcripts.
+#     """
+#     # Get coordinate intervals of coding sequences of transcripts
+#     cds_ht = transcript_cds.ht()
+#     filter_intervals = cds_ht.aggregate(
+#         hl.agg.filter(
+#             transcripts.contains(cds_ht.transcript),
+#             hl.agg.collect(cds_ht.interval),
+#         ),
+#         _localize=False,
+#     )
+#     # Filter context HT to sites in these intervals
+#     return hl.filter_intervals(context_ht, filter_intervals)
 
 
 ####################################################################################
 ## Observed and expected-related utils
 ####################################################################################
-def get_exome_bases() -> int:
-    """
-    Get number of bases in the exome.
+# def get_exome_bases() -> int:
+#     """
+#     Get number of bases in the exome.
 
-    Read in context HT (containing all coding bases in the genome), remove outlier transcripts, and filter to median coverage >= 5.
+#     Read in context HT (containing all coding bases in the genome), remove outlier transcripts, and filter to median coverage >= 5.
 
-    :return: Number of bases in the exome.
-    :rtype: int
-    """
-    logger.info("Reading in SNPs-only, VEP-annotated context ht...")
-    ht = vep_context.ht()
+#     :return: Number of bases in the exome.
+#     :rtype: int
+#     """
+#     logger.info("Reading in SNPs-only, VEP-annotated context ht...")
+#     ht = vep_context.ht()
 
-    logger.info("Filtering to canonical transcripts...")
-    ht = filter_vep_to_canonical_transcripts(ht, vep_root="vep", filter_empty_csq=True)
+#     logger.info("Filtering to canonical transcripts...")
+#     ht = filter_vep_to_canonical_transcripts(ht, vep_root="vep", filter_empty_csq=True)
 
-    logger.info("Removing outlier transcripts...")
-    outlier_transcripts = get_constraint_transcripts(outlier=True)
-    ht = ht.transmute(transcript_consequences=ht.vep.transcript_consequences)
-    ht = ht.explode(ht.transcript_consequences)
-    ht = ht.filter(
-        ~outlier_transcripts.contains(ht.transcript_consequences.transcript_id)
-    )
+#     logger.info("Removing outlier transcripts...")
+#     outlier_transcripts = get_constraint_transcripts(outlier=True)
+#     ht = ht.transmute(transcript_consequences=ht.vep.transcript_consequences)
+#     ht = ht.explode(ht.transcript_consequences)
+#     ht = ht.filter(
+#         ~outlier_transcripts.contains(ht.transcript_consequences.transcript_id)
+#     )
 
-    logger.info(
-        "Collecting context HT by key (to make sure each locus only gets counted once)..."
-    )
-    ht = ht.key_by("locus").collect_by_key()
+#     logger.info(
+#         "Collecting context HT by key (to make sure each locus only gets counted once)..."
+#     )
+#     ht = ht.key_by("locus").collect_by_key()
 
-    logger.info("Removing positions with median coverage < 5...")
-    # Taking just the first value since the coverage should be the same for all entries at a locus
-    ht = ht.filter(ht.values[0].coverage.exomes.median >= 5)
-    ht = ht.select()
-    return ht.count()
+#     logger.info("Removing positions with median coverage < 5...")
+#     # Taking just the first value since the coverage should be the same for all entries at a locus
+#     ht = ht.filter(ht.values[0].coverage.exomes.median >= 5)
+#     ht = ht.select()
+#     return ht.count()
 
 
 def keep_criteria(

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -321,11 +321,12 @@ def calculate_misbad(
     if use_test_transcripts and do_k_fold_training:
         raise DataException("Cannot generate k-fold models with test transcripts!")
 
+    transcript_type = "test" if use_test_transcripts else "train"
+
     if use_test_transcripts or not do_k_fold_training:
         if not file_exists(
             amino_acids_oe_path(is_test=use_test_transcripts, freeze=freeze)
         ):
-            transcript_type = "test" if use_test_transcripts else "training"
             raise DataException(
                 "Table with all amino acid substitutions and missense OE "
                 f"in {transcript_type} transcripts doesn't exist!"

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -14,7 +14,6 @@ from rmc.resources.rmc import CURRENT_FREEZE, amino_acids_oe_path, misbad_path
 from rmc.utils.constraint import add_obs_annotation, get_oe_annotation
 from rmc.utils.generic import (
     annotate_and_filter_codons,
-    filter_context_to_transcript_cds,
     filter_context_using_gnomad,
     process_context_ht,
 )

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -141,9 +141,7 @@ def prepare_amino_acid_ht(
         overwrite=overwrite_temp,
     )
 
-    logger.info(
-        "Getting observed to expected ratio, rekeying Table, and writing to output path..."
-    )
+    logger.info("Getting observed to expected ratio and rekeying Table...")
     # Note that `get_oe_annotation` is pulling the missense OE ratio
     context_ht = get_oe_annotation(context_ht, freeze)
     context_ht = context_ht.key_by("locus", "alleles", "transcript")

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -66,7 +66,7 @@ def prepare_amino_acid_ht(
     :param gnomad_data_type: gnomAD data type. Used to retrieve public release and coverage resources.
         Must be one of "exomes" or "genomes" (check is done within `public_release`).
         Default is "exomes".
-    :param loftee_hc_str: String indicating that LOFTEE a loss-of-function variant is predcited to cause
+    :param loftee_hc_str: String indicating that a variant is predicted to cause loss-of-function with high confidence by LOFTEE.
     :return: None; writes amino acid Table(s) to resource path(s).
     """
     if use_test_transcripts and do_k_fold_training:

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -171,7 +171,9 @@ def prepare_amino_acid_ht(
             if use_test_transcripts
             else training_transcripts_path()
         )
-        context_ht = filter_context_to_transcript_cds(context_ht, filter_transcripts)
+        context_ht = context_ht.filter(
+            filter_transcripts.contains(context_ht.transcript)
+        )
         context_ht.write(
             amino_acids_oe_path(is_test=use_test_transcripts, freeze=freeze),
             overwrite=overwrite_output,
@@ -187,8 +189,8 @@ def prepare_amino_acid_ht(
                 filter_transcripts = hl.experimental.read_expression(
                     training_transcripts_path(fold=i, is_val=is_val)
                 )
-                context_ht = filter_context_to_transcript_cds(
-                    context_ht, filter_transcripts
+                context_ht = context_ht.filter(
+                    filter_transcripts.contains(context_ht.transcript)
                 )
                 context_ht.write(
                     amino_acids_oe_path(

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -100,7 +100,14 @@ def prepare_amino_acid_ht(
     )
 
     logger.info("Checking LOFTEE LoF information...")
-    loftee_lof_agg = context_ht.aggregate(hl.agg.counter(context_ht.lof))
+    loftee_lof_agg_path = f"{TEMP_PATH_WITH_FAST_DEL}/lof_agg.he"
+    if not overwrite_temp and file_exists(loftee_lof_agg_path):
+        loftee_lof_agg = hl.eval(hl.experimental.read_expression(loftee_lof_agg_path))
+    else:
+        loftee_lof_agg = context_ht.aggregate(hl.agg.counter(context_ht.lof))
+        hl.experimental.write_expression(
+            hl.literal(loftee_lof_agg), loftee_lof_agg_path
+        )
     logger.info("LOFTEE aggregation: %s", loftee_lof_agg)
 
     logger.info("Filtering to LOFTEE HC pLoF without flags...")

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -396,9 +396,14 @@ def calculate_misbad(
         ht = high_ht.join(low_ht, how="outer")
         ht = ht.transmute(mut_type=hl.coalesce(ht.mut_type, ht.mut_type_1))
         mb_ht = ht.group_by("ref", "alt").aggregate(
+            high_obs=hl.agg.sum(ht.high_obs),
+            high_pos=hl.agg.sum(ht.high_pos),
+            low_obs=hl.agg.sum(ht.low_obs),
+            low_pos=hl.agg.sum(ht.low_pos),
+        )
+        mb_ht = mb_ht.annotate(
             high_low=(
-                (hl.agg.sum(ht.high_obs) / hl.agg.sum(ht.high_pos))
-                / (hl.agg.sum(ht.low_obs) / hl.agg.sum(ht.low_pos))
+                (mb_ht.high_obs / mb_ht.high_pos) / (mb_ht.low_obs / mb_ht.low_pos)
             )
         )
         mb_ht = mb_ht.annotate(mut_type=variant_csq_expr(mb_ht.ref, mb_ht.alt))

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -202,7 +202,7 @@ def prepare_pop_path_ht(
         Default is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :param adj_freq_index: Index of array that contains allele frequency information calculated on
-        high quality (adj) genotypes across all genetic ancestry groups. Default is 0.
+        high quality (adj) genotypes across genetic ancestry groups. Default is 0.
     :param cov_threshold: Coverage threshold used to filter context Table. Default is 0.
     :return: None; function writes Table to resource path.
     """


### PR DESCRIPTION
PR contains the following minor changes:

- Bug fixes in resource paths and variable placement introduced in https://github.com/broadinstitute/regional_missense_constraint/pull/285
- Fix for description of `adj_freq_index` parameter in some functions that were missed in https://github.com/broadinstitute/regional_missense_constraint/pull/286
- Addition of temporary storage of an aggregator that is created in `prepare_amino_acid_ht` of missense badness model generation which was slowing down runtime quite a bit
- Addition of code to save observed and possible counts in misbad HT (for use in misbad exploratory analyses)
- Update to logged information