### PR TITLE
Browser release updates

### DIFF
--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -303,7 +303,9 @@ def main(args):
                     logger.info(
                         "Adding section annotation before searching for first break..."
                     )
-                    # Add transcript start and stop positions from browser HT
+                    # Add transcript start and stop positions from CDS HT
+                    # NOTE: For RMC freezes 1-7, the transcript start and ends were from the
+                    # browser HT (`gene_model`) rather than the CDS HT!
                     transcript_ht = transcript_cds.ht().key_by()
                     transcript_ht = transcript_ht.annotate(
                         start=transcript_ht.interval.start.position,

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -40,6 +40,7 @@ from rmc.utils.constraint import (
     get_max_chisq_per_group,
     merge_rmc_hts,
     process_sections,
+    reformat_annotations_for_release,
 )
 from rmc.utils.generic import (
     filter_context_using_gnomad,
@@ -597,6 +598,9 @@ def main(args):
             create_context_with_oe(
                 freeze=args.freeze, overwrite_temp=args.overwrite_temp
             )
+
+            logger.info("Reformatting RMC results for browser release...")
+            reformat_annotations_for_release(args.freeze, args.overwrite_temp)
 
     finally:
         logger.info("Copying hail log to logging bucket...")

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -17,7 +17,7 @@ from rmc.resources.gnomad import (
     processed_exomes,
     prop_obs_coverage,
 )
-from rmc.resources.reference_data import filtered_context, gene_model
+from rmc.resources.reference_data import filtered_context, transcript_cds
 from rmc.resources.resource_utils import MISSENSE
 from rmc.resources.rmc import (
     CURRENT_FREEZE,
@@ -304,7 +304,11 @@ def main(args):
                         "Adding section annotation before searching for first break..."
                     )
                     # Add transcript start and stop positions from browser HT
-                    transcript_ht = gene_model.ht().select("start", "stop")
+                    transcript_ht = transcript_cds.ht().key_by()
+                    transcript_ht = transcript_ht.annotate(
+                        start=transcript_ht.interval.start.position,
+                        stop=transcript_ht.interval.end.position,
+                    )
                     ht = ht.annotate(**transcript_ht[ht.transcript])
                     ht = ht.annotate(
                         section=hl.format("%s_%s_%s", ht.transcript, ht.start, ht.stop)

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1334,7 +1334,8 @@ def annot_rmc_with_aa(ht: hl.Table, overwrite_temp: bool):
         overwrite_temp=overwrite_temp, keep_transcripts=rmc_transcripts
     )
     context_ht = get_ref_aa(
-        ht=context_ht, overwrite_temp=overwrite_temp, collect_all_aa=False
+        ht=context_ht,
+        overwrite_temp=overwrite_temp,
     )
     ht = ht.annotate(
         start_aa=context_ht[ht.start_coordinate, ht.transcript].ref_aa,
@@ -1602,7 +1603,10 @@ def reformat_annotations_for_release(freeze: int, overwrite_temp: bool) -> None:
         stop_coordinate=ht.interval.end,
     )
 
+    # Annotate amino acids
     ht = annot_rmc_with_aa(ht, overwrite_temp)
+
+    # Add region struct
     ht = ht.annotate(
         regions=hl.struct(
             start_coordinate=ht.start_coordinate,

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -32,6 +32,7 @@ from rmc.resources.rmc import (
     context_with_oe_dedup,
     no_breaks_he_path,
     oe_bin_counts_tsv,
+    rmc_browser,
     rmc_results,
     simul_search_bucket_path,
     simul_search_round_bucket_path,
@@ -1310,44 +1311,58 @@ def create_context_with_oe(
     logger.info("Output OE-annotated dedup context HT fields: %s", set(ht.row))
 
 
-def reformat_annotations_for_release(ht: hl.Table) -> hl.Table:
+def reformat_annotations_for_release(freeze: int, overwrite: bool) -> None:
     """
     Reformat annotations in input HT for release.
 
     This reformatting is necessary to load data into the gnomAD browser.
 
     Desired schema:
-    ---------------------------------------
+    ----------------------------------------
+    Global fields:
+        'transcripts_not_searched': set<str>
+        'transcripts_no_rmc': set<str>
+        'outlier_transcripts': set<str>
+    ----------------------------------------
     Row fields:
-        'transcript_id': str
-        'regions': array<struct {
-            'start': int32
-            'stop': int32
-            'observed_missense': int32
-            'expected_missense': float64
-            'chisq': float64
-        }>
-
+        'interval': interval<locus<GRCh37>>
+        'transcript': str
+        'regions': struct {
+            start_coordinate: locus<GRCh37>,
+            stop_coordinate: locus<GRCh37>,
+            start_aa: str,
+            stop_aa: str,
+            obs: int64,
+            exp: float64,
+            oe: float64,
+            chisq: float64
+        }
     ----------------------------------------
-    Key: ['transcript_id']
+    Key: ['interval', 'transcript']
     ----------------------------------------
 
-    :param ht: Input Table.
-    :return: Table with schema described above.
+    :param freeze: RMC data freeze number.
+    :param overwrite: Whether to overwrite existing data.
+    :return: None; writes Table with desired schema to resource path.
     """
+    ht = rmc_results.versions[freeze].ht()
     ht = ht.annotate(
         regions=hl.struct(
-            start=ht.section_start,
-            stop=ht.section_end,
-            observed_missense=ht.section_obs,
-            expected_missense=ht.section_exp,
+            start_coordinate=ht.start_coordinate,
+            stop_coordinate=ht.stop_coordinate,
+            start_aa=ht.start_aa,
+            stop_aa=ht.stop_aa,
+            obs=ht.section_obs,
+            exp=ht.section_exp,
+            oe=ht.section_oe,
             chisq=ht.section_chisq,
         )
     )
     # Group Table by transcript
-    return ht.group_by(transcript_id=ht.transcript).aggregate(
+    ht = ht.group_by(transcript_id=ht.transcript).aggregate(
         regions=hl.agg.collect(ht.regions)
     )
+    ht.write(rmc_browser.versions[freeze].path, overwrite=overwrite)
 
 
 def check_loci_existence(ht1: hl.Table, ht2: hl.Table, annot_str: str) -> hl.Table:

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -276,7 +276,6 @@ def get_aa_from_context(
 def get_ref_aa(
     ht: hl.Table,
     overwrite_temp: bool,
-    collect_all_aa: bool,
     extra_aa_map: Dict[str, str] = {"*": "Ter", "U": "Sec"},
     aa_to_remove: str = "X",
 ) -> hl.Table:
@@ -287,7 +286,6 @@ def get_ref_aa(
     :param overwrite_temp: Whether to overwrite temporary data.
         If False, will read existing temp data rather than overwriting.
         If True, will overwrite temp data.
-    :param collect_all_aa: Whether to group input HT by transcript and collect all reference AAs in that transcript.
     :param extra_aa_map: Dictionary mapping any amino acid one letter codes to three letter codes.
         Designed to capture any amino acids not present in `ACID_NAMES_PATH`.
         Default is {"*": "Ter", "U": "Sec"}.
@@ -335,15 +333,7 @@ def get_ref_aa(
         _read_if_exists=not overwrite_temp,
         overwrite=overwrite_temp,
     )
-    if collect_all_aa:
-        ht = ht.key_by("transcript", "locus")
-        group_ht = ht.group_by("transcript").aggregate(aa_list=hl.agg.collect(ht.aa))
-        group_ht = group_ht.checkpoint(
-            f"{TEMP_PATH_WITH_FAST_DEL}/rmc/ref_aa_per_transcript.ht", overwrite=True
-        )
-        return group_ht
-    ht = ht.transmute(ref_aa=ht.aa_info[0].ref_aa)
-    return ht
+    return ht.transmute(ref_aa=ht.aa_info[0].ref_aa)
 
 
 def get_gnomad_public_release(

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Tuple
+from typing import Dict, List, Set, Tuple
 
 import hail as hl
 from gnomad.resources.grch37.gnomad import coverage, public_release
@@ -217,6 +217,132 @@ def process_context_ht(
             *grouping,
         )
         return annotate_with_mu(ht, mu_ht)
+    return ht
+
+
+def get_aa_from_context(
+    overwrite_temp: bool,
+    keep_transcripts: Set[str] = None,
+    n_partitions: int = 10000,
+) -> hl.Table:
+    """
+    Extract amino acid information from VEP context HT.
+
+    :param overwrite_temp: Whether to overwrite temporary data.
+        If False, will read existing temp data rather than overwriting.
+        If True, will overwrite temp data.
+    :param keep_transcripts: Desired set of transcripts to keep from the context HT.
+        If set, function will filter to keep these trancripts only.
+        Default is None.
+    :param n_partitions: Desired number of partitions for context HT after filtering.
+        Default is 10,000.
+    :return: VEP context HT filtered to keep only transcript ID, protein number, and amino acid information.
+    """
+    logger.info(
+        "Reading in VEP context HT and filtering to coding effects in non-outlier"
+        " canonical transcripts..."
+    )
+    # Drop globals and select only VEP transcript consequences field
+    ht = process_context_ht(
+        filter_to_missense=False, add_annotations=False
+    ).select_globals()
+    ht = ht.select("transcript_consequences")
+    ht = ht.filter(
+        ~hl.literal(CSQ_NON_CODING).contains(
+            ht.transcript_consequences.most_severe_consequence
+        )
+    )
+    # Unnest annotations from context HT
+    ht = ht.transmute(
+        transcript=ht.transcript_consequences.trancript_id,
+        protein_start=ht.transcript_consequences.protein_start,
+        protein_end=ht.transcript_consequences.protein_end,
+        amino_acids=ht.transcript_consequences.amino_acids,
+    )
+
+    if keep_transcripts:
+        logger.info("Filtering to desired transcripts only...")
+        ht = ht.filter(hl.literal(keep_transcripts).contains(ht.transcript))
+
+    ht = ht.naive_coalesce(n_partitions)
+    ht = ht.checkpoint(
+        f"{TEMP_PATH_WITH_FAST_DEL}/rmc/amino_acids.ht",
+        _read_if_exists=not overwrite_temp,
+        overwrite=overwrite_temp,
+    )
+    return ht
+
+
+def get_ref_aa(
+    ht: hl.Table,
+    overwrite_temp: bool,
+    collect_all_aa: bool,
+    extra_aa_map: Dict[str, str] = {"*": "Ter", "U": "Sec"},
+    aa_to_remove: str = "X",
+) -> hl.Table:
+    """
+    Filter input HT to keep only reference amino acid information.
+
+    :param ht: Input Table. Should be HT output from `get_aa_from_context`.
+    :param overwrite_temp: Whether to overwrite temporary data.
+        If False, will read existing temp data rather than overwriting.
+        If True, will overwrite temp data.
+    :param collect_all_aa: Whether to group input HT by transcript and collect all reference AAs in that transcript.
+    :param extra_aa_map: Dictionary mapping any amino acid one letter codes to three letter codes.
+        Designed to capture any amino acids not present in `ACID_NAMES_PATH`.
+        Default is {"*": "Ter", "U": "Sec"}.
+    :param aa_to_remove: Any amino acid one letter codes to remove. Default is "X".
+    :return: HT with one reference amino acid annotated per locus/transcript if `collect_all_aa` is False.
+        HT grouped by transcript with a list of all reference amino acids in that transcript if `collect_all_aa` is True.
+    """
+    logger.info("Mapping amino acid one letter codes to three letter codes...")
+    aa_map = get_aa_map()
+    # Add any extra mappings into amino acid mapping dict
+    if extra_aa_map:
+        aa_map = aa_map | extra_aa_map
+    ht = ht.annotate(ref_aa_1_letter=ht.amino_acids.split("/")[0])
+    ht = ht.annotate(
+        ref_aa=hl.literal(aa_map).get(ht.ref_aa_1_letter, ht.ref_aa_1_letter)
+    )
+    if aa_to_remove:
+        ht = ht.filter(ht.ref_aa != aa_to_remove)
+
+    # Double check that protein start always equals protein end
+    protein_num_check = ht.aggregate(
+        hl.agg.count_where(ht.protein_start != ht.protein_end)
+    )
+    if protein_num_check != 0:
+        raise DataException(
+            f"{protein_num_check} sites had different protein start and end values --"
+            " please double check!"
+        )
+    # Reformat reference AA to have both the 3 letter code and number
+    ht = ht.annotate(ref_aa=hl.format("%s%s", ht.ref_aa, ht.protein_start))
+
+    # Select fields and checkpoint
+    ht = ht.select("ref_aa", "transcript")
+    ht = ht.checkpoint(
+        f"{TEMP_PATH_WITH_FAST_DEL}/rmc/ref_amino_acids.ht",
+        _read_if_exists=not overwrite_temp,
+        overwrite=overwrite_temp,
+    )
+
+    # Collect by key to collapse AA per locus
+    ht = ht.key_by("locus", "transcript").drop("alleles")
+    ht = ht.collect_by_key(name="aa_info")
+    ht = ht.checkpoint(
+        f"{TEMP_PATH_WITH_FAST_DEL}/rmc/ref_aa_collected.ht",
+        _read_if_exists=not overwrite_temp,
+        overwrite=overwrite_temp,
+    )
+    if collect_all_aa:
+        ht = ht.key_by("transcript", "locus")
+        group_ht = ht.group_by("transcript").aggregate(aa_list=hl.agg.collect(ht.aa))
+        group_ht = group_ht.checkpoint(
+            f"{TEMP_PATH_WITH_FAST_DEL}/rmc/ref_aa_per_transcript.ht", overwrite=True
+        )
+        return group_ht
+    ht = ht.transmute(ref_aa=ht.aa_info[0].ref_aa)
     return ht
 
 


### PR DESCRIPTION
This PR contains code updates required to reformat RMC results for gnomAD browser release.

Major updates:
`rmc/utils/generic.py`
- Added two new functions to get reference amino acid information (3 letter code + number) from context HT

`rmc/utils/constraint.py`
- Added functions to annotate RMC results HT with amino acids, then check for and fix any missing amino acid information
- Updated `reformat_annotations_for_release` to reformat RMC HT to new desired schema
- Added a function to annotate the globals of the RMC HT for release


Minor changes:
`rmc/pipeline/regional_constraint.py`
- Updated code to annotate CDS start and stop positions as transcript start and stops (rather than browser start/stops)
- Added call to `reformat_annotations_for_release`