### PR TITLE
Expand MPC code to evaluate regression models with all combinations of variables including BLOSUM/Grantham

### DIFF
--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Tuple, Union
 
 import hail as hl
 import numpy as np
-import pandas as pd
 import statsmodels
 import statsmodels.api as sm
 from gnomad.resources.resource_utils import DataException

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -442,13 +442,13 @@ def run_regressions(
     add_model_res = {}
     add_model_aic = []
     add_X = []
-    for var in comb_var:
-        logger.info("Running joint (additive interactions) regression for %s...", var)
-        formula = f"pop_v_path ~ {' + '.join(var)}"
+    for var_a in comb_var:
+        logger.info("Running joint (additive interactions) regression for %s...", var_a)
+        formula = f"pop_v_path ~ {' + '.join(var_a)}"
         X, model = _run_glm(formula)
         add_X.append(X)
         add_model_aic.append(model.aic)
-        add_model_res[var] = model
+        add_model_res[var_a] = model
 
     # Find lowest AIC for multiple variable (additive interactions only) regression and
     # corresponding model
@@ -462,13 +462,13 @@ def run_regressions(
     mult_model_res = {}
     mult_model_aic = []
     mult_X = []
-    for var in comb_var:
-        logger.info("Running joint (multiplicative interactions) regression for %s...", var)
-        formula = f"pop_v_path ~ {' * '.join(var)}"
+    for var_m in comb_var:
+        logger.info("Running joint (multiplicative interactions) regression for %s...", var_m)
+        formula = f"pop_v_path ~ {' * '.join(var_m)}"
         X, model = _run_glm(formula)
         mult_X.append(X)
         mult_model_aic.append(model.aic)
-        mult_model_res[var] = model
+        mult_model_res[var_m] = model
 
     # Find lowest AIC for multiple variable (multiplicative interactions) regression and
     # corresponding model

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -410,7 +410,7 @@ def run_regressions(
         X, model = _run_glm(formula)
         single_var_X.append(X)
         single_var_aic.append(model.aic)
-        single_var_res[var] = model.params
+        single_var_res[var] = model
 
     # Find lowest AIC for single variable regressions and corresponding model
     min_single_aic = min(single_var_aic)
@@ -458,7 +458,7 @@ def run_regressions(
             "Single variable regression using %s had the lowest AIC", min_single_aic_var
         )
         logger.info("Coefficients: %s", single_var_res[min_single_aic_var])
-        model = single_var_res
+        model = single_var_res[min_single_aic_var]
         X = min_single_X
     elif min_aic == add_model.aic:
         logger.info(

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -489,7 +489,7 @@ def run_regressions(
     # corresponding model
     min_mult_aic = min(mult_model_aic)
     min_mult_idx = mult_model_aic.index(min_mult_aic)
-    min_mult_aic_var = comb_var[min_mult_idx]
+    min_mult_aic_var = var_combs[min_mult_idx]
     min_mult_X = mult_model_X[min_mult_idx]
     min_mult_formula = f"pop_v_path ~ {' * '.join(min_mult_aic_var)}"
 

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -374,7 +374,7 @@ def run_regressions(
 
     model_types = ["single", "additive", "multiplicative", "spec"]
     # Model type labels for use in logging information
-    model_types_log = {
+    log_model_types = {
         "single": "single variable",
         "additive": "joint (no interactions)",
         "multiplicative": "joint (with interactions)",
@@ -437,7 +437,7 @@ def run_regressions(
         model_aics = []
         model_formulas = []
         formula_interaction_char = "*" if model_type == "multiplicative" else "+"
-        log_model_type = model_types_log[model_type]
+        log_model_type = log_model_types[model_type]
 
         for var_comb in var_combs:
             logger.info("Running %s regression for %s...", log_model_type, var_comb)

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -475,7 +475,7 @@ def run_regressions(
 
     # Find model with lowest AIC for single variable regressions
     min_models["single"], min_model_formulas["single"] = _get_min_aic_glm(
-        [x for x in all_vars]
+        [[x] for x in all_vars]
     )
 
     # List possible variable combinations for joint regressions

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -433,16 +433,15 @@ def run_regressions(
         min_single_aic_var,
     )
 
-    # List possible variable combinations for Joint Regression
-    comb_var = []
-    for k in range(2,6):
-        comb_var += [x for x in combinations(all_var,k)]
+    # List possible variable combinations for joint regression
+    var_combs = []
+    for k in range(2, len(all_var) + 1):
+        var_combs += [x for x in combinations(all_var, k)]
 
-    logger.info("Running joint (additive interactions only) regression...")
     add_model_res = {}
     add_model_aic = []
-    add_X = []
-    for var_a in comb_var:
+    add_model_X = []
+    for var_comb in var_combs:
         logger.info("Running joint (additive interactions) regression for %s...", var_a)
         formula = f"pop_v_path ~ {' + '.join(var_a)}"
         X, model = _run_glm(formula)
@@ -463,7 +462,9 @@ def run_regressions(
     mult_model_aic = []
     mult_X = []
     for var_m in comb_var:
-        logger.info("Running joint (multiplicative interactions) regression for %s...", var_m)
+        logger.info(
+            "Running joint (multiplicative interactions) regression for %s...", var_m
+        )
         formula = f"pop_v_path ~ {' * '.join(var_m)}"
         X, model = _run_glm(formula)
         mult_X.append(X)
@@ -498,7 +499,7 @@ def run_regressions(
         logger.info(
             "Single variable regression using %s had the lowest AIC", min_single_aic_var
         )
-        logger.info("Coefficients: %s", single_var_res[min_single_aic_var])
+        logger.info("Coefficients: %s", single_var_res[min_single_aic_var].params)
         model = single_var_res[min_single_aic_var]
         X = min_single_X
     elif min_aic == min_add_aic:

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -321,7 +321,8 @@ def prepare_pop_path_ht(
 
 
 def run_regressions(
-    variables: List[str] = ["oe", "misbad", "polyphen", "blosum", "grantham"],
+    variables: List[str] = ["oe", "misbad", "polyphen"],
+    additional_variables: List[str] = ["blosum", "grantham"],
     overwrite: bool = True,
     freeze: int = CURRENT_FREEZE,
 ) -> None:
@@ -342,8 +343,10 @@ def run_regressions(
     Note that higher MPC scores predict increased missense deleteriousness, and
     smaller n_less values and fitted scores will lead to higher MPC scores.
 
-    :param List[str] variables: Variables to include in all regressions (single, joint).
-        Default is ["oe", "misbad", "polyphen", "blosum", "grantham"].
+    :param List[str] variables: Primary Variables to include in all regressions (single, joint).
+        Default is ["oe", "misbad", "polyphen"].
+    :param List[str] additional_variables: Additional variables to include in all regressions (single, joint).
+        Default is ["blosum", "grantham"].
     :param bool overwrite: Whether to overwrite gnomAD fitted score table if it already exists. Default is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: None; function writes Table with gnomAD fitted scores
@@ -403,7 +406,8 @@ def run_regressions(
     single_var_res = {}
     single_var_aic = []
     single_var_X = []
-    for var in variables:
+    all_var = variables + additional_variables
+    for var in all_var:
         logger.info("Running %s regression...", var)
         # Create design matrices
         formula = f"pop_v_path ~ {var}"
@@ -415,7 +419,7 @@ def run_regressions(
     # Find lowest AIC for single variable regressions and corresponding model
     min_single_aic = min(single_var_aic)
     single_var_idx = single_var_aic.index(min_single_aic)
-    min_single_aic_var = variables[single_var_idx]
+    min_single_aic_var = all_var[single_var_idx]
     min_single_X = single_var_X[single_var_idx]
     if single_var_aic.count(min_single_aic) > 1:
         logger.warning(
@@ -432,7 +436,7 @@ def run_regressions(
     # List possible variable combinations for Joint Regression
     comb_var = []
     for k in range(2,6):
-    	comb_var += [x for x in combinations(variables,k)]
+        comb_var += [x for x in combinations(all_var,k)]
 
     logger.info("Running joint (additive interactions only) regression...")
     add_model_res = {}

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -436,43 +436,43 @@ def run_regressions(
 
     logger.info("Running joint (additive interactions only) regression...")
     add_model_res = {}
-	add_model_aic = []
-	add_X = []
-	for var in comb_var:
-		logger.info("Running joint (additive interactions) regression for %s...", var)
-		formula = f"pop_v_path ~ {' + '.join(var)}"
-		X, model = _run_glm(formula)
-		add_X.append(X)
-		add_model_aic.append(model.aic)
-		add_model_res[var] = model
+    add_model_aic = []
+    add_X = []
+    for var in comb_var:
+        logger.info("Running joint (additive interactions) regression for %s...", var)
+        formula = f"pop_v_path ~ {' + '.join(var)}"
+        X, model = _run_glm(formula)
+        add_X.append(X)
+        add_model_aic.append(model.aic)
+        add_model_res[var] = model
 
-	# Find lowest AIC for multiple variable (additive interactions only) regression and
-	# corresponding model
-	min_add_aic = min(add_model_aic)
-	min_add_idx = add_model_aic.index(min_add_aic)
-	min_add_aic_var = comb_var[min_add_idx]
-	min_add_X = add_X[min_add_idx]
-	min_add_formula = f"pop_v_path ~ {' + '.join(min_add_aic_var)}"
+    # Find lowest AIC for multiple variable (additive interactions only) regression and
+    # corresponding model
+    min_add_aic = min(add_model_aic)
+    min_add_idx = add_model_aic.index(min_add_aic)
+    min_add_aic_var = comb_var[min_add_idx]
+    min_add_X = add_X[min_add_idx]
+    min_add_formula = f"pop_v_path ~ {' + '.join(min_add_aic_var)}"
 
     logger.info("Running joint regression with all interactions...")
     mult_model_res = {}
     mult_model_aic = []
     mult_X = []
     for var in comb_var:
-    	logger.info("Running joint (multiplicative interactions) regression for %s...", var)
-    	formula = f"pop_v_path ~ {' * '.join(var)}"
-    	X, model = _run_glm(formula)
-    	mult_X.append(X)
-    	mult_model_aic.append(model.aic)
-    	mult_model_res[var] = model
+        logger.info("Running joint (multiplicative interactions) regression for %s...", var)
+        formula = f"pop_v_path ~ {' * '.join(var)}"
+        X, model = _run_glm(formula)
+        mult_X.append(X)
+        mult_model_aic.append(model.aic)
+        mult_model_res[var] = model
 
     # Find lowest AIC for multiple variable (multiplicative interactions) regression and
-	# corresponding model
-	min_mult_aic = min(mult_model_aic)
-	min_mult_idx = mult_model_aic.index(min_mult_aic)
-	min_mult_aic_var = comb_var[min_mult_idx]
-	min_mult_X = mult_X[min_mult_idx]
-	min_mult_formula = f"pop_v_path ~ {' * '.join(min_mult_aic_var)}"
+    # corresponding model
+    min_mult_aic = min(mult_model_aic)
+    min_mult_idx = mult_model_aic.index(min_mult_aic)
+    min_mult_aic_var = comb_var[min_mult_idx]
+    min_mult_X = mult_X[min_mult_idx]
+    min_mult_formula = f"pop_v_path ~ {' * '.join(min_mult_aic_var)}"
 
     logger.info("Running joint regression with specific interactions...")
     # Currently hardcoded to be formula from ExAC

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -442,7 +442,9 @@ def run_regressions(
     add_model_aic = []
     add_model_X = []
     for var_comb_add in var_combs:
-        logger.info("Running joint (additive interactions) regression for %s...", var_comb_add)
+        logger.info(
+            "Running joint (additive interactions) regression for %s...", var_comb_add
+        )
         formula = f"pop_v_path ~ {' + '.join(var_comb_add)}"
         X, model = _run_glm(formula)
         add_model_X.append(X)
@@ -474,7 +476,8 @@ def run_regressions(
     mult_model_X = []
     for var_comb_mult in var_combs:
         logger.info(
-            "Running joint (multiplicative interactions) regression for %s...", var_comb_mult
+            "Running joint (multiplicative interactions) regression for %s...",
+            var_comb_mult,
         )
         formula = f"pop_v_path ~ {' * '.join(var_comb_mult)}"
         X, model = _run_glm(formula)

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -496,7 +496,7 @@ def run_regressions(
     min_models["spec"] = _run_glm(min_model_formulas["spec"])
 
     min_model_aics = {x: min_models[x].aic for x in model_types}
-    overall_min_aic = min(min_model_aics)
+    overall_min_aic = min(min_model_aics.values())
     logger.info("Lowest model AIC: %f", overall_min_aic)
     if list(min_model_aics.values()).count(overall_min_aic) > 1:
         logger.warning(

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -343,7 +343,7 @@ def run_regressions(
     Note that higher MPC scores predict increased missense deleteriousness, and
     smaller n_less values and fitted scores will lead to higher MPC scores.
 
-    :param List[str] variables: Primary Variables to include in all regressions (single, joint).
+    :param List[str] variables: Primary variables to include in all regressions (single, joint).
         Default is ["oe", "misbad", "polyphen"].
     :param List[str] additional_variables: Additional variables to include in all regressions (single, joint).
         Default is ["blosum", "grantham"].

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -407,13 +407,13 @@ def run_regressions(
         return model
 
     def _get_min_aic_glm(
-        var_combs: List[List[str]],
+        var_combs: List[Tuple[str, ...]],
         model_type: str = "single",
     ) -> Tuple[statsmodels.genmod.generalized_linear_model.GLMResultsWrapper, str,]:
         """
         Run logistic regressions on different variable combinations and return results on model with lowest AIC.
 
-        :param List[List[str]] var_combs: Variable combinations to generate regressions with.
+        :param List[Tuple[str]] var_combs: Variable combinations to generate regressions with.
         :param str model_type: Regression formula type.
             One of "single", "additive", or "multiplicative".
             If "single", each variable combination must consist of only one variable.
@@ -475,7 +475,7 @@ def run_regressions(
 
     # Find model with lowest AIC for single variable regressions
     min_models["single"], min_model_formulas["single"] = _get_min_aic_glm(
-        [[x] for x in all_vars]
+        [(x,) for x in all_vars]
     )
 
     # List possible variable combinations for joint regressions


### PR DESCRIPTION
Major Changes:

1. Include BLOSUM and Grantham scores into pool of variables for running single + joint regressions. 
2. Evaluate linear regression models for all possible combinations of variables including MPC + BLOSUM + Grantham and pick one with lowest AIC.

Minor changes:

1. Update documentation of `additional_variables` in function description `run_regressions` since it will now be added into combined variable pool for single + joint regressions.
2. Fix a bug causing single variables regression model with lowest AIC to output the model parameters instead of stats model object.
3. Replace `all_model_aic` with just the lowest AIC from each category of regression (single, additive, multiplicative and special) since having a long list of AICs from each combination is irrelevant in downstream steps.