### PR TITLE
Flexibility updates for training transcript sets for missense badness and MPC

### DIFF
--- a/rmc/pipeline/calculate_missense_badness.py
+++ b/rmc/pipeline/calculate_missense_badness.py
@@ -30,7 +30,6 @@ def main(args):
             hl.init(log="/calc_misbad_prep_context_gamma_ht.log", tmp_dir=temp_dir)
             prepare_amino_acid_ht(
                 overwrite_temp=args.overwrite_temp,
-                overwrite_output=args.overwrite_output,
                 do_k_fold_training=args.do_k_fold_training,
                 freeze=args.freeze,
             )
@@ -40,7 +39,6 @@ def main(args):
             calculate_misbad(
                 use_exac_oe_cutoffs=args.use_exac_oe_cutoffs,
                 overwrite_temp=args.overwrite_temp,
-                overwrite_output=args.overwrite_output,
                 do_k_fold_training=args.do_k_fold_training,
                 freeze=args.freeze,
             )
@@ -56,12 +54,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--overwrite-temp",
-        help="Overwrite existing temporary data, for use in functions with option to modify existing final output data.",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--overwrite-output",
-        help="Completely overwrite existing final output data, for use in functions with option to modify existing final output data.",
+        help="Overwrite existing intermediate temporary data.",
         action="store_true",
     )
     parser.add_argument(

--- a/rmc/pipeline/calculate_missense_badness.py
+++ b/rmc/pipeline/calculate_missense_badness.py
@@ -77,8 +77,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--do-k-fold-training",
         help="""
-        Generate k-fold missense badness models (one each for training and validation transcripts in each fold)
-        instead of one model for all training transcripts.
+        Generate k-fold missense badness models trained on training sets from respective folds.
+        Otherwise, one model is generated, trained on all training transcripts.
         """,
         action="store_true",
     )

--- a/rmc/pipeline/calculate_missense_badness.py
+++ b/rmc/pipeline/calculate_missense_badness.py
@@ -31,7 +31,6 @@ def main(args):
             prepare_amino_acid_ht(
                 overwrite_temp=args.overwrite_temp,
                 overwrite_output=args.overwrite_output,
-                use_test_transcripts=args.use_test_transcripts,
                 do_k_fold_training=args.do_k_fold_training,
                 freeze=args.freeze,
             )
@@ -42,7 +41,6 @@ def main(args):
                 use_exac_oe_cutoffs=args.use_exac_oe_cutoffs,
                 overwrite_temp=args.overwrite_temp,
                 overwrite_output=args.overwrite_output,
-                use_test_transcripts=args.use_test_transcripts,
                 do_k_fold_training=args.do_k_fold_training,
                 freeze=args.freeze,
             )
@@ -75,11 +73,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--slack-channel",
         help="Send message to Slack channel/user.",
-    )
-    parser.add_argument(
-        "--use-test-transcripts",
-        help="Use test transcripts instead of training transcripts in creation of missense badness.",
-        action="store_true",
     )
     parser.add_argument(
         "--do-k-fold-training",

--- a/rmc/pipeline/calculate_mpc.py
+++ b/rmc/pipeline/calculate_mpc.py
@@ -66,59 +66,16 @@ def main(args):
         if args.command == "annotate-hts":
             hl.init(log="/annotate_hts.log", tmp_dir=temp_dir)
             mpc_bucket_path = f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{args.freeze}"
-            if args.clinvar:
-                from rmc.resources.reference_data import clinvar_plp_mis_haplo
-
-                annotate_mpc(
-                    ht=clinvar_plp_mis_haplo.ht(),
-                    output_ht_path=f"{mpc_bucket_path}/clinvar_mpc_annot.ht",
-                    temp_label="_clinvar",
-                    model_train_fold=args.model_train_fold,
-                    use_release=args.use_release,
-                    overwrite_temp=args.overwrite_temp,
-                    freeze=args.freeze,
-                )
-                # TODO: Add support for annotating with models from specific folds (all folds?)
+            # TODO: Add support for annotating with models from specific folds (all folds?)
 
             if args.dd:
                 from rmc.resources.reference_data import ndd_de_novo
 
                 dd_ht = ndd_de_novo.ht()
-                dd_ht = dd_ht.explode("sample_set")
-                case_ht = dd_ht.filter(dd_ht.sample_set != "control")
                 annotate_mpc(
-                    ht=case_ht,
-                    output_ht_path=f"{mpc_bucket_path}/dd_case_mpc_annot.ht",
-                    temp_label="_dd_case",
-                    model_train_fold=args.model_train_fold,
-                    use_release=args.use_release,
-                    overwrite_temp=args.overwrite_temp,
-                    freeze=args.freeze,
-                )
-                control_ht = dd_ht.filter(dd_ht.sample_set == "control")
-                shared_variants = case_ht.join(control_ht, how="inner")
-                logger.info(
-                    "%i variants overlapped between cases and controls",
-                    shared_variants.count(),
-                )
-                annotate_mpc(
-                    ht=control_ht,
-                    output_ht_path=f"{mpc_bucket_path}/dd_control_mpc_annot.ht",
-                    temp_label="_dd_control",
-                    model_train_fold=args.model_train_fold,
-                    use_release=args.use_release,
-                    overwrite_temp=args.overwrite_temp,
-                    freeze=args.freeze,
-                )
-
-            if args.gnomad_exomes:
-                from gnomad.resources.grch37.gnomad import public_release
-
-                ht = public_release("exomes").ht()
-                annotate_mpc(
-                    ht=ht,
-                    output_ht_path=f"{mpc_bucket_path}/gnomAD_mpc_annot.ht",
-                    temp_label="_gnomad_exome",
+                    ht=dd_ht,
+                    output_ht_path=f"{mpc_bucket_path}/dd_mpc_annot.ht",
+                    temp_label="_dd",
                     model_train_fold=args.model_train_fold,
                     use_release=args.use_release,
                     overwrite_temp=args.overwrite_temp,

--- a/rmc/pipeline/calculate_mpc.py
+++ b/rmc/pipeline/calculate_mpc.py
@@ -199,18 +199,9 @@ if __name__ == "__main__":
         Suffix to add to temporary data paths to avoid conflicting names for different models.
         """,
     )
-    # temp_label="_clinvar",
-    annotate_hts.add_argument(
-        "--clinvar", help="Calculate MPC for ClinVar variants.", action="store_true"
-    )
     annotate_hts.add_argument(
         "--dd",
         help="Calculate MPC for de novo variants from developmental disorder (DD) cases and controls.",
-        action="store_true",
-    )
-    annotate_hts.add_argument(
-        "--gnomad-exomes",
-        help="Calculate MPC for all gnomAD exomes variants.",
         action="store_true",
     )
     annotate_hts.add_argument(

--- a/rmc/pipeline/calculate_mpc.py
+++ b/rmc/pipeline/calculate_mpc.py
@@ -38,6 +38,7 @@ def main(args):
             prepare_pop_path_ht(
                 overwrite_temp=args.overwrite_temp,
                 overwrite_output=args.overwrite_output,
+                do_k_fold_training=args.do_k_fold_training,
                 freeze=args.freeze,
             )
 
@@ -47,6 +48,7 @@ def main(args):
                 variables=args.variables.split(","),
                 additional_variables=args.extra_variables.split(","),
                 overwrite=args.overwrite,
+                do_k_fold_training=args.do_k_fold_training,
                 freeze=args.freeze,
             )
 

--- a/rmc/pipeline/calculate_mpc.py
+++ b/rmc/pipeline/calculate_mpc.py
@@ -37,7 +37,6 @@ def main(args):
             hl.init(log="/write_pop_path_ht.log", tmp_dir=temp_dir)
             prepare_pop_path_ht(
                 overwrite_temp=args.overwrite_temp,
-                overwrite_output=args.overwrite_output,
                 do_k_fold_training=args.do_k_fold_training,
                 freeze=args.freeze,
             )
@@ -47,7 +46,7 @@ def main(args):
             run_regressions(
                 variables=args.variables.split(","),
                 additional_variables=args.extra_variables.split(","),
-                overwrite=args.overwrite,
+                overwrite_temp=args.overwrite_temp,
                 do_k_fold_training=args.do_k_fold_training,
                 freeze=args.freeze,
             )
@@ -56,7 +55,6 @@ def main(args):
             hl.init(log="/create_mpc_release.log", tmp_dir=temp_dir)
             create_mpc_release_ht(
                 overwrite_temp=args.overwrite_temp,
-                overwrite_output=args.overwrite_output,
                 freeze=args.freeze,
             )
 
@@ -70,7 +68,6 @@ def main(args):
                     ht=clinvar_plp_mis_haplo.ht(),
                     output_ht_path=f"{mpc_bucket_path}/clinvar_mpc_annot.ht",
                     overwrite_temp=args.overwrite_temp,
-                    overwrite_output=args.overwrite_output,
                     freeze=args.freeze,
                 )
 
@@ -84,7 +81,6 @@ def main(args):
                     ht=case_ht,
                     output_ht_path=f"{mpc_bucket_path}/dd_case_mpc_annot.ht",
                     overwrite_temp=args.overwrite_temp,
-                    overwrite_output=args.overwrite_output,
                     freeze=args.freeze,
                 )
                 control_ht = dd_ht.filter(dd_ht.sample_set == "control")
@@ -97,7 +93,6 @@ def main(args):
                     ht=control_ht,
                     output_ht_path=f"{mpc_bucket_path}/dd_control_mpc_annot.ht",
                     overwrite_temp=args.overwrite_temp,
-                    overwrite_output=args.overwrite_output,
                     freeze=args.freeze,
                 )
 
@@ -109,7 +104,6 @@ def main(args):
                     ht=ht,
                     output_ht_path=f"{mpc_bucket_path}/gnomAD_mpc_annot.ht",
                     overwrite_temp=args.overwrite_temp,
-                    overwrite_output=args.overwrite_output,
                     freeze=args.freeze,
                 )
 
@@ -118,7 +112,6 @@ def main(args):
                     ht=hl.read_table(args.ht_in_path),
                     output_ht_path=args.ht_out_path,
                     overwrite_temp=args.overwrite_temp,
-                    overwrite_output=args.overwrite_output,
                     freeze=args.freeze,
                 )
 
@@ -132,16 +125,8 @@ if __name__ == "__main__":
         "This regional missense constraint script calculates the MPC (missense badness, PolyPhen-2, and regional missense constraint) score."
     )
     parser.add_argument(
-        "--overwrite", help="Overwrite existing data.", action="store_true"
-    )
-    parser.add_argument(
         "--overwrite-temp",
-        help="Overwrite existing intermediate temporary data, for use in functions with option to modify existing final output data.",
-        action="store_true",
-    )
-    parser.add_argument(
-        "--overwrite-output",
-        help="Completely overwrite existing final output data, for use in functions with option to modify existing final output data.",
+        help="Overwrite existing intermediate temporary data.",
         action="store_true",
     )
     parser.add_argument(
@@ -228,6 +213,7 @@ if __name__ == "__main__":
         "--ht-out-path",
         help="Output path for hail Table after adding MPC annotation. Required if --specify-ht is set.",
     )
+    # TODO: Review if all these args are needed
 
     args = parser.parse_args()
 

--- a/rmc/pipeline/calculate_mpc.py
+++ b/rmc/pipeline/calculate_mpc.py
@@ -231,7 +231,7 @@ if __name__ == "__main__":
     annotate_hts.add_argument(
         "--use-release",
         help="""
-        Use scores in MPC release HT to annotate.
+        Use scores in MPC release hail Table to annotate.
 
         Otherwise, scores will be directly computed using specified MPC model.
         """,
@@ -245,21 +245,21 @@ if __name__ == "__main__":
     )
     # temp_label="_clinvar",
     annotate_hts.add_argument(
-        "--clinvar", help="Calculate MPC for ClinVar variants", action="store_true"
+        "--clinvar", help="Calculate MPC for ClinVar variants.", action="store_true"
     )
     annotate_hts.add_argument(
         "--dd",
-        help="Calculate MPC for de novo variants from developmental disorder (DD) cases and controls",
+        help="Calculate MPC for de novo variants from developmental disorder (DD) cases and controls.",
         action="store_true",
     )
     annotate_hts.add_argument(
         "--gnomad-exomes",
-        help="Calculate MPC for all gnomAD exomes variants",
+        help="Calculate MPC for all gnomAD exomes variants.",
         action="store_true",
     )
     annotate_hts.add_argument(
         "--specify-ht",
-        help="Calculate MPC for variants in specified hail Table",
+        help="Calculate MPC for variants in specified hail Table.",
         action="store_true",
     )
     annotate_hts.add_argument(

--- a/rmc/pipeline/calculate_mpc.py
+++ b/rmc/pipeline/calculate_mpc.py
@@ -14,11 +14,7 @@ from rmc.resources.basics import LOGGING_PATH, MPC_PREFIX, TEMP_PATH_WITH_FAST_D
 from rmc.resources.resource_utils import CURRENT_GNOMAD_VERSION
 from rmc.resources.rmc import CURRENT_FREEZE, context_with_oe, mpc_release
 from rmc.slack_creds import slack_token
-from rmc.utils.mpc import (
-    annotate_mpc,
-    prepare_pop_path_ht,
-    run_regressions,
-)
+from rmc.utils.mpc import annotate_mpc, prepare_pop_path_ht, run_regressions
 
 logging.basicConfig(
     format="%(asctime)s (%(name)s %(lineno)s): %(message)s",
@@ -121,7 +117,7 @@ if __name__ == "__main__":
         "--do-k-fold-training",
         help="""
         Generate (or prepare generation of) k-fold MPC models trained on training sets from respective folds.
-        
+
         Otherwise, one model is generated, trained on all training transcripts.
         """,
         action="store_true",

--- a/rmc/pipeline/calculate_mpc.py
+++ b/rmc/pipeline/calculate_mpc.py
@@ -68,8 +68,9 @@ def main(args):
 
                 annotate_mpc(
                     ht=clinvar_plp_mis_haplo.ht(),
-                    output_path=f"{mpc_bucket_path}/clinvar_mpc_annot.ht",
-                    overwrite=args.overwrite,
+                    output_ht_path=f"{mpc_bucket_path}/clinvar_mpc_annot.ht",
+                    overwrite_temp=args.overwrite_temp,
+                    overwrite_output=args.overwrite_output,
                     freeze=args.freeze,
                 )
 
@@ -81,8 +82,9 @@ def main(args):
                 case_ht = dd_ht.filter(dd_ht.sample_set != "control")
                 annotate_mpc(
                     ht=case_ht,
-                    output_path=f"{mpc_bucket_path}/dd_case_mpc_annot.ht",
-                    overwrite=args.overwrite_temp,
+                    output_ht_path=f"{mpc_bucket_path}/dd_case_mpc_annot.ht",
+                    overwrite_temp=args.overwrite_temp,
+                    overwrite_output=args.overwrite_output,
                     freeze=args.freeze,
                 )
                 control_ht = dd_ht.filter(dd_ht.sample_set == "control")
@@ -93,8 +95,9 @@ def main(args):
                 )
                 annotate_mpc(
                     ht=control_ht,
-                    output_path=f"{mpc_bucket_path}/dd_control_mpc_annot.ht",
-                    overwrite=args.overwrite,
+                    output_ht_path=f"{mpc_bucket_path}/dd_control_mpc_annot.ht",
+                    overwrite_temp=args.overwrite_temp,
+                    overwrite_output=args.overwrite_output,
                     freeze=args.freeze,
                 )
 
@@ -104,16 +107,18 @@ def main(args):
                 ht = public_release("exomes").ht()
                 annotate_mpc(
                     ht=ht,
-                    output_path=f"{mpc_bucket_path}/gnomAD_mpc_annot.ht",
-                    overwrite=args.overwrite,
+                    output_ht_path=f"{mpc_bucket_path}/gnomAD_mpc_annot.ht",
+                    overwrite_temp=args.overwrite_temp,
+                    overwrite_output=args.overwrite_output,
                     freeze=args.freeze,
                 )
 
             if args.specify_ht:
                 annotate_mpc(
                     ht=hl.read_table(args.ht_in_path),
-                    output_path=args.ht_out_path,
-                    overwrite=args.overwrite,
+                    output_ht_path=args.ht_out_path,
+                    overwrite_temp=args.overwrite_temp,
+                    overwrite_output=args.overwrite_output,
                     freeze=args.freeze,
                 )
 

--- a/rmc/pipeline/calculate_mpc.py
+++ b/rmc/pipeline/calculate_mpc.py
@@ -52,8 +52,8 @@ def main(args):
                 freeze=args.freeze,
             )
 
-        if args.command == "calculate-mpc":
-            hl.init(log="/calculate_mpc_release.log", tmp_dir=temp_dir)
+        if args.command == "create-mpc-release":
+            hl.init(log="/create_mpc_release.log", tmp_dir=temp_dir)
             create_mpc_release_ht(
                 overwrite_temp=args.overwrite_temp,
                 overwrite_output=args.overwrite_output,
@@ -82,7 +82,7 @@ def main(args):
                 annotate_mpc(
                     ht=case_ht,
                     output_path=f"{mpc_bucket_path}/dd_case_mpc_annot.ht",
-                    overwrite=args.overwrite,
+                    overwrite=args.overwrite_temp,
                     freeze=args.freeze,
                 )
                 control_ht = dd_ht.filter(dd_ht.sample_set == "control")
@@ -187,10 +187,10 @@ if __name__ == "__main__":
         default="blosum,grantham",
     )
 
-    calculate_score = subparsers.add_parser(
-        "calculate-mpc",
+    create_mpc_release = subparsers.add_parser(
+        "create-mpc-release",
         help="""
-        Calculate MPC release Table (VEP context Table filtered to missense variants in canonical, non-outlier transcripts).
+        Create MPC release Table (VEP context Table filtered to missense variants in canonical, non-outlier transcripts).
         """,
     )
 

--- a/rmc/pipeline/calculate_mpc.py
+++ b/rmc/pipeline/calculate_mpc.py
@@ -12,11 +12,10 @@ from gnomad.utils.slack import slack_notifications
 
 from rmc.resources.basics import LOGGING_PATH, MPC_PREFIX, TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.resource_utils import CURRENT_GNOMAD_VERSION
-from rmc.resources.rmc import CURRENT_FREEZE
+from rmc.resources.rmc import CURRENT_FREEZE, context_with_oe, mpc_release
 from rmc.slack_creds import slack_token
 from rmc.utils.mpc import (
     annotate_mpc,
-    create_mpc_release_ht,
     prepare_pop_path_ht,
     run_regressions,
 )
@@ -55,7 +54,11 @@ def main(args):
 
         if args.command == "create-mpc-release":
             hl.init(log="/create_mpc_release.log", tmp_dir=temp_dir)
-            create_mpc_release_ht(
+            annotate_mpc(
+                ht=context_with_oe.versions[args.freeze].ht().select(),
+                output_ht_path=mpc_release.versions[args.freeze].path,
+                temp_label="_release",
+                use_release=False,
                 overwrite_temp=args.overwrite_temp,
                 freeze=args.freeze,
             )

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -562,7 +562,9 @@ def main(args):
             rmc_ht = rmc_ht.annotate_globals(p_value=p_value)
 
             logger.info("Writing out RMC results...")
-            rmc_ht.write(rmc_results.versions[args.freeze].path)
+            rmc_ht.write(
+                rmc_results.versions[args.freeze].path, overwrite=args.overwrite
+            )
 
             logger.info("Getting transcripts without evidence of RMC...")
             create_no_breaks_he(freeze=args.freeze, overwrite=args.overwrite)
@@ -663,7 +665,12 @@ if __name__ == "__main__":
         default=CURRENT_FREEZE,
     )
     parser.add_argument(
-        "--overwrite", help="Overwrite existing data.", action="store_true"
+        "--overwrite",
+        help="""
+        Overwrite existing output data.
+        Applies to all outputs except OE-annotated context table (created in `--finalize`).
+        """,
+        action="store_true",
     )
     parser.add_argument(
         "--overwrite-temp",

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -276,7 +276,6 @@ def main(args):
                 "Searching for transcripts or transcript subsections with a single significant break..."
             )
             if args.search_num == 1:
-
                 all_loci_chisq_ht_path = f"{SINGLE_BREAK_TEMP_PATH}/all_loci_chisq.ht"
                 if file_exists(all_loci_chisq_ht_path) and not args.save_chisq_ht:
                     ht = hl.read_table(all_loci_chisq_ht_path)
@@ -569,7 +568,9 @@ def main(args):
             create_no_breaks_he(freeze=args.freeze, overwrite=args.overwrite)
 
             logger.info("Creating OE-annotated context table...")
-            create_context_with_oe(freeze=args.freeze, overwrite_output=args.overwrite)
+            create_context_with_oe(
+                freeze=args.freeze, overwrite_temp=args.overwrite_temp
+            )
 
     finally:
         logger.info("Copying hail log to logging bucket...")
@@ -663,6 +664,14 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--overwrite", help="Overwrite existing data.", action="store_true"
+    )
+    parser.add_argument(
+        "--overwrite-temp",
+        help="""
+        Overwrite existing intermediate temporary data.
+        Only applicable in creating OE-annotated context table.
+        """,
+        action="store_true",
     )
     parser.add_argument(
         "--slack-channel",

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -82,14 +82,12 @@ def train_val_test_transcripts_path(
     :param fold: Fold number in training set to select transcripts from.
         If None, all training transcripts will be returned.
         If not None, only validation or training transcripts from the specified fold will be returned.
-        Default is None.
-        NOTE that `is_test` must be False if `fold` is not None.
+        Default is None. NOTE that `is_test` must be False if `fold` is not None.
     :param is_val: Whether to return validation transcripts.
         If False, training transcripts from the specified fold of the training set will be returned.
         If True, validation transcripts from the specified fold of the training set will be returned.
-        Default is False.
-        NOTE that `is_test` and `is_val` cannot both be true, and that `fold` must not be None
-            if `is_val` is True.
+        Default is False. NOTE that `is_test` and `is_val` cannot both be true,
+        and that `fold` must not be None if `is_val` is True.
     :return: Path to Table.
     """
     if is_test and is_val:

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -98,7 +98,7 @@ def train_val_test_transcripts_path(
         raise DataException("Fold number must be specified for validation transcripts!")
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
-            f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
+            f"Fold number must be an integer between 1 and {FOLD_K}, inclusive!"
         )
 
     transcript_type = "test" if is_test else ("val" if is_val else "train")

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -76,18 +76,23 @@ def train_val_test_transcripts_path(
 
     By default, all training transcripts are returned.
 
+    .. note::
+        - `is_test` cannot be True if `fold` is defined.
+        - `is_test` and `is_val` cannot be True simultaneously.
+        - If `is_val` is True, `fold` must also be defined.
+        - If specified, `fold` value must be between 1 and `FOLD_K`.
+
     :param is_test: Whether to return test transcripts.
         If False, training transcripts will be returned. If True, test transcripts will be returned.
         Default is False.
     :param fold: Fold number in training set to select transcripts from.
         If None, all training transcripts will be returned.
         If not None, only validation or training transcripts from the specified fold will be returned.
-        Default is None. NOTE that `is_test` must be False if `fold` is not None.
+        Default is None.
     :param is_val: Whether to return validation transcripts.
         If False, training transcripts from the specified fold of the training set will be returned.
         If True, validation transcripts from the specified fold of the training set will be returned.
-        Default is False. NOTE that `is_test` and `is_val` cannot both be true,
-        and that `fold` must not be None if `is_val` is True.
+        Default is False.
     :return: Path to Table.
     """
     if is_test and is_val:

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -620,7 +620,9 @@ This Table contains only one row per each unique locus/alleles combination.
 ####################################################################################
 ## Assessment related resources
 ####################################################################################
-oe_bin_counts_tsv = f"{CONSTRAINT_PREFIX}/{CURRENT_FREEZE}/{CURRENT_FREEZE}/oe_bin.tsv"
+oe_bin_counts_tsv = (
+    f"{CONSTRAINT_PREFIX}/{CURRENT_GNOMAD_VERSION}/{CURRENT_FREEZE}/oe_bin.tsv"
+)
 """
 TSV with RMC regions grouped by obs/exp (OE) bin.
 

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -563,7 +563,7 @@ def mpc_model_pkl_path(
         from the specified fold of the overall training set. If None, the model is generated from
         variants in all training transcripts. Default is None.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
-    :return: Path to Table.
+    :return: Path to model.
     """
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -473,7 +473,6 @@ Contains same information as `rmc_results` but has different formatting for gnom
 ####################################################################################
 def amino_acids_oe_path(
     fold: int = None,
-    is_val: bool = False,
     freeze: int = CURRENT_FREEZE,
 ) -> str:
     """
@@ -482,57 +481,40 @@ def amino_acids_oe_path(
     Table is input to missense badness calculations.
 
     :param int fold: Fold number in training set to select training transcripts from.
-        If not None, the Table is generated from variants in only validation or training transcripts
+        If not None, the Table is generated from variants in only training transcripts
         from the specified fold of the overall training set. If None, the Table is generated from
         variants in all training transcripts. Default is None.
-    :param bool is_val: Whether the Table is generated from variants in validation transcripts.
-        If True, the Table is generated from variants in the validation transcripts from the specified fold
-        of the overall training set. If False, the Table is generated from variants in
-        all training transcripts or training transcripts from the specified fold.
-        Default is False. NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
-    if is_val and fold is None:
-        raise DataException("Fold number must be specified for validation set!")
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
             f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )
-    transcript_type = "val" if is_val else "train"
     fold_name = f"_fold{fold}" if fold is not None else ""
-    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/{transcript_type}{fold_name}/amino_acid_oe.ht"
+    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/train{fold_name}/amino_acid_oe.ht"
 
 
 def misbad_path(
     fold: int = None,
-    is_val: bool = False,
     freeze: int = CURRENT_FREEZE,
 ) -> str:
     """
     Table containing all possible amino acid substitutions and their missense badness scores.
 
     :param int fold: Fold number in training set to select training transcripts from.
-        If not None, the Table is generated from variants in only validation or training transcripts
+        If not None, the Table is generated from variants in only training transcripts
         from the specified fold of the overall training set. If None, the Table is generated from
         variants in all training transcripts. Default is None.
-    :param bool is_val: Whether the Table is generated from variants in validation transcripts.
-        If True, the Table is generated from variants in the validation transcripts from the specified fold
-        of the overall training set. If False, the Table is generated from variants in
-        all training transcripts or training transcripts from the specified fold.
-        Default is False. NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
-    if is_val and fold is None:
-        raise DataException("Fold number must be specified for validation set!")
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
             f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )
-    transcript_type = "val" if is_val else "train"
     fold_name = f"_fold{fold}" if fold is not None else ""
-    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/{transcript_type}{fold_name}/missense_badness.ht"
+    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/train{fold_name}/missense_badness.ht"
 
 
 ####################################################################################
@@ -540,7 +522,6 @@ def misbad_path(
 ####################################################################################
 def joint_clinvar_gnomad_path(
     fold: int = None,
-    is_val: bool = False,
     freeze: int = CURRENT_FREEZE,
 ) -> str:
     """
@@ -554,31 +535,22 @@ def joint_clinvar_gnomad_path(
     Table is input to MPC (missense badness, polyphen-2, and constraint) calculations.
 
     :param int fold: Fold number in training set to select training transcripts from.
-        If not None, the Table is generated from variants in only validation or training transcripts
+        If not None, the Table is generated from variants in only  training transcripts
         from the specified fold of the overall training set. If None, the Table is generated from
         variants in all training transcripts. Default is None.
-    :param bool is_val: Whether the Table is generated from variants in validation transcripts.
-        If True, the Table is generated from variants in the validation transcripts from the specified fold
-        of the overall training set. If False, the Table is generated from variants in
-        all training transcripts or training transcripts from the specified fold.
-        Default is False. NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
-    if is_val and fold is None:
-        raise DataException("Fold number must be specified for validation set!")
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
             f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )
-    transcript_type = "val" if is_val else "train"
     fold_name = f"_fold{fold}" if fold is not None else ""
-    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/{transcript_type}{fold_name}/joint_clinvar_gnomad.ht"
+    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/train{fold_name}/joint_clinvar_gnomad.ht"
 
 
 def mpc_model_pkl_path(
     fold: int = None,
-    is_val: bool = False,
     freeze: int = CURRENT_FREEZE,
 ) -> str:
     """
@@ -587,32 +559,25 @@ def mpc_model_pkl_path(
     Model created using logistic regression.
 
     :param int fold: Fold number in training set to select training transcripts from.
-        If not None, the model is generated from variants in only validation or training transcripts
+        If not None, the model is generated from variants in only training transcripts
         from the specified fold of the overall training set. If None, the model is generated from
         variants in all training transcripts. Default is None.
-    :param bool is_val: Whether the model is generated from variants in validation transcripts.
-        If True, the model is generated from variants in the validation transcripts from the specified fold
-        of the overall training set. If False, the model is generated from variants in
-        all training transcripts or training transcripts from the specified fold.
-        Default is False. NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
-    if is_val and fold is None:
-        raise DataException("Fold number must be specified for validation set!")
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
             f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )
-    transcript_type = "val" if is_val else "train"
     fold_name = f"_fold{fold}" if fold is not None else ""
-    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/{transcript_type}{fold_name}/mpc_model.pkl"
+    return (
+        f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/train{fold_name}/mpc_model.pkl"
+    )
 
 
 def gnomad_fitted_score_path(
     is_grouped: bool = False,
     fold: int = None,
-    is_val: bool = False,
     freeze: int = CURRENT_FREEZE,
 ) -> str:
     """
@@ -622,27 +587,19 @@ def gnomad_fitted_score_path(
 
     :param bool is_grouped: Whether the Table is grouped by score. Default is False.
     :param int fold: Fold number in training set to select training transcripts from.
-        If not None, the Table is generated from variants in only validation or training transcripts
+        If not None, the Table is generated from variants in only training transcripts
         from the specified fold of the overall training set. If None, the Table is generated from
         variants in all training transcripts. Default is None.
-    :param bool is_val: Whether the Table is generated from variants in validation transcripts.
-        If True, the Table is generated from variants in the validation transcripts from the specified fold
-        of the overall training set. If False, the Table is generated from variants in
-        all training transcripts or training transcripts from the specified fold.
-        Default is False. NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
-    if is_val and fold is None:
-        raise DataException("Fold number must be specified for validation set!")
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
             f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )
-    transcript_type = "val" if is_val else "train"
     fold_name = f"_fold{fold}" if fold is not None else ""
     group = "_group" if is_grouped else ""
-    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/{transcript_type}{fold_name}/gnomad_fitted_scores{group}.ht"
+    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/train{fold_name}/gnomad_fitted_scores{group}.ht"
 
 
 mpc_release = VersionedTableResource(

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -613,19 +613,6 @@ mpc_release = VersionedTableResource(
 )
 """
 Table containing missense variants in canonical transcripts annotated with MPC.
-"""
-
-mpc_release_dedup = VersionedTableResource(
-    default_version=CURRENT_FREEZE,
-    versions={
-        freeze: TableResource(
-            path=f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/mpc_dedup.ht"
-        )
-        for freeze in FREEZES
-    },
-)
-"""
-Table containing missense variants in canonical transcripts annotated with MPC.
 
 This Table contains only one row per each unique locus/alleles combination.
 """

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -483,16 +483,13 @@ def amino_acids_oe_path(
 
     :param int fold: Fold number in training set to select training transcripts from.
         If not None, the Table is generated from variants in only validation or training transcripts
-        from the specified fold of the overall training set.
-        If None, the Table is generated from variants in all training transcripts.
-        Default is None.
+        from the specified fold of the overall training set. If None, the Table is generated from
+        variants in all training transcripts. Default is None.
     :param bool is_val: Whether the Table is generated from variants in validation transcripts.
         If True, the Table is generated from variants in the validation transcripts from the specified fold
-        of the overall training set.
-        If False, the Table is generated from variants in all training transcripts or from variants in
-        training transcripts from the specified fold of the overall training set.
-        Default is False.
-        NOTE that `fold` must not be None if `is_val` is True.
+        of the overall training set. If False, the Table is generated from variants in
+        all training transcripts or training transcripts from the specified fold.
+        Default is False. NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
@@ -517,16 +514,13 @@ def misbad_path(
 
     :param int fold: Fold number in training set to select training transcripts from.
         If not None, the Table is generated from variants in only validation or training transcripts
-        from the specified fold of the overall training set.
-        If None, the Table is generated from variants in all training transcripts.
-        Default is None.
+        from the specified fold of the overall training set. If None, the Table is generated from
+        variants in all training transcripts. Default is None.
     :param bool is_val: Whether the Table is generated from variants in validation transcripts.
         If True, the Table is generated from variants in the validation transcripts from the specified fold
-        of the overall training set.
-        If False, the Table is generated from variants in all training transcripts or from variants in
-        training transcripts from the specified fold of the overall training set.
-        Default is False.
-        NOTE that `fold` must not be None if `is_val` is True.
+        of the overall training set. If False, the Table is generated from variants in
+        all training transcripts or training transcripts from the specified fold.
+        Default is False. NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
@@ -561,16 +555,13 @@ def joint_clinvar_gnomad_path(
 
     :param int fold: Fold number in training set to select training transcripts from.
         If not None, the Table is generated from variants in only validation or training transcripts
-        from the specified fold of the overall training set.
-        If None, the Table is generated from variants in all training transcripts.
-        Default is None.
+        from the specified fold of the overall training set. If None, the Table is generated from
+        variants in all training transcripts. Default is None.
     :param bool is_val: Whether the Table is generated from variants in validation transcripts.
         If True, the Table is generated from variants in the validation transcripts from the specified fold
-        of the overall training set.
-        If False, the Table is generated from variants in all training transcripts or from variants in
-        training transcripts from the specified fold of the overall training set.
-        Default is False.
-        NOTE that `fold` must not be None if `is_val` is True.
+        of the overall training set. If False, the Table is generated from variants in
+        all training transcripts or training transcripts from the specified fold.
+        Default is False. NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
@@ -596,17 +587,14 @@ def mpc_model_pkl_path(
     Model created using logistic regression.
 
     :param int fold: Fold number in training set to select training transcripts from.
-        If not None, the Table is generated from variants in only validation or training transcripts
-        from the specified fold of the overall training set.
-        If None, the Table is generated from variants in all training transcripts.
-        Default is None.
-    :param bool is_val: Whether the Table is generated from variants in validation transcripts.
-        If True, the Table is generated from variants in the validation transcripts from the specified fold
-        of the overall training set.
-        If False, the Table is generated from variants in all training transcripts or from variants in
-        training transcripts from the specified fold of the overall training set.
-        Default is False.
-        NOTE that `fold` must not be None if `is_val` is True.
+        If not None, the model is generated from variants in only validation or training transcripts
+        from the specified fold of the overall training set. If None, the model is generated from
+        variants in all training transcripts. Default is None.
+    :param bool is_val: Whether the model is generated from variants in validation transcripts.
+        If True, the model is generated from variants in the validation transcripts from the specified fold
+        of the overall training set. If False, the model is generated from variants in
+        all training transcripts or training transcripts from the specified fold.
+        Default is False. NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
@@ -635,16 +623,13 @@ def gnomad_fitted_score_path(
     :param bool is_grouped: Whether the Table is grouped by score. Default is False.
     :param int fold: Fold number in training set to select training transcripts from.
         If not None, the Table is generated from variants in only validation or training transcripts
-        from the specified fold of the overall training set.
-        If None, the Table is generated from variants in all training transcripts.
-        Default is None.
+        from the specified fold of the overall training set. If None, the Table is generated from
+        variants in all training transcripts. Default is None.
     :param bool is_val: Whether the Table is generated from variants in validation transcripts.
         If True, the Table is generated from variants in the validation transcripts from the specified fold
-        of the overall training set.
-        If False, the Table is generated from variants in all training transcripts or from variants in
-        training transcripts from the specified fold of the overall training set.
-        Default is False.
-        NOTE that `fold` must not be None if `is_val` is True.
+        of the overall training set. If False, the Table is generated from variants in
+        all training transcripts or training transcripts from the specified fold.
+        Default is False. NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -175,6 +175,7 @@ FINAL_ANNOTATIONS = {
 Set of annotations to keep from individual break search round result HTs when finalizing release HT.
 """
 
+
 # NOTE: Removed all references to rescue search pathway,
 # but freeze 2 and 3 temp results were written with code that
 # differentiated between "initial" and "rescue" search
@@ -466,6 +467,7 @@ Table containing all transcripts with evidence of regional missense constraint.
 Contains same information as `rmc_results` but has different formatting for gnomAD browser.
 """
 
+
 ####################################################################################
 ## Missense badness related resources
 ####################################################################################
@@ -512,7 +514,7 @@ def amino_acids_oe_path(
         )
     transcript_type = "test" if is_test else ("val" if is_val else "train")
     fold_name = f"_fold{fold}" if fold is not None else ""
-    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/amino_acid_oe_{transcript_type}{fold_name}.ht"
+    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/{transcript_type}{fold_name}/amino_acid_oe.ht"
 
 
 def misbad_path(
@@ -556,7 +558,7 @@ def misbad_path(
         )
     transcript_type = "test" if is_test else ("val" if is_val else "train")
     fold_name = f"_fold{fold}" if fold is not None else ""
-    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/missense_badness_{transcript_type}{fold_name}.ht"
+    return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/{transcript_type}{fold_name}/missense_badness.ht"
 
 
 ####################################################################################

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -472,7 +472,6 @@ Contains same information as `rmc_results` but has different formatting for gnom
 ## Missense badness related resources
 ####################################################################################
 def amino_acids_oe_path(
-    is_test: bool = False,
     fold: int = None,
     is_val: bool = False,
     freeze: int = CURRENT_FREEZE,
@@ -482,43 +481,33 @@ def amino_acids_oe_path(
 
     Table is input to missense badness calculations.
 
-    :param bool is_test: Whether the Table is generated from variants in test transcripts.
-        If False, the Table is generated from variants in training transcripts only.
-        If True, the Table is generated from variants in test transcripts only.
-        Default is False.
     :param int fold: Fold number in training set to select training transcripts from.
         If not None, the Table is generated from variants in only validation or training transcripts
-            from the specified fold.
-        If None, the Table is generated from variants in test transcripts or from variants in all
-            training transcripts.
+        from the specified fold of the overall training set.
+        If None, the Table is generated from variants in all training transcripts.
         Default is None.
-        NOTE that `is_test` must be False if `fold` is not None.
     :param bool is_val: Whether the Table is generated from variants in validation transcripts.
-        If True, the Table is generated from variants in the validation transcripts
-            from the specified fold of the training set.
-        If False, the Table is generated from variants in test transcripts,
-            from variants in all training transcripts, or from variants in
-            training transcripts from the specified fold of the training set.
+        If True, the Table is generated from variants in the validation transcripts from the specified fold
+        of the overall training set.
+        If False, the Table is generated from variants in all training transcripts or from variants in
+        training transcripts from the specified fold of the overall training set.
         Default is False.
         NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
-    if is_test and fold is not None:
-        raise DataException("Fold number cannot be specified for test set!")
     if is_val and fold is None:
         raise DataException("Fold number must be specified for validation set!")
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
             f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )
-    transcript_type = "test" if is_test else ("val" if is_val else "train")
+    transcript_type = "val" if is_val else "train"
     fold_name = f"_fold{fold}" if fold is not None else ""
     return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/{transcript_type}{fold_name}/amino_acid_oe.ht"
 
 
 def misbad_path(
-    is_test: bool = False,
     fold: int = None,
     is_val: bool = False,
     freeze: int = CURRENT_FREEZE,
@@ -526,37 +515,28 @@ def misbad_path(
     """
     Table containing all possible amino acid substitutions and their missense badness scores.
 
-    :param bool is_test: Whether the Table is generated from variants in test transcripts.
-        If False, the Table is generated from variants in training transcripts only.
-        If True, the Table is generated from variants in test transcripts only.
-        Default is False.
     :param int fold: Fold number in training set to select training transcripts from.
         If not None, the Table is generated from variants in only validation or training transcripts
-            from the specified fold.
-        If None, the Table is generated from variants in test transcripts or from variants in all
-            training transcripts.
+        from the specified fold of the overall training set.
+        If None, the Table is generated from variants in all training transcripts.
         Default is None.
-        NOTE that `is_test` must be False if `fold` is not None.
     :param bool is_val: Whether the Table is generated from variants in validation transcripts.
-        If True, the Table is generated from variants in the validation transcripts
-            from the specified fold of the training set.
-        If False, the Table is generated from variants in test transcripts,
-            from variants in all training transcripts, or from variants in
-            training transcripts from the specified fold of the training set.
+        If True, the Table is generated from variants in the validation transcripts from the specified fold
+        of the overall training set.
+        If False, the Table is generated from variants in all training transcripts or from variants in
+        training transcripts from the specified fold of the overall training set.
         Default is False.
         NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
-    if is_test and fold is not None:
-        raise DataException("Fold number cannot be specified for test set!")
     if is_val and fold is None:
         raise DataException("Fold number must be specified for validation set!")
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
             f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )
-    transcript_type = "test" if is_test else ("val" if is_val else "train")
+    transcript_type = "val" if is_val else "train"
     fold_name = f"_fold{fold}" if fold is not None else ""
     return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/{transcript_type}{fold_name}/missense_badness.ht"
 
@@ -565,7 +545,6 @@ def misbad_path(
 ## MPC related resources
 ####################################################################################
 def joint_clinvar_gnomad_path(
-    is_test: bool = False,
     fold: int = None,
     is_val: bool = False,
     freeze: int = CURRENT_FREEZE,
@@ -580,43 +559,33 @@ def joint_clinvar_gnomad_path(
 
     Table is input to MPC (missense badness, polyphen-2, and constraint) calculations.
 
-    :param bool is_test: Whether the Table is generated from variants in test transcripts.
-        If False, the Table is generated from variants in training transcripts only.
-        If True, the Table is generated from variants in test transcripts only.
-        Default is False.
     :param int fold: Fold number in training set to select training transcripts from.
         If not None, the Table is generated from variants in only validation or training transcripts
-            from the specified fold.
-        If None, the Table is generated from variants in test transcripts or from variants in all
-            training transcripts.
+        from the specified fold of the overall training set.
+        If None, the Table is generated from variants in all training transcripts.
         Default is None.
-        NOTE that `is_test` must be False if `fold` is not None.
     :param bool is_val: Whether the Table is generated from variants in validation transcripts.
-        If True, the Table is generated from variants in the validation transcripts
-            from the specified fold of the training set.
-        If False, the Table is generated from variants in test transcripts,
-            from variants in all training transcripts, or from variants in
-            training transcripts from the specified fold of the training set.
+        If True, the Table is generated from variants in the validation transcripts from the specified fold
+        of the overall training set.
+        If False, the Table is generated from variants in all training transcripts or from variants in
+        training transcripts from the specified fold of the overall training set.
         Default is False.
         NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
-    if is_test and fold is not None:
-        raise DataException("Fold number cannot be specified for test set!")
     if is_val and fold is None:
         raise DataException("Fold number must be specified for validation set!")
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
             f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )
-    transcript_type = "test" if is_test else ("val" if is_val else "train")
+    transcript_type = "val" if is_val else "train"
     fold_name = f"_fold{fold}" if fold is not None else ""
     return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/{transcript_type}{fold_name}/joint_clinvar_gnomad.ht"
 
 
 def mpc_model_pkl_path(
-    is_test: bool = False,
     fold: int = None,
     is_val: bool = False,
     freeze: int = CURRENT_FREEZE,
@@ -626,44 +595,34 @@ def mpc_model_pkl_path(
 
     Model created using logistic regression.
 
-    :param bool is_test: Whether the Table is generated from variants in test transcripts.
-        If False, the Table is generated from variants in training transcripts only.
-        If True, the Table is generated from variants in test transcripts only.
-        Default is False.
     :param int fold: Fold number in training set to select training transcripts from.
         If not None, the Table is generated from variants in only validation or training transcripts
-            from the specified fold.
-        If None, the Table is generated from variants in test transcripts or from variants in all
-            training transcripts.
+        from the specified fold of the overall training set.
+        If None, the Table is generated from variants in all training transcripts.
         Default is None.
-        NOTE that `is_test` must be False if `fold` is not None.
     :param bool is_val: Whether the Table is generated from variants in validation transcripts.
-        If True, the Table is generated from variants in the validation transcripts
-            from the specified fold of the training set.
-        If False, the Table is generated from variants in test transcripts,
-            from variants in all training transcripts, or from variants in
-            training transcripts from the specified fold of the training set.
+        If True, the Table is generated from variants in the validation transcripts from the specified fold
+        of the overall training set.
+        If False, the Table is generated from variants in all training transcripts or from variants in
+        training transcripts from the specified fold of the overall training set.
         Default is False.
         NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
-    if is_test and fold is not None:
-        raise DataException("Fold number cannot be specified for test set!")
     if is_val and fold is None:
         raise DataException("Fold number must be specified for validation set!")
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
             f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )
-    transcript_type = "test" if is_test else ("val" if is_val else "train")
+    transcript_type = "val" if is_val else "train"
     fold_name = f"_fold{fold}" if fold is not None else ""
     return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/{transcript_type}{fold_name}/mpc_model.pkl"
 
 
 def gnomad_fitted_score_path(
     is_grouped: bool = False,
-    is_test: bool = False,
     fold: int = None,
     is_val: bool = False,
     freeze: int = CURRENT_FREEZE,
@@ -674,37 +633,28 @@ def gnomad_fitted_score_path(
     Table is input to MPC (missense badness, polyphen-2, and constraint) calculations on other datasets.
 
     :param bool is_grouped: Whether the Table is grouped by score. Default is False.
-    :param bool is_test: Whether the Table is generated from variants in test transcripts.
-        If False, the Table is generated from variants in training transcripts only.
-        If True, the Table is generated from variants in test transcripts only.
-        Default is False.
     :param int fold: Fold number in training set to select training transcripts from.
         If not None, the Table is generated from variants in only validation or training transcripts
-            from the specified fold.
-        If None, the Table is generated from variants in test transcripts or from variants in all
-            training transcripts.
+        from the specified fold of the overall training set.
+        If None, the Table is generated from variants in all training transcripts.
         Default is None.
-        NOTE that `is_test` must be False if `fold` is not None.
     :param bool is_val: Whether the Table is generated from variants in validation transcripts.
-        If True, the Table is generated from variants in the validation transcripts
-            from the specified fold of the training set.
-        If False, the Table is generated from variants in test transcripts,
-            from variants in all training transcripts, or from variants in
-            training transcripts from the specified fold of the training set.
+        If True, the Table is generated from variants in the validation transcripts from the specified fold
+        of the overall training set.
+        If False, the Table is generated from variants in all training transcripts or from variants in
+        training transcripts from the specified fold of the overall training set.
         Default is False.
         NOTE that `fold` must not be None if `is_val` is True.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :return: Path to Table.
     """
-    if is_test and fold is not None:
-        raise DataException("Fold number cannot be specified for test set!")
     if is_val and fold is None:
         raise DataException("Fold number must be specified for validation set!")
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
             f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
         )
-    transcript_type = "test" if is_test else ("val" if is_val else "train")
+    transcript_type = "val" if is_val else "train"
     fold_name = f"_fold{fold}" if fold is not None else ""
     group = "_group" if is_grouped else ""
     return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/{transcript_type}{fold_name}/gnomad_fitted_scores{group}.ht"

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -489,7 +489,7 @@ def amino_acids_oe_path(
     """
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
-            f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
+            f"Fold number must be an integer between 1 and {FOLD_K}, inclusive!"
         )
     fold_name = f"_fold{fold}" if fold is not None else ""
     return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/train{fold_name}/amino_acid_oe.ht"
@@ -511,7 +511,7 @@ def misbad_path(
     """
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
-            f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
+            f"Fold number must be an integer between 1 and {FOLD_K}, inclusive!"
         )
     fold_name = f"_fold{fold}" if fold is not None else ""
     return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/train{fold_name}/missense_badness.ht"
@@ -543,7 +543,7 @@ def joint_clinvar_gnomad_path(
     """
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
-            f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
+            f"Fold number must be an integer between 1 and {FOLD_K}, inclusive!"
         )
     fold_name = f"_fold{fold}" if fold is not None else ""
     return f"{MPC_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/train{fold_name}/joint_clinvar_gnomad.ht"
@@ -567,7 +567,7 @@ def mpc_model_pkl_path(
     """
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
-            f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
+            f"Fold number must be an integer between 1 and {FOLD_K}, inclusive!"
         )
     fold_name = f"_fold{fold}" if fold is not None else ""
     return (
@@ -595,7 +595,7 @@ def gnomad_fitted_score_path(
     """
     if fold is not None and fold not in range(1, FOLD_K + 1):
         raise DataException(
-            f"Fold number must be an integer between 1 and {FOLD_K} inclusive!"
+            f"Fold number must be an integer between 1 and {FOLD_K}, inclusive!"
         )
     fold_name = f"_fold{fold}" if fold is not None else ""
     group = "_group" if is_grouped else ""

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1220,7 +1220,6 @@ def create_context_with_oe(
     missense_str: str = MISSENSE,
     n_partitions: int = 30000,
     overwrite_temp: bool = False,
-    overwrite_output: bool = True,
 ) -> None:
     """
     Filter VEP context Table to missense variants in canonical transcripts, and add missense observed/expected.
@@ -1240,11 +1239,6 @@ def create_context_with_oe(
     :param bool overwrite_temp: Whether to overwrite intermediate temporary (OE-independent) data if it already exists.
         If False, will read existing intermediate temporary data rather than overwriting.
         Default is False.
-    :param bool overwrite_output: Whether to entirely overwrite final output (OE-dependent) data if it already exists.
-        If False, will read and modify existing output data by adding or modifying columns rather than overwriting entirely.
-        If True, will clear existing output data and write new output data.
-        The output Tables are the OE-annotated context Tables with duplicated or deduplicated sections.
-        Default is True.
     :return: None; function writes Table to resource path.
     """
     logger.info("Importing set of transcripts to keep...")
@@ -1281,8 +1275,7 @@ def create_context_with_oe(
     ht = ht.key_by("locus", "alleles", "transcript")
     ht = ht.checkpoint(
         context_with_oe.versions[freeze].path,
-        overwrite=overwrite_output,
-        _read_if_exists=not overwrite_output,
+        overwrite=True,
     )
     logger.info("Output OE-annotated context HT fields: %s", set(ht.row))
 
@@ -1298,7 +1291,7 @@ def create_context_with_oe(
     ht = ht.drop("values")
     ht.write(
         context_with_oe_dedup.versions[freeze].path,
-        overwrite=overwrite_output,
+        overwrite=True,
     )
     logger.info("Output OE-annotated dedup context HT fields: %s", set(ht.row))
 

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -117,10 +117,7 @@ def prepare_amino_acid_ht(
     )
 
     logger.info("Filtering sites using gnomAD %s...", gnomad_data_type)
-    context_ht = filter_context_using_gnomad(
-        context_ht,
-        gnomad_data_type,
-    )
+    context_ht = filter_context_using_gnomad(context_ht, gnomad_data_type)
 
     logger.info("Adding observed annotation...")
     context_ht = add_obs_annotation(context_ht)
@@ -170,10 +167,7 @@ def prepare_amino_acid_ht(
             train_val_test_transcripts_path(fold=fold)
         )
         ht = ht.filter(filter_transcripts.contains(ht.transcript))
-        ht.write(
-            amino_acids_oe_path(fold=fold, freeze=freeze),
-            overwrite=True,
-        )
+        ht.write(amino_acids_oe_path(fold=fold, freeze=freeze), overwrite=True)
 
     if not do_k_fold_training:
         logger.info("Writing out HT for training transcripts only...")
@@ -302,12 +296,7 @@ def calculate_misbad(
     else:
         if not all(
             [
-                file_exists(
-                    amino_acids_oe_path(
-                        fold=i,
-                        freeze=freeze,
-                    )
-                )
+                file_exists(amino_acids_oe_path(fold=i, freeze=freeze))
                 for i in range(1, FOLD_K + 1)
             ]
         ):
@@ -329,12 +318,7 @@ def calculate_misbad(
             Default is None.
         :return: None; writes Table with missense badness scores to resource path.
         """
-        ht = hl.read_table(
-            amino_acids_oe_path(
-                fold=fold,
-                freeze=freeze,
-            )
-        )
+        ht = hl.read_table(amino_acids_oe_path(fold=fold, freeze=freeze))
         if use_exac_oe_cutoffs:
             logger.info("Removing rows with OE greater than 0.6 and less than 0.8...")
             ht = ht.filter((ht.oe <= 0.6) | (ht.oe > 0.8))

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -164,8 +164,8 @@ def prepare_amino_acid_ht(
         Filter table to a set of transcripts and write out.
 
         :param hl.Table ht: Input table.
-        :param str transcripts_path: String containing path to HailExpression of transcripts to filter to.
-        :param str output_path: String containing path to write out table to.
+        :param str transcripts_path: Path to HailExpression of transcripts to filter to.
+        :param str output_path: Path to write out table to.
         :return: None; function writes HT to specified path.
         """
         filter_transcripts = hl.experimental.read_expression(transcripts_path)

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -416,7 +416,7 @@ def calculate_misbad(
         _create_misbad_model(
             ht=hl.read_table(amino_acids_oe_path(freeze=freeze)),
             mb_path=misbad_path(freeze=freeze),
-            temp_label=f"_{transcript_type}",
+            temp_label="_train",
         )
     else:
         for i in range(1, FOLD_K + 1):

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -168,18 +168,13 @@ def prepare_amino_acid_ht(
         :param hl.Table ht: Input table.
         :param int fold: Fold number in training set to select training transcripts from.
             If not None, the Table is generated from variants in only validation or training transcripts
-                from the specified fold.
-            If None, the Table is generated from variants in test transcripts or from variants in all
-                training transcripts.
+            from the specified fold. If None, the Table is generated from variants in all training transcripts.
             Default is None.
         :param bool is_val: Whether the Table is generated from variants in validation transcripts.
-            If True, the Table is generated from variants in the validation transcripts
-                from the specified fold of the training set.
-            If False, the Table is generated from variants in test transcripts,
-                from variants in all training transcripts, or from variants in
-                training transcripts from the specified fold of the training set.
+            If True, the Table is generated from variants in the validation transcripts from
+            the specified fold of the training set. If False, the Table is generated from
+            variants in all training transcripts or training transcripts from the specified fold.
             Default is False.
-            NOTE that `fold` must not be None if `is_val` is True.
         :return: None; function writes HT to specified path.
         """
         filter_transcripts = hl.experimental.read_expression(
@@ -347,20 +342,15 @@ def calculate_misbad(
         """
         Calculate missense badness scores from a Table of amino acid substitutions and their missense OE ratios.
 
-        :param str temp_label: Model-specific suffix to add to temporary table paths to avoid conflicting
-            path names for different models.
+        :param str temp_label: Suffix to add to temporary data paths to avoid conflicting names for different models.
         :param int fold: Fold number in training set to select training transcripts from.
             If not None, the Table is generated from variants in only validation or training transcripts
-                from the specified fold.
-            If None, the Table is generated from variants in test transcripts or from variants in all
-                training transcripts.
+            from the specified fold. If None, the Table is generated from variants in all training transcripts.
             Default is None.
         :param bool is_val: Whether the Table is generated from variants in validation transcripts.
-            If True, the Table is generated from variants in the validation transcripts
-                from the specified fold of the training set.
-            If False, the Table is generated from variants in test transcripts,
-                from variants in all training transcripts, or from variants in
-                training transcripts from the specified fold of the training set.
+            If True, the Table is generated from variants in the validation transcripts from
+            the specified fold of the training set. If False, the Table is generated from
+            variants in all training transcripts or training transcripts from the specified fold.
             Default is False.
         :return: None; writes Table with missense badness scores to resource path.
         """

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -337,7 +337,7 @@ def calculate_misbad(
         Calculate missense badness scores from a Table of amino acid substitutions and their missense OE ratios.
 
         :param hl.Table ht: Table containing all possible amino acid substitutions and their missense OE ratio.
-        :param str mb_path: Output path for missense badness scores.
+        :param str mb_path: Output path for table of missense badness scores.
         :param str temp_label: Model-specific suffix to add to temporary table paths
             to avoid conflicting writes for different models.
         :return: None; writes Table with missense badness scores to resource path.

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -245,8 +245,10 @@ def aggregate_aa_and_filter_oe(
 
     logger.info("Grouping HT and aggregating observed and possible variant counts...")
     ht = ht.group_by("ref", "alt").aggregate(
-        obs=hl.agg.sum(ht.observed), possible=hl.agg.count()
+        obs=hl.agg.sum(ht.observed), pos=hl.agg.count()
     )
+    oe_direction = "high" if keep_high_oe else "low"
+    ht = ht.rename({"obs": f"{oe_direction}_obs", "pos": f"{oe_direction}_pos"})
 
     logger.info("Adding variant consequence (mut_type) annotation and returning...")
     return ht.annotate(mut_type=variant_csq_expr(ht.ref, ht.alt))
@@ -339,12 +341,6 @@ def calculate_misbad(
             )
             oe_hts[oe_direction] = aggregate_aa_and_filter_oe(
                 ht, keep_high_oe=keep_high_oe
-            )
-            oe_hts[oe_direction] = oe_hts[oe_direction].transmute(
-                **{
-                    f"{oe_direction}_obs": oe_hts[oe_direction].obs,
-                    f"{oe_direction}_pos": oe_hts[oe_direction].possible,
-                }
             )
             oe_hts[oe_direction] = oe_hts[oe_direction].checkpoint(
                 f"{TEMP_PATH_WITH_FAST_DEL}/amino_acids_{oe_direction}_oe{temp_label}.ht",

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -113,7 +113,14 @@ def prepare_amino_acid_ht(
     context_ht = context_ht.filter(
         hl.is_missing(context_ht.lof) | (context_ht.lof == loftee_hc_str)
     )
-    hc_lof_flag_agg = context_ht.aggregate(hl.agg.counter(context_ht.lof_flags))
+    hc_lof_flag_agg_path = f"{TEMP_PATH_WITH_FAST_DEL}/lof_flag_agg.he"
+    if not overwrite_temp and file_exists(hc_lof_flag_agg_path):
+        hc_lof_flag_agg = hl.eval(hl.experimental.read_expression(hc_lof_flag_agg_path))
+    else:
+        hc_lof_flag_agg = context_ht.aggregate(hl.agg.counter(context_ht.lof_flags))
+        hl.experimental.write_expression(
+            hl.literal(hc_lof_flag_agg), hc_lof_flag_agg_path
+        )
     logger.info("Flag counter for LOFTEE HC pLoF: %s", hc_lof_flag_agg)
     context_ht = context_ht.filter(hl.is_missing(context_ht.lof_flags))
 

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -607,9 +607,9 @@ def run_regressions(
             # Check input formula is formulated properly
             formula_components = re.split("[~+:*]", model_formula.replace(" ", ""))
             formula_y = formula_components.pop(0)
-            formula_components = set(formula_components)
+            formula_xs = set(formula_components)
             if (formula_y != "pop_v_path") or (
-                not all([x in df.columns.values for x in formula_components])
+                not all([x in df.columns.values for x in formula_xs])
             ):
                 raise DataException("Model formula is not formulated properly!")
 

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -503,7 +503,6 @@ def get_min_aic_model(
         min_model_formulas[overall_min_model_type],
     )
     logger.info("Coefficients: %s", overall_min_model.params)
-
     return overall_min_model
 
 

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -207,7 +207,7 @@ def prepare_pop_path_ht(
     :param adj_freq_index: Index of array that contains allele frequency information calculated on
         high quality (adj) genotypes across genetic ancestry groups. Default is 0.
     :param int cov_threshold: Coverage threshold used to filter context Table. Default is 0.
-    :return: None; function writes Table(s) to resource path.
+    :return: None; function writes Table(s) to resource path(s).
     """
     logger.info("Reading in ClinVar P/LP missense variants in severe HI genes...")
     clinvar_ht = clinvar_plp_mis_haplo.ht()
@@ -314,9 +314,9 @@ def prepare_pop_path_ht(
         fold: int = None,
     ) -> None:
         """
-        Add missense badness calculated on a set of transcripts to table, filter to those transcripts, and write out.
+        Add missense badness calculated on a set of transcripts, filter to those transcripts, and write out Table.
 
-        :param hl.Table ht: Input table.
+        :param hl.Table ht: Input Table.
         :param int fold: Fold number in training set to select training transcripts from.
             If not None, the Table is generated from variants in only training transcripts
             from the specified fold of the overall training set. If None, the Table is generated from
@@ -397,7 +397,7 @@ def get_min_aic_model(
     def _find_min_aic_model(
         var_combs: List[Tuple[str, ...]],
         model_type: str = "single",
-    ) -> Tuple[statsmodels.genmod.generalized_linear_model.GLMResultsWrapper, str,]:
+    ) -> Tuple[statsmodels.genmod.generalized_linear_model.GLMResultsWrapper, str]:
         """
         Run logistic regressions on different variable combinations and return results on model with lowest AIC.
 
@@ -889,7 +889,7 @@ def annotate_mpc(
     For more information on the fitted score and MPC calculation, see the docstring of `run_regressions`.
 
     :param hl.Table ht: Input Table.
-    :param str output_ht_path: Path to write out annotated table (with duplicate variants removed.
+    :param str output_ht_path: Path to write out annotated Table (with duplicate variants removed.
     :param str temp_label: Suffix to add to temporary data paths to avoid conflicting names for different models.
     :param bool use_release: Whether to use the MPC HT release in annotation of MPC scores.
         If True, MPC scores will be taken from the MPC release HT. If False, MPC scores

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -179,7 +179,11 @@ def prepare_pop_path_ht(
     cov_threshold: int = 0,
 ) -> None:
     """
-    Prepare Table with 'population' (common gnomAD missense) and 'pathogenic' (ClinVar pathogenic/likely pathogenic missense) variants.
+    Prepare Table(s) with 'population' and 'pathogenic' variants in given set of transcripts.
+
+    'Population' variants are defined as common gnomAD missenses.
+    'Pathogenic' variants are defined as ClinVar pathogenic/likely pathogenic missenses in
+    predicted-haploinsufficient genes.
 
     .. note::
         Assumes tables containing all variants in canonical transcripts and their
@@ -194,15 +198,15 @@ def prepare_pop_path_ht(
     :param bool overwrite_temp: Whether to overwrite intermediate temporary data if it already exists.
         If False, will read existing intermediate temporary data rather than overwriting.
         Default is False.
-    :param do_k_fold_training: Whether to generate k-fold models with the training transcripts.
-        If False, will use all training transcripts in calculation of a single model.
-        If True, will calculate k models corresponding to the k-folds of the training transcripts.
+    :param do_k_fold_training: Whether to generate k-fold Tables with the training transcripts.
+        If False, will use all training transcripts to prepare a single Table for a single model.
+        If True, will prepare Tables for k models corresponding to the k-folds of the training transcripts.
         Default is False.
     :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
     :param adj_freq_index: Index of array that contains allele frequency information calculated on
         high quality (adj) genotypes across genetic ancestry groups. Default is 0.
     :param int cov_threshold: Coverage threshold used to filter context Table. Default is 0.
-    :return: None; function writes Table to resource path.
+    :return: None; function writes Table(s) to resource path.
     """
     logger.info("Reading in ClinVar P/LP missense variants in severe HI genes...")
     clinvar_ht = clinvar_plp_mis_haplo.ht()

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -1011,26 +1011,3 @@ def annotate_mpc(
         logger.info("Annotating MPC scores to input table and writing out...")
         ht = ht.annotate(mpc=scores_ht[ht.key].mpc)
         ht.write(output_ht_path, overwrite=True)
-
-
-def create_mpc_release_ht(
-    overwrite_temp: bool = True,
-    freeze: int = CURRENT_FREEZE,
-) -> None:
-    """
-    Annotate variants in VEP context Table with MPC scores calculated using all training transcripts.
-
-    :param bool overwrite_temp: Whether to overwrite intermediate temporary data if it already exists.
-        If False, will read existing intermediate temporary data rather than overwriting.
-        Default is True.
-    :param int freeze: RMC data freeze number. Default is CURRENT_FREEZE.
-    :return: None; function writes Table to resource path.
-    """
-    annotate_mpc(
-        ht=context_with_oe.versions[freeze].ht().select(),
-        output_ht_path=mpc_release.versions[freeze].path,
-        temp_label="_release",
-        use_release=False,
-        overwrite_temp=overwrite_temp,
-        freeze=freeze,
-    )

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -764,8 +764,6 @@ def annotate_mpc(
 
     :param hl.Table ht: Input Table.
     :param str output_ht_path: Path to write out annotated table (with duplicate variants removed.
-    :param str dup_output_ht_path: Path to write out annotated table, possibly containing duplicate variants.
-        Duplicate variants may be present if a single site is part of multiple transcripts.
     :param bool overwrite_temp: Whether to overwrite intermediate temporary data if it already exists.
         If False, will read existing intermediate temporary data rather than overwriting.
         Default is True.

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -683,7 +683,10 @@ def calculate_fitted_scores(
     assert interaction_char in {"*", ":"}, "interaction_char must be one of '*' or ':'!"
 
     logger.info("Extracting MPC model relationships from pickle...")
-    with hl.hadoop_open(mpc_model_pkl_path(fold=fold, freeze=freeze), "rb") as p:
+    model_path = mpc_model_pkl_path(fold=fold, freeze=freeze)
+    if not file_exists(model_path):
+        raise DataException("Please check that MPC model exists!")
+    with hl.hadoop_open(model_path, "rb") as p:
         model = pickle.load(p)
     mpc_rel_vars = model.params.to_dict()
     try:

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -753,7 +753,6 @@ def calculate_fitted_scores(
         scores_ht = scores_ht.annotate(
             misbad=mb_ht[scores_ht.ref, scores_ht.alt].misbad
         )
-
     if "blosum" in addtl_annots:
         logger.info("Annotating HT with BLOSUM...")
         if not file_exists(blosum.path):
@@ -762,7 +761,6 @@ def calculate_fitted_scores(
         scores_ht = scores_ht.annotate(
             blosum=blosum_ht[scores_ht.ref, scores_ht.alt].score
         )
-
     if "grantham" in addtl_annots:
         logger.info("Annotating HT with Grantham...")
         if not file_exists(grantham.path):

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -694,17 +694,17 @@ def calculate_fitted_scores(
         raise DataException("Please check that MPC model exists!")
     with hl.hadoop_open(model_path, "rb") as p:
         model = pickle.load(p)
-    mpc_rel_vars = model.params.to_dict()
+    mpc_vars_rel = model.params.to_dict()
     try:
-        intercept = mpc_rel_vars.pop(intercept_str)
+        intercept = mpc_vars_rel.pop(intercept_str)
     except KeyError:
         raise DataException(
             f"{intercept_str} not in model parameters! Please double check and rerun."
         )
 
-    variable_dict = {k: v for k, v in mpc_rel_vars.items() if not interaction_char in k}
+    variable_dict = {k: v for k, v in mpc_vars_rel.items() if not interaction_char in k}
     variables = variable_dict.keys()
-    interactions_dict = {k: v for k, v in mpc_rel_vars.items() if interaction_char in k}
+    interaction_dict = {k: v for k, v in mpc_vars_rel.items() if interaction_char in k}
 
     # Collect fields from context HT containing annotations to extract
     # NOTE: `ref` and `alt` fields are also extracted for annotation of missense badness
@@ -791,11 +791,11 @@ def calculate_fitted_scores(
 
     logger.info("Calculating fitted scores...")
     annot_expr = [
-        (scores_ht[variable] * mpc_rel_vars[variable]) for variable in variables
+        (scores_ht[variable] * mpc_vars_rel[variable]) for variable in variables
     ]
     interaction_annot_expr = []
-    for interaction in interactions_dict.keys():
-        expr = mpc_rel_vars[interaction]
+    for interaction in interaction_dict.keys():
+        expr = mpc_vars_rel[interaction]
         for variable in interaction.split(interaction_char):
             expr *= scores_ht[variable]
         interaction_annot_expr.append(expr)

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -548,9 +548,9 @@ def run_regressions(
     :param str model_formula: Model formula to use in regression.
         Default is 'pop_v_path ~ oe + misbad + oe:misbad + polyphen + oe:polyphen'.
         This was the formula selected in ExAC.
-    :param List[str] variables: Variables to include in all regressions (single, joint).
+    :param List[str] variables: Primary variables to include in all regressions (single, joint).
         Default is ['oe', 'misbad', 'polyphen'].
-    :param List[str] additional_variables: Additional variables to include in single variable regressions only.
+    :param List[str] additional_variables: Additional variables to include in all regressions.
         Default is ['blosum', 'grantham'].
     :param bool overwrite_temp: Whether to overwrite intermediate temporary data if it already exists.
         If False, will read existing intermediate temporary data rather than overwriting.
@@ -570,7 +570,7 @@ def run_regressions(
     def _generate_regression_model(
         temp_label: str,
         fold: int = None,
-    ):
+    ) -> None:
         """
         Generate a regression model on the given set of transcripts.
 


### PR DESCRIPTION
This PR adds updates for flexibility in training up different models for missense badness and MPC depending on input training transcript sets and model components. Plus some other miscellaneous updates.

Major changes:

- MPC-related:
    - Addition of capacity to train MPC models on different input training transcript sets (e.g. all training transcripts vs. training transcripts from a specific fold) and model components
        - E.g. bringing in missense badness scores trained on a specific training set in construction of an MPC model for that specific training set
        - Turning MPC-related resource definitions into functions that can return different paths for different input training transcript sets and model components
    - Addition of support for utils functions in the pipeline file `calculate_mpc.py`
    - Addition of capacity to train MPC models using a specific input formula or by trying out models from mix-and-match of a set of input variables/components and keeping the best one.
        - The multiple functionalities previously contained within `run_regressions` have now been separated into `run_glm` (for just fitting a single regression), `get_min_aic_model` (to get the model with the minimum AIC from mix-and-matching an input set of variables) and `run_regressions` (the top-level function).
    - Addition of capacity to annotate MPC scores onto a given Table of input variants using the MPC release HT (containing all VEP context missense variants and their MPC scores) or computing scores from a saved model without using a prewritten release HT. This allows us to try out different models without the burden of writing out the entire length of the context HT for each model.
    - Restructuring of `calculate_fitted_scores` for code efficiency and flexibility for different models
    - Removal of the version of the MPC release Table that has multiple rows for variants in multiple transcripts. Only the "deduplicated" version of this Table is now retained.
        - This necessitated some tinkering with how fitted scores are annotated in `calculate_fitted_scores` i.e. handling on what happens when a variant is located in multiple transcripts.
    - Addition of a suffix label on temporary files (`temp_label`) generated during the process of model generation to avoid conflicting file writes. (This will be further updated in later commits to be converted to a subfolder structure.)
- Missense badness-related:
    - Removal of code related to creation of missense badness models with anything other than training transcripts, i.e. testing transcripts or validation transcripts from a specific fold. This was mistakenly added in previous PRs.
    - Code efficiency improvements in `prepare_amino_acid_ht` and `calculate_misbad`

Minor changes:

- Addressing code from previous PRs:
    - Addition of a temporary save point for an aggregation that had been made for logging purposes on the HC LoF filter. This update means that the aggregation does not have to be performed every time `prepare_amino_acid_ht` is run (e.g., useful when this function is rerun with different training transcript sets).
    - Merging of functions returning paths to training, validation, and test transcripts in `reference_data.py`
    - Removal of the `overwrite_output` parameter which was a vestige from previous experimentation with RMC regions. All output resources are now always written out (`overwrite=True`). This and the points regarding line spacing and documentation should be the only changes made to `constraint.py` and `regional_constraint.py` (code for RMC regions and not missense badness or MPC).
- Addition of subfolder structure to paths for missense badness and MPC resources in `rmc.py`, so that resources corresponding to models trained on a particular transcript set are located in the same folder.
- Formatting/spacing for various lines
- Updates to documentation for various function/argparse arguments
- Small changes to some temp file names