### PR TITLE
Use true expected values in RMC (+ flexibility for non-mis)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8.16
+          python-version: 3.11
       - name: Use pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: pip-${{ hashFiles('**/requirements*.txt') }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.7.0
     hooks:
       - id: black
         language_version: python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 [tool.black]
-target-version = ['py38']
+target-version = ['py39', 'py310', 'py311']
 preview = true
 [tool.isort]
 profile = "black"
+known_third_party = "gnomad"
+known_third_party = "gnomad-constraint"
 [tool.autopep8]
 # Use same max line length as the default in Black - 88
 max_line_length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,7 @@ target-version = ['py39', 'py310', 'py311']
 preview = true
 [tool.isort]
 profile = "black"
-known_third_party = "gnomad"
-known_third_party = "gnomad-constraint"
+known_third_party = "gnomad, gnomad-constraint"
 [tool.autopep8]
 # Use same max line length as the default in Black - 88
 max_line_length = 88

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,7 +3,7 @@
 # requirements-dev.txt, which is used for GitHub Actions
 # These should be kept in sync with the versions in .pre-commit-config.yaml
 autopep8==2.0.2
-black==22.3.0
+black==23.7.0
 isort==5.12.0
 pydocstyle==6.1.1
 pylint

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ attrs==23.1.0
     # via pytest
 autopep8==2.0.2
     # via -r requirements-dev.in
-black==22.3.0
+black==23.7.0
     # via -r requirements-dev.in
 cfgv==3.3.1
     # via pre-commit
@@ -39,7 +39,9 @@ mypy-extensions==1.0.0
 nodeenv==1.8.0
     # via pre-commit
 packaging==23.1
-    # via pytest
+    # via
+    #   black
+    #   pytest
 pathspec==0.11.1
     # via black
 platformdirs==3.8.1

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -356,7 +356,8 @@ def main(args):
                 tmp_dir=TEMP_PATH_WITH_FAST_DEL,
                 quiet=args.quiet,
             )
-
+            # TODO: Check that all downstream usages of RMC results table filter out
+            # constraint outliers appropriately
             logger.info("Checking round paths...")
             round_nums = check_break_search_round_nums(args.freeze)
 
@@ -370,10 +371,12 @@ def main(args):
                 _read_if_exists=not args.overwrite,
             )
 
-            # TODO: Remove this block to retain outlier transcripts initially
-            logger.info("Removing outlier transcripts...")
-            constraint_transcripts = get_constraint_transcripts(outlier=False)
-            rmc_ht = rmc_ht.filter(constraint_transcripts.contains(rmc_ht.transcript))
+            if args.filter_outliers:
+                logger.info("Removing outlier transcripts...")
+                constraint_transcripts = get_constraint_transcripts(outlier=False)
+                rmc_ht = rmc_ht.filter(
+                    constraint_transcripts.contains(rmc_ht.transcript)
+                )
 
             # Add p-value threshold to globals
             if not args.p_value:
@@ -530,6 +533,10 @@ if __name__ == "__main__":
 
     finalize = subparsers.add_parser(
         "finalize", help="Combine and reformat (finalize) RMC output."
+    )
+    finalize.add_argument(
+        "--filter-outliers",
+        help="Remove constraint outlier transcripts from RMC output.",
     )
 
     args = parser.parse_args()

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -24,6 +24,7 @@ from rmc.resources.rmc import (
 from rmc.slack_creds import slack_token
 from rmc.utils.constraint import (
     check_break_search_round_nums,
+    create_filtered_context_ht,
     create_constraint_prep_ht,
     create_context_with_oe,
     create_no_breaks_he,
@@ -31,7 +32,7 @@ from rmc.utils.constraint import (
     merge_rmc_hts,
     process_sections,
 )
-from rmc.utils.generic import create_filtered_context_ht, get_constraint_transcripts
+from rmc.utils.generic import get_constraint_transcripts
 
 logging.basicConfig(
     format="%(asctime)s (%(name)s %(lineno)s): %(message)s",

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -285,10 +285,8 @@ def main(args):
             else:
                 simul_exists = False
                 logger.info(
-                    (
-                        "No sections in round %i had breakpoints in simultaneous breaks"
-                        " search."
-                    ),
+                    "No sections in round %i had breakpoints in simultaneous breaks"
+                    " search.",
                     args.search_num,
                 )
 
@@ -351,10 +349,8 @@ def main(args):
                 simul_break_ht.write(merged_path, overwrite=args.overwrite)
             else:
                 logger.info(
-                    (
-                        "No sections in round %i had breakpoints (neither in single nor"
-                        " in simultaneous search)."
-                    ),
+                    "No sections in round %i had breakpoints (neither in single nor"
+                    " in simultaneous search).",
                     args.search_num,
                 )
 

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -53,7 +53,12 @@ def main(args):
             )
             logger.warning("Code currently only processes b37 data!")
             logger.info("Creating filtered context HT...")
-            create_filtered_context_ht(args.overwrite)
+            n_partitions = 30000
+            create_filtered_context_ht(
+                n_partitions=args.n_partitions if args.n_partitions else n_partitions,
+                overwrite_temp=args.overwrite_temp,
+                overwrite=args.overwrite,
+            )
 
         if args.command == "prep-constraint":
             hl.init(
@@ -69,7 +74,12 @@ def main(args):
                 csq = NONSENSES
             elif args.prep_synonymous:
                 csq = SYNONYMOUS
-            create_constraint_prep_ht(filter_csq=csq, overwrite=args.overwrite)
+            n_partitions = 150000
+            create_constraint_prep_ht(
+                filter_csq=csq,
+                n_partitions=args.n_partitions if args.n_partitions else n_partitions,
+                overwrite=args.overwrite,
+            )
 
         if args.command == "search-for-single-break":
             hl.init(
@@ -104,8 +114,7 @@ def main(args):
                 else:
                     # Read `constraint_prep` resource HT if this is the first search
                     logger.info("Reading in constraint prep HT...")
-                    # Repartition on read
-                    ht = hl.read_table(constraint_prep.path, _n_partitions=15000)
+                    ht = constraint_prep.ht()
 
             else:
                 logger.info(
@@ -405,18 +414,20 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         "This script searches for regional missense constraint in gnomAD."
     )
+    # TODO: Make subparsers for prepping for RMC and running RMC
     parser.add_argument(
         "--n-partitions",
-        help="Desired number of partitions for output data.",
+        help="""
+        Desired number of partitions for context Table or constraint prep Table depending on
+        which is being prepared.
+        """,
         type=int,
-        default=40000,
     )
     parser.add_argument(
         "--search-num",
-        help=(
-            "Search iteration number (e.g., second round of searching for single break"
-            " would be 2)."
-        ),
+        help="""
+        Search iteration number (e.g., second round of searching for single break would be 2).
+        """,
         type=int,
     )
     parser.add_argument(

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -71,8 +71,16 @@ def main(args):
             csq = {MISSENSE}
             if args.prep_nonsense:
                 csq = NONSENSES
+                logger.warning(
+                    "Pipeline is currently set up to run on missenses. Please make sure"
+                    " all missense-relevant files are deleted before running."
+                )
             elif args.prep_synonymous:
                 csq = SYNONYMOUS
+                logger.warning(
+                    "Pipeline is currently set up to run on missenses. Please make sure"
+                    " all missense-relevant files are deleted before running."
+                )
             n_partitions = 150000
             create_constraint_prep_ht(
                 filter_csq=csq,

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -23,12 +23,12 @@ from rmc.resources.rmc import (
 )
 from rmc.slack_creds import slack_token
 from rmc.utils.constraint import (
+    annotate_max_chisq_per_section,
     check_break_search_round_nums,
-    create_filtered_context_ht,
     create_constraint_prep_ht,
     create_context_with_oe,
+    create_filtered_context_ht,
     create_no_breaks_he,
-    annotate_max_chisq_per_section,
     merge_rmc_hts,
     process_sections,
 )

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -67,7 +67,7 @@ def main(args):
                 and not args.prep_nonsense
                 and not args.prep_synonymous
             ):
-                create_constraint_prep_ht(overwrite=args.overwrite)
+                create_constraint_prep_ht(filter_csq=None, overwrite=args.overwrite)
             else:
                 csq = set()
                 if args.prep_missense:
@@ -76,9 +76,7 @@ def main(args):
                     csq.update(NONSENSES)
                 if args.prep_synonymous:
                     csq.add(SYNONYMOUS)
-                create_constraint_prep_ht(
-                    filter_csq=csq, overwrite=args.overwrite
-                )
+                create_constraint_prep_ht(filter_csq=csq, overwrite=args.overwrite)
 
         if args.command == "search-for-single-break":
             hl.init(

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -11,7 +11,6 @@ from rmc.resources.basics import (
     TEMP_PATH_WITH_FAST_DEL,
     TEMP_PATH_WITH_SLOW_DEL,
 )
-from rmc.resources.reference_data import gene_model
 from rmc.resources.resource_utils import MISSENSE
 from rmc.resources.rmc import (
     CURRENT_FREEZE,

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -446,7 +446,7 @@ if __name__ == "__main__":
         "--overwrite",
         help="""
         Overwrite existing output data.
-        Applies to all outputs except OE-annotated context table (created in `--finalize`).
+        Applies to all outputs except OE-annotated context table (created in `finalize`).
         """,
         action="store_true",
     )

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -157,6 +157,7 @@ def main(args):
                     is_breakpoint_only=True,
                     freeze=args.freeze,
                 ),
+                _read_if_exists=not args.overwrite,
                 overwrite=args.overwrite,
             )
 
@@ -366,8 +367,8 @@ def main(args):
             rmc_ht = rmc_ht.select_globals()
             rmc_ht = rmc_ht.checkpoint(
                 f"{TEMP_PATH_WITH_SLOW_DEL}/freeze{args.freeze}_rmc_results.ht",
-                overwrite=args.overwrite,
                 _read_if_exists=not args.overwrite,
+                overwrite=args.overwrite,
             )
 
             if args.filter_outliers:

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -4,6 +4,7 @@ import logging
 import hail as hl
 from gnomad.utils.file_utils import file_exists
 from gnomad.utils.slack import slack_notifications
+from gnomad.utils.vep import LOF_CSQ_SET
 
 from rmc.resources.basics import (
     LOGGING_PATH,
@@ -11,7 +12,7 @@ from rmc.resources.basics import (
     TEMP_PATH_WITH_FAST_DEL,
     TEMP_PATH_WITH_SLOW_DEL,
 )
-from rmc.resources.resource_utils import MISSENSE, NONSENSE, SYNONYMOUS
+from rmc.resources.resource_utils import MISSENSE, SYNONYMOUS
 from rmc.resources.rmc import (
     CURRENT_FREEZE,
     P_VALUE,
@@ -71,11 +72,11 @@ def main(args):
             else:
                 csq = set()
                 if args.prep_missense:
-                    csq = csq.add(MISSENSE)
+                    csq.add(MISSENSE)
                 if args.prep_nonsense:
-                    csq = csq.add(NONSENSE)
+                    csq.update(LOF_CSQ_SET)
                 if args.prep_synonymous:
-                    csq = csq.add(SYNONYMOUS)
+                    csq.add(SYNONYMOUS)
                 create_constraint_prep_ht(
                     filter_csq=True, csq=csq, overwrite=args.overwrite
                 )

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -56,8 +56,7 @@ def main(args):
             n_partitions = 30000
             create_filtered_context_ht(
                 n_partitions=args.n_partitions if args.n_partitions else n_partitions,
-                overwrite_temp=args.overwrite_temp,
-                overwrite=args.overwrite,
+                overwrite=args.overwrite_temp,
             )
 
         if args.command == "prep-constraint":
@@ -460,10 +459,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--overwrite-temp",
-        help="""
-        Overwrite existing intermediate temporary data.
-        Only applicable in creating OE-annotated context table.
-        """,
+        help="Overwrite existing intermediate temporary data.",
         action="store_true",
     )
     parser.add_argument(

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -67,7 +67,7 @@ def main(args):
                 and not args.prep_nonsense
                 and not args.prep_synonymous
             ):
-                create_constraint_prep_ht(filter_csq=False, overwrite=args.overwrite)
+                create_constraint_prep_ht(overwrite=args.overwrite)
             else:
                 csq = set()
                 if args.prep_missense:
@@ -77,7 +77,7 @@ def main(args):
                 if args.prep_synonymous:
                     csq.add(SYNONYMOUS)
                 create_constraint_prep_ht(
-                    filter_csq=True, csq=csq, overwrite=args.overwrite
+                    filter_csq=csq, overwrite=args.overwrite
                 )
 
         if args.command == "search-for-single-break":

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -4,7 +4,6 @@ import logging
 import hail as hl
 from gnomad.utils.file_utils import file_exists
 from gnomad.utils.slack import slack_notifications
-from gnomad.utils.vep import LOF_CSQ_SET
 
 from rmc.resources.basics import (
     LOGGING_PATH,
@@ -12,7 +11,7 @@ from rmc.resources.basics import (
     TEMP_PATH_WITH_FAST_DEL,
     TEMP_PATH_WITH_SLOW_DEL,
 )
-from rmc.resources.resource_utils import MISSENSE, SYNONYMOUS
+from rmc.resources.resource_utils import MISSENSE, NONSENSES, SYNONYMOUS
 from rmc.resources.rmc import (
     CURRENT_FREEZE,
     P_VALUE,
@@ -74,7 +73,7 @@ def main(args):
                 if args.prep_missense:
                     csq.add(MISSENSE)
                 if args.prep_nonsense:
-                    csq.update(LOF_CSQ_SET)
+                    csq.update(NONSENSES)
                 if args.prep_synonymous:
                     csq.add(SYNONYMOUS)
                 create_constraint_prep_ht(

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -62,21 +62,14 @@ def main(args):
                 quiet=args.quiet,
             )
             logger.info("Creating constraint prep HT...")
-            if (
-                not args.prep_missense
-                and not args.prep_nonsense
-                and not args.prep_synonymous
-            ):
-                create_constraint_prep_ht(filter_csq=None, overwrite=args.overwrite)
-            else:
-                csq = set()
-                if args.prep_missense:
-                    csq.add(MISSENSE)
-                if args.prep_nonsense:
-                    csq.update(NONSENSES)
-                if args.prep_synonymous:
-                    csq.add(SYNONYMOUS)
-                create_constraint_prep_ht(filter_csq=csq, overwrite=args.overwrite)
+            # Constraint prep HT is filtered to missense variants by default
+            # Use these args to run constraint prep on other variant consequences
+            csq = {MISSENSE}
+            if args.prep_nonsense:
+                csq = NONSENSES
+            elif args.prep_synonymous:
+                csq = SYNONYMOUS
+            create_constraint_prep_ht(filter_csq=csq, overwrite=args.overwrite)
 
         if args.command == "search-for-single-break":
             hl.init(
@@ -488,19 +481,19 @@ if __name__ == "__main__":
         break search.
         """,
     )
-    prep_constraint.add_argument(
-        "--prep-missense",
-        help="Include missense variants in constraint prep Table.",
-        action="store_true",
-    )
-    prep_constraint.add_argument(
+    prep_csq = parser.add_mutually_exclusive_group()
+    prep_csq.add_argument(
         "--prep-nonsense",
-        help="Include nonsense variants in constraint prep Table.",
+        help="""
+        "Filter to nonsense instead of missense variants in constraint prep Table.
+        """,
         action="store_true",
     )
-    prep_constraint.add_argument(
+    prep_csq.add_argument(
         "--prep-synonymous",
-        help="Include synonymous variants in constraint prep Table.",
+        hhelp="""
+        "Filter to synonymous instead of missense variants in constraint prep Table.
+        """,
         action="store_true",
     )
 

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -111,7 +111,8 @@ def main(args):
                 else:
                     # Read `constraint_prep` resource HT if this is the first search
                     logger.info("Reading in constraint prep HT...")
-                    ht = constraint_prep.ht()
+                    # Repartition on read
+                    ht = hl.read_table(constraint_prep.path, _n_partitions=15000)
 
             else:
                 logger.info(

--- a/rmc/pipeline/two_breaks/README.md
+++ b/rmc/pipeline/two_breaks/README.md
@@ -4,5 +4,4 @@ This folder contains the pipeline scripts required to search for two simultaneou
 The order to run the scripts is:
 1. `prepare_transcripts.py`
 2. `run_batches.py` or `run_batches_dataproc.py`
-3. `verify_transcripts.py`
 4. `merge_hts.py`

--- a/rmc/pipeline/two_breaks/prepare_transcripts.py
+++ b/rmc/pipeline/two_breaks/prepare_transcripts.py
@@ -59,7 +59,6 @@ def main(args):
                     freeze=args.freeze,
                 ),
                 out_ht_path=grouped_ht_path,
-                group_str="section",
                 overwrite=args.overwrite,
             )
 
@@ -70,7 +69,6 @@ def main(args):
             )
             split_sections_by_len(
                 ht_path=grouped_ht_path,
-                group_str="section",
                 search_num=args.search_num,
                 missense_len_threshold=args.missense_len_threshold,
                 overwrite=args.overwrite,

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -137,7 +137,6 @@ def get_obs_exp_expr(
 
     Typically imported from `constraint.py`. See `constraint.py` for full docstring.
 
-    :param hl.expr.BooleanExpression cond_expr: Condition to check prior to adding obs/exp expression.
     :param hl.expr.Int64Expression obs_expr: Expression containing number of observed variants.
     :param hl.expr.Float64Expression exp_expr: Expression containing number of expected variants.
     :return: Observed/expected expression.

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -507,8 +507,8 @@ def process_section_group(
         )
         ht = ht.checkpoint(
             f"{prep_path}/{section_group[0]}.ht",
-            overwrite=not read_if_exists,
             _read_if_exists=read_if_exists,
+            overwrite=not read_if_exists,
         )
     else:
         # Add start_idx struct with i_start, j_start, i_max_idx, j_max_idx annotations

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -100,7 +100,6 @@ def main(args):
             freeze=args.freeze,
         )
         for counter, group in enumerate(section_groups):
-
             output_ht_path = f"{raw_path}/simul_break_dataproc_{counter}.ht"
             if file_exists(output_ht_path):
                 raise DataException(

--- a/rmc/resources/gnomad.py
+++ b/rmc/resources/gnomad.py
@@ -10,16 +10,6 @@ Path to bucket with gnomAD v2 loss-of-function (LoF) constraint results.
 
 FLAGSHIP_LOF_MODEL_PREFIX = f"{FLAGSHIP_LOF}/model"
 
-processed_genomes = TableResource(
-    path=f"{FLAGSHIP_LOF_MODEL_PREFIX}/genomes_processed.ht"
-)
-"""
-Processed gnomAD genomes Table.
-
-Dropped colocated variants in vep annotation and removed all non-pass variants.
-Also annotated with context Table (sequence context, transcript information, most severe consequence).
-"""
-
 prop_obs_coverage = TableResource(
     path=f"{FLAGSHIP_LOF_MODEL_PREFIX}/prop_observed_by_coverage_no_common_pass_filtered_bins.ht"
 )

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -33,6 +33,43 @@ Table contains constraint-related annotations, including observed variant counts
 expected variant counts, probability of mutation, CpG status, gnomAD exome coverage,
 and methylation level.
 
+Schema:
+----------------------------------------
+Global fields:
+    'plateau_models': struct {
+        total: dict<bool, array<float64>>
+    } 
+    'plateau_x_models': struct {
+        total: dict<bool, array<float64>>
+    } 
+    'plateau_y_models': struct {
+        total: dict<bool, array<float64>>
+    } 
+    'coverage_model': tuple (
+        float64, 
+        float64
+    ) 
+----------------------------------------
+Row fields:
+    'locus': locus<GRCh37>
+    'alleles': array<str>
+    'context': str
+    'ref': str
+    'alt': str
+    'methylation_level': int32
+    'cpg': bool
+    'mutation_type': str
+    'annotation': str
+    'modifier': str
+    'coverage': int32
+    'transcript': str
+    'expected': float64
+    'coverage_correction': float64
+    'observed': int32    
+----------------------------------------
+Key: ['locus', 'alleles']
+----------------------------------------
+
 Used to create the constraint prep Table.
 """
 

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -1,8 +1,5 @@
 """Script containing reference resources."""
-from gnomad.resources.resource_utils import (
-    DataException,
-    TableResource,
-)
+from gnomad.resources.resource_utils import DataException, TableResource
 
 from rmc.resources.basics import AMINO_ACIDS_PREFIX, RESOURCE_BUILD_PREFIX
 from rmc.resources.resource_utils import CURRENT_BUILD

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -17,62 +17,6 @@ Path to bucket containing reference data resources.
 ####################################################################################
 ## Reference genome related resources
 ####################################################################################
-filtered_context = VersionedTableResource(
-    default_version="v1",
-    versions={
-        "v1": TableResource(
-            path=f"{REF_DATA_PREFIX}/ht/context_fasta_snps_only_vep_v1.ht",
-        )
-    },
-)
-"""
-Variant-level VEP context Table filtered to missense, nonsense, and synonymous variants in all canonical
-protein-coding transcripts.
-
-Table contains constraint-related annotations, including observed variant counts,
-expected variant counts, probability of mutation, CpG status, gnomAD exome coverage,
-and methylation level.
-
-Schema:
-----------------------------------------
-Global fields:
-    'plateau_models': struct {
-        total: dict<bool, array<float64>>
-    } 
-    'plateau_x_models': struct {
-        total: dict<bool, array<float64>>
-    } 
-    'plateau_y_models': struct {
-        total: dict<bool, array<float64>>
-    } 
-    'coverage_model': tuple (
-        float64, 
-        float64
-    ) 
-----------------------------------------
-Row fields:
-    'locus': locus<GRCh37>
-    'alleles': array<str>
-    'context': str
-    'ref': str
-    'alt': str
-    'methylation_level': int32
-    'cpg': bool
-    'mutation_type': str
-    'annotation': str
-    'modifier': str
-    'coverage': int32
-    'transcript': str
-    'expected': float64
-    'coverage_correction': float64
-    'observed': int32    
-----------------------------------------
-Key: ['locus', 'alleles']
-----------------------------------------
-
-Used to create the constraint prep Table.
-"""
-
 gene_model = TableResource(path=f"{RESOURCE_BUILD_PREFIX}/browser/b37_transcripts.ht")
 """
 Table containing transcript start and stop positions displayed in the browser.

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -2,7 +2,6 @@
 from gnomad.resources.resource_utils import (
     DataException,
     TableResource,
-    VersionedTableResource,
 )
 
 from rmc.resources.basics import AMINO_ACIDS_PREFIX, RESOURCE_BUILD_PREFIX

--- a/rmc/resources/resource_utils.py
+++ b/rmc/resources/resource_utils.py
@@ -9,11 +9,15 @@ MISSENSE = "missense_variant"
 """
 String representing missense variant VEP annotation.
 """
-SYNONYMOUS = "synonymous_variant"
+NONSENSES = {"stop_gained", "splice_donor_variant", "splice_acceptor_variant"}
 """
-String representing synonymous variant VEP annotation.
+Set containing loss-of-function (LoF) single-nucleotide variant VEP annotations.
 """
 READ_THROUGH = "stop_lost"
 """
 String representing read-through (stop lost) variant VEP annotation.
+"""
+SYNONYMOUS = "synonymous_variant"
+"""
+String representing synonymous variant VEP annotation.
 """

--- a/rmc/resources/resource_utils.py
+++ b/rmc/resources/resource_utils.py
@@ -21,3 +21,7 @@ SYNONYMOUS = "synonymous_variant"
 """
 String representing synonymous variant VEP annotation.
 """
+KEEP_CODING_CSQ = {MISSENSE, READ_THROUGH, SYNONYMOUS}.union(NONSENSES)
+"""
+Set of variant consequences to keep in filtered context Table.
+"""

--- a/rmc/resources/resource_utils.py
+++ b/rmc/resources/resource_utils.py
@@ -9,11 +9,11 @@ MISSENSE = "missense_variant"
 """
 String representing missense variant VEP annotation.
 """
-NONSENSE = "nonsense_variant"
-"""
-String representing nonsense variant VEP annotation.
-"""
 SYNONYMOUS = "synonymous_variant"
 """
 String representing synonymous variant VEP annotation.
+"""
+READ_THROUGH = "stop_lost"
+"""
+String representing read-through (stop lost) variant VEP annotation.
 """

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -139,7 +139,7 @@ Schema:
             total: dict<bool, array<float64>>
         }
         'coverage_model': tuple (
-            float64, 
+            float64,
             float64
         )
     }
@@ -171,17 +171,17 @@ Schema:
 Global fields:
     'plateau_models': struct {
         total: dict<bool, array<float64>>
-    } 
+    }
     'plateau_x_models': struct {
         total: dict<bool, array<float64>>
-    } 
+    }
     'plateau_y_models': struct {
         total: dict<bool, array<float64>>
-    } 
+    }
     'coverage_model': tuple (
-        float64, 
+        float64,
         float64
-    ) 
+    )
 ----------------------------------------
 Row fields:
     'locus': locus<GRCh37>
@@ -198,7 +198,7 @@ Row fields:
     'transcript': str
     'expected': float64
     'coverage_correction': float64
-    'observed': int32    
+    'observed': int32
 ----------------------------------------
 Key: ['locus', 'alleles']
 ----------------------------------------
@@ -226,23 +226,23 @@ Schema:
 Global fields:
     'plateau_models': struct {
         total: dict<bool, array<float64>>
-    } 
+    }
     'plateau_x_models': struct {
         total: dict<bool, array<float64>>
-    } 
+    }
     'plateau_y_models': struct {
         total: dict<bool, array<float64>>
-    } 
+    }
     'coverage_model': tuple (
-        float64, 
+        float64,
         float64
-    ) 
+    )
 ----------------------------------------
 Row fields:
     'locus': locus<GRCh37>
     'section': str
-    'observed': int32  
-    'expected': float64 
+    'observed': int32
+    'expected': float64
 ----------------------------------------
 Key: ['locus', 'section']
 ----------------------------------------

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -123,6 +123,8 @@ for each canonical transcript in Gencode v19.
 ####################################################################################
 ## RMC-related resources
 ####################################################################################
+coverage_plateau_models_path = "{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{CURRENT_FREEZE}/coverage_plateau_models.he"
+
 constraint_prep = VersionedTableResource(
     default_version=CURRENT_FREEZE,
     versions={

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -151,6 +151,32 @@ constraint_prep = VersionedTableResource(
 Locus-level Table used in first step of regional constraint calculation over specific coding variant
 consequences for all canonical protein-coding transcripts.
 
+Schema:
+----------------------------------------
+Global fields:
+    'plateau_models': struct {
+        total: dict<bool, array<float64>>
+    } 
+    'plateau_x_models': struct {
+        total: dict<bool, array<float64>>
+    } 
+    'plateau_y_models': struct {
+        total: dict<bool, array<float64>>
+    } 
+    'coverage_model': tuple (
+        float64, 
+        float64
+    ) 
+----------------------------------------
+Row fields:
+    'locus': locus<GRCh37>
+    'section': str
+    'observed': int32  
+    'expected': float64 
+----------------------------------------
+Key: ['locus', 'section']
+----------------------------------------
+
 NOTE: The content of the freeze 1 HT for RMC is slightly different:
     - Expected counts were calculated using the workaround method instead of directly from the plateau model.
     - `mu_snp` contains the coverage-corrected not raw mutation rates.

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -129,10 +129,19 @@ Path to HailExpression containing struct for coverage correction model and plate
 
 Schema:
     struct {
-        coverage: Tuple[float, float],
-        plateau_autosomes: DictExpression,
-        plateau_X: DictExpression,
-        plateau_Y: DictExpression
+        'plateau_models': struct {
+            total: dict<bool, array<float64>>
+        }
+        'plateau_x_models': struct {
+            total: dict<bool, array<float64>>
+        }
+        'plateau_y_models': struct {
+            total: dict<bool, array<float64>>
+        }
+        'coverage_model': tuple (
+            float64, 
+            float64
+        )
     }
 
 Used to compute expected variant counts.

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -148,8 +148,9 @@ constraint_prep = VersionedTableResource(
     },
 )
 """
-Locus-level Table used in first step of regional constraint calculation over specific coding variant
-consequences for all canonical protein-coding transcripts.
+Locus-level Table used in first step of regional constraint calculation.
+
+Filtered to only one specific coding variant consequence but contains all canonical, protein-coding transcripts.
 
 Schema:
 ----------------------------------------

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -147,11 +147,71 @@ Schema:
 Used to compute expected variant counts.
 """
 
+
+# TODO: Delete current version
+filtered_context = VersionedTableResource(
+    default_version=CURRENT_FREEZE,
+    versions={
+        freeze: TableResource(
+            path=f"{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/context_coding_snps_annot.ht"
+        )
+        for freeze in FREEZES
+    },
+)
+"""
+Variant-level VEP context Table filtered to missense, nonsense, read-through and synonymous
+variants in all canonical protein-coding transcripts.
+
+Table contains constraint-related annotations, including observed variant counts,
+expected variant counts, probability of mutation, CpG status, gnomAD exome coverage,
+and methylation level.
+
+Schema:
+----------------------------------------
+Global fields:
+    'plateau_models': struct {
+        total: dict<bool, array<float64>>
+    } 
+    'plateau_x_models': struct {
+        total: dict<bool, array<float64>>
+    } 
+    'plateau_y_models': struct {
+        total: dict<bool, array<float64>>
+    } 
+    'coverage_model': tuple (
+        float64, 
+        float64
+    ) 
+----------------------------------------
+Row fields:
+    'locus': locus<GRCh37>
+    'alleles': array<str>
+    'context': str
+    'ref': str
+    'alt': str
+    'methylation_level': int32
+    'cpg': bool
+    'mutation_type': str
+    'annotation': str
+    'modifier': str
+    'coverage': int32
+    'transcript': str
+    'expected': float64
+    'coverage_correction': float64
+    'observed': int32    
+----------------------------------------
+Key: ['locus', 'alleles']
+----------------------------------------
+
+Used to create the constraint prep Table.
+"""
+
+
 constraint_prep = VersionedTableResource(
     default_version=CURRENT_FREEZE,
     versions={
         freeze: TableResource(
-            path=f"{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/context_obs_exp_annot.ht"
+            path=f"{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/constraint_prep.ht"
         )
         for freeze in FREEZES
     },

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -124,6 +124,19 @@ for each canonical transcript in Gencode v19.
 ## RMC-related resources
 ####################################################################################
 coverage_plateau_models_path = "{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{CURRENT_FREEZE}/coverage_plateau_models.he"
+"""
+Path to HailExpression containing struct for coverage correction model and plateau models.
+
+Schema:
+    struct {
+        coverage: Tuple[float, float],
+        plateau_autosomes: DictExpression,
+        plateau_X: DictExpression,
+        plateau_Y: DictExpression
+    }
+
+Used to compute expected variant counts.
+"""
 
 constraint_prep = VersionedTableResource(
     default_version=CURRENT_FREEZE,

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -363,6 +363,7 @@ def create_constraint_prep_ht(
         if not csq:
             raise DataException("Need to specify consequence if filter_csq is True!")
         logger.info("Filtering to %s...", csq)
+        csq = hl.literal(csq)
         ht = ht.filter(csq.contains(ht.annotation))
 
     logger.info("Aggregating by locus...")

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -712,9 +712,7 @@ def annotate_subsection_exprs(ht: hl.Table) -> hl.Table:
         section_obs=hl.agg.sum(ht.observed),
         section_exp=hl.agg.sum(ht.expected),
     )
-    ht = ht.annotate(
-        **group_ht[ht.section]
-    )
+    ht = ht.annotate(**group_ht[ht.section])
     logger.info(
         "Getting observed/expected value for each transcript or transcript"
         " subsection..."

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -33,6 +33,7 @@ from rmc.resources.rmc import (
     constraint_prep,
     context_with_oe,
     context_with_oe_dedup,
+    coverage_plateau_models_path,
     no_breaks_he_path,
     oe_bin_counts_tsv,
     rmc_results,
@@ -300,7 +301,17 @@ def create_filtered_context_ht(overwrite: bool = True) -> None:
         coverage_x_ht,
         coverage_y_ht,
     )
-    # TODO: Add HE here
+    # Write out models to HailExpression to save
+    hl.experimental.write_expression(
+        hl.struct(
+            coverage=coverage_model,
+            plateau_autosomes=plateau_models,
+            plateau_X=plateau_x_models,
+            plateau_Y=plateau_y_models,
+        ),
+        coverage_plateau_models_path,
+    )
+    # Also annotate as HT globals
     ht = ht.annotate_globals(
         plateau_models=plateau_models,
         plateau_x_models=plateau_x_models,

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -43,8 +43,8 @@ from rmc.resources.rmc import (
     single_search_round_ht_path,
 )
 from rmc.utils.generic import (
-    filter_to_region_type,
     filter_context_using_gnomad,
+    filter_to_region_type,
     generate_models,
     get_annotations_from_context_ht_vep,
     get_constraint_transcripts,

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1150,6 +1150,7 @@ def get_oe_annotation(ht: hl.Table, freeze: int) -> hl.Table:
     Use regional OE value if available, otherwise use transcript OE value.
 
     .. note::
+        - Assumes `constraint_prep` Table is missense-specific
         - Assumes input Table has `locus` and `trancript` annotations
         - OE values are transcript specific
         - Assumes merged RMC results HT exists
@@ -1162,7 +1163,6 @@ def get_oe_annotation(ht: hl.Table, freeze: int) -> hl.Table:
     :return: Table with `oe` annotation.
     """
     ht = constraint_prep.ht().select_globals()
-    ht = ht.filter(ht.annotation == MISSENSE)
     group_ht = ht.group_by("transcript").aggregate(
         obs=hl.agg.sum(ht.observed),
         exp=hl.agg.sum(ht.expected),

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -223,16 +223,14 @@ def calculate_exp_from_mu(
             group_ht.coverage, group_ht.coverage_model
         ),
     )
-    group_ht = group_ht.annotate(
-        expected_grouping=group_ht.mu_adj * group_ht.coverage_correction
-    )
+    group_ht = group_ht.annotate(exp_agg=group_ht.mu_adj * group_ht.coverage_correction)
 
     logger.info(
         "Annotating expected counts per allele by distributing expected counts equally"
         " among all alleles in each grouping..."
     )
     group_ht = group_ht.annotate(
-        expected_per_variant=group_ht.expected_grouping / group_ht.n_grouping
+        expected=group_ht.exp_agg / group_ht.n_grouping
     )
     context_ht = context_ht.annotate(
         expected=group_ht[
@@ -244,7 +242,7 @@ def calculate_exp_from_mu(
             context_ht.modifier,
             context_ht.transcript,
             context_ht.coverage,
-        ].expected_per_variant,
+        ].expected,
         coverage_correction=group_ht[
             context_ht.context,
             context_ht.ref,

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -19,7 +19,6 @@ from rmc.resources.basics import (
 from rmc.resources.gnomad import constraint_ht, prop_obs_coverage
 from rmc.resources.reference_data import (
     clinvar_plp_mis_haplo,
-    filtered_context,
     gene_model,
     ndd_de_novo,
 )
@@ -34,6 +33,7 @@ from rmc.resources.rmc import (
     context_with_oe,
     context_with_oe_dedup,
     coverage_plateau_models_path,
+    filtered_context,
     no_breaks_he_path,
     oe_bin_counts_tsv,
     rmc_results,

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -286,11 +286,12 @@ def create_filtered_context_ht(
         " exomes..."
     )
     ht = filter_context_using_gnomad(ht, "exomes")
-    logger.info("Checkpointing context HT before annotating obs and exp...")
-    ht = ht.checkpoint(
-        f"{TEMP_PATH_WITH_FAST_DEL}/processed_context.ht",
-        _read_if_exists=not overwrite_temp,
-        overwrite=overwrite_temp,
+    # Repartition
+    ht.write(
+        f"{TEMP_PATH_WITH_FAST_DEL}/processed_context.ht", overwrite=overwrite_temp
+    )
+    ht = hl.read_table(
+        f"{TEMP_PATH_WITH_FAST_DEL}/processed_context.ht", _n_partitions=30000
     )
 
     # TODO: Import models built in gnomad-constraint rather than rebuilding here

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -363,8 +363,7 @@ def create_constraint_prep_ht(
         if not csq:
             raise DataException("Need to specify consequence if filter_csq is True!")
         logger.info("Filtering to %s...", csq)
-        csq = hl.literal(csq)
-        ht = ht.filter(csq.contains(ht.annotation))
+        ht = ht.filter(hl.literal(csq).contains(ht.annotation))
 
     logger.info("Aggregating by locus...")
     # Context HT is keyed by locus and allele, which means there is one row for every possible missense variant

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -229,30 +229,12 @@ def calculate_exp_from_mu(
         "Annotating expected counts per allele by distributing expected counts equally"
         " among all alleles in each grouping..."
     )
-    group_ht = group_ht.annotate(expected=group_ht.exp_agg / group_ht.n_grouping)
+    group_ht = group_ht.annotate(
+        expected=group_ht.exp_agg / group_ht.n_grouping
+    ).select("expected", "coverage_correction")
     context_ht = context_ht.annotate(
-        expected=group_ht[
-            context_ht.context,
-            context_ht.ref,
-            context_ht.alt,
-            context_ht.methylation_level,
-            context_ht.annotation,
-            context_ht.modifier,
-            context_ht.transcript,
-            context_ht.coverage,
-        ].expected,
-        coverage_correction=group_ht[
-            context_ht.context,
-            context_ht.ref,
-            context_ht.alt,
-            context_ht.methylation_level,
-            context_ht.annotation,
-            context_ht.modifier,
-            context_ht.transcript,
-            context_ht.coverage,
-        ].coverage_correction,
+        **group_ht.index(*[context_ht[g] for g in groupings])
     )
-    # TODO: Condense the join above to use `groupings`, without re-keying `context_ht`
     return context_ht
 
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -316,6 +316,7 @@ def create_filtered_context_ht(
             plateau_Y=plateau_y_models,
         ),
         coverage_plateau_models_path,
+        overwrite=overwrite_temp,
     )
     # Also annotate as HT globals
     ht = ht.annotate_globals(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -709,12 +709,11 @@ def annotate_subsection_exprs(ht: hl.Table) -> hl.Table:
         " subsection..."
     )
     group_ht = ht.group_by("section").aggregate(
-        obs=hl.agg.sum(ht.observed),
-        exp=hl.agg.sum(ht.expected),
+        section_obs=hl.agg.sum(ht.observed),
+        section_exp=hl.agg.sum(ht.expected),
     )
     ht = ht.annotate(
-        section_obs=group_ht[ht.section].obs,
-        section_exp=group_ht[ht.section].exp,
+        **group_ht[ht.section]
     )
     logger.info(
         "Getting observed/expected value for each transcript or transcript"

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -454,8 +454,15 @@ def annotate_fwd_exprs(ht: hl.Table) -> hl.Table:
     .. note::
         'Forward' refers to moving through the transcript from smaller to larger chromosomal positions.
 
-    Expects:
-        - Input HT is annotated with section, observed, and expected counts per site.
+    Expects input HT to contain the following fields:
+        - section
+        - observed
+        - expected
+
+    Adds the following fields:
+        - fwd_cumulative_obs
+        - fwd_cumulative_exp
+        - fwd_oe
 
     :param ht: Input Table.
     :return: Table with forward values (cumulative obs, exp, and forward o/e) annotated.
@@ -498,6 +505,17 @@ def annotate_reverse_exprs(ht: hl.Table) -> hl.Table:
 
     .. note::
         'Reverse' refers to moving through the transcript from larger to smaller chromosomal positions.
+
+    Expects input HT to contain the following fields:
+        - section_obs
+        - section_exp
+        - fwd_cumulative_obs
+        - fwd_cumulative_exp
+
+    Adds the following fields:
+        - reverse_cumulative_obs
+        - reverse_cumulative_exp
+        - reverse_oe
 
     :param ht: Input Table.
     :return: Table with reverse values annotated.
@@ -557,6 +575,13 @@ def annotate_max_chisq_per_section(
 ) -> hl.Table:
     """
     Get maximum chi square value per transcript or transcript subsection.
+
+    Expects input HT to contain the following fields:
+        - section
+        - chisq
+
+    Adds the following field:
+        - section_max_chisq
 
     :param ht: Input Table.
     :param freeze: RMC data freeze number.
@@ -697,9 +722,15 @@ def annotate_subsection_exprs(ht: hl.Table) -> hl.Table:
     """
     Annotate total observed, expected, and observed/expected (OE) counts for each section of a transcript.
 
-    .. note::
-        - Assumes input Table has annotations `section`, `observed`, `expected`.
-        - Adds annotations `section_obs`, `section_exp`, `section_oe`.
+    Expects input HT to contain the following fields:
+        - section
+        - observed
+        - expected
+
+    Adds the following fields:
+        - section_obs
+        - section_exp
+        - section_oe
 
     :param ht: Input Table.
     :return: Table annotated with section observed, expected, and OE counts.

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -9,6 +9,7 @@ from gnomad.resources.grch37.gnomad import coverage, public_release
 from gnomad.resources.grch37.reference_data import vep_context
 from gnomad.resources.resource_utils import DataException
 from gnomad.utils.file_utils import file_exists
+from gnomad.utils.vep import LOF_CSQ_SET
 
 from rmc.resources.basics import (
     SINGLE_BREAK_TEMP_PATH,
@@ -23,7 +24,7 @@ from rmc.resources.reference_data import (
     gene_model,
     ndd_de_novo,
 )
-from rmc.resources.resource_utils import MISSENSE, NONSENSE, SYNONYMOUS
+from rmc.resources.resource_utils import MISSENSE, SYNONYMOUS, READ_THROUGH
 from rmc.resources.rmc import (
     CURRENT_FREEZE,
     FINAL_ANNOTATIONS,
@@ -277,7 +278,8 @@ def create_filtered_context_ht(overwrite: bool = True) -> None:
         " annotations..."
     )
     # NOTE: Constraint outlier transcripts are not removed
-    ht = process_context_ht(filter_csq=True, csq={MISSENSE, NONSENSE, SYNONYMOUS})
+    csq = {MISSENSE, SYNONYMOUS, READ_THROUGH}.union(LOF_CSQ_SET)
+    ht = process_context_ht(filter_csq=True, csq=csq)
 
     logger.info(
         "Filtering context HT to all covered sites not found or rare in gnomAD"

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -414,7 +414,7 @@ def get_obs_exp_expr(
     :param exp_expr: Expression containing number of expected variants.
     :return: Observed/expected expression.
     """
-    return hl.min(obs_expr / exp_expr, 1)
+    return hl.nanmin(obs_expr / exp_expr, 1)
 
 
 def get_reverse_cumulative_obs_exp_expr(
@@ -442,7 +442,7 @@ def get_reverse_cumulative_obs_exp_expr(
         # Picked 1e-09 here as tiny number that is not 0
         # ExAC code also did not allow reverse exp to be zero, as this breaks the likelihood ratio tests
         reverse_cumulative_obs=section_obs_expr - fwd_cumulative_obs_expr,
-        reverse_cumulative_exp=hl.max(
+        reverse_cumulative_exp=hl.nanmax(
             section_exp_expr - fwd_cumulative_exp_expr, 1e-09
         ),
     )

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -17,11 +17,7 @@ from rmc.resources.basics import (
     TEMP_PATH_WITH_SLOW_DEL,
 )
 from rmc.resources.gnomad import constraint_ht, prop_obs_coverage
-from rmc.resources.reference_data import (
-    clinvar_plp_mis_haplo,
-    gene_model,
-    ndd_de_novo,
-)
+from rmc.resources.reference_data import clinvar_plp_mis_haplo, gene_model, ndd_de_novo
 from rmc.resources.resource_utils import KEEP_CODING_CSQ, MISSENSE
 from rmc.resources.rmc import (
     CURRENT_FREEZE,
@@ -622,10 +618,8 @@ def search_for_break(
         " and alt (evidence of domains of missense constraint) probability densities..."
     )
     logger.info(
-        (
-            "Skipping breakpoints that create at least one section that has < %i"
-            " expected missense variants..."
-        ),
+        "Skipping breakpoints that create at least one section that has < %i"
+        " expected missense variants...",
         min_num_exp_mis,
     )
     ht = ht.annotate(
@@ -1028,10 +1022,8 @@ def merge_round_no_break_ht(
         ht = ht.filter(~hl.literal(simul_sections).contains(ht.section))
     else:
         logger.warning(
-            (
-                "Simul breaks results HT (round %i) did not exist. Please double check"
-                " that this was expected!"
-            ),
+            "Simul breaks results HT (round %i) did not exist. Please double check"
+            " that this was expected!",
             search_num,
         )
     return ht

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -122,7 +122,7 @@ def get_fwd_cumulative_count_expr(
     Return annotation with the cumulative number of variant counts (non-inclusive).
 
     Function can return either the cumulative expected and observed counts.
-    
+
     Value returned is non-inclusive (does not include value of row) due to the nature of `hl.scan`
     and needs to be corrected later.
 
@@ -174,7 +174,7 @@ def calculate_exp_from_mu(
     groupings: List[str] = GROUPINGS,
 ) -> hl.Table:
     """
-    Annotate Table with the per-variant (locus+allele) expected counts based on the per-variant mu.
+    Annotate Table with the per-variant (locus-allele) expected counts based on the per-variant mu.
 
     .. note::
         - Assumes that input Table is annotated with all of the fields in `groupings` and that

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -241,8 +241,7 @@ def calculate_exp_from_mu(
 def create_filtered_context_ht(
     csq: Set[str] = {MISSENSE, READ_THROUGH, SYNONYMOUS}.union(NONSENSES),
     n_partitions: int = 30000,
-    overwrite_temp: bool = False,
-    overwrite: bool = True,
+    overwrite: bool = False,
 ) -> None:
     """
     Create allele-level VEP context Table with constraint annotations including expected variant counts.
@@ -256,8 +255,7 @@ def create_filtered_context_ht(
     :param csq: Variant consequences to filter Table to.
         Default is the missense, read-through, synonymous, and nonsense consequences.
     :param n_partitions: Number of desired partitions for the Table. Default is 30000.
-    :param overwrite_temp: Whether to overwrite temporary data. Default is False.
-    :param overwrite: Whether to overwrite output Table. Default is True.
+    :param overwrite: Whether to overwrite temporary data. Default is False.
     :return: None; writes Table to path.
     """
     logger.info(
@@ -277,8 +275,8 @@ def create_filtered_context_ht(
     ht = ht.naive_coalsece(n_partitions)
     ht = ht.checkpoint(
         f"{TEMP_PATH_WITH_FAST_DEL}/processed_context.ht",
-        _read_if_exists=not overwrite_temp,
-        overwrite=overwrite_temp,
+        _read_if_exists=not overwrite,
+        overwrite=overwrite,
     )
 
     # TODO: Import models built in gnomad-constraint rather than rebuilding here
@@ -305,7 +303,7 @@ def create_filtered_context_ht(
             plateau_Y=plateau_y_models,
         ),
         coverage_plateau_models_path,
-        overwrite=overwrite_temp,
+        overwrite=overwrite,
     )
     # Also annotate as HT globals
     ht = ht.annotate_globals(
@@ -326,8 +324,8 @@ def create_filtered_context_ht(
     )
     ht = ht.checkpoint(
         f"{TEMP_PATH_WITH_FAST_DEL}/context_exp.ht",
-        _read_if_exists=not overwrite_temp,
-        overwrite=overwrite_temp,
+        _read_if_exists=not overwrite,
+        overwrite=overwrite,
     )
 
     logger.info("Removing alleles with negative expected values...")
@@ -340,7 +338,7 @@ def create_filtered_context_ht(
         "Annotating context HT with number of observed variants and writing out..."
     )
     ht = add_obs_annotation(ht)
-    ht.write(filtered_context.path, overwrite=overwrite)
+    ht.write(filtered_context.path, overwrite=True)
 
 
 def create_constraint_prep_ht(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -9,7 +9,6 @@ from gnomad.resources.grch37.gnomad import coverage, public_release
 from gnomad.resources.grch37.reference_data import vep_context
 from gnomad.resources.resource_utils import DataException
 from gnomad.utils.file_utils import file_exists
-from gnomad.utils.vep import LOF_CSQ_SET
 
 from rmc.resources.basics import (
     SINGLE_BREAK_TEMP_PATH,
@@ -24,7 +23,7 @@ from rmc.resources.reference_data import (
     gene_model,
     ndd_de_novo,
 )
-from rmc.resources.resource_utils import MISSENSE, SYNONYMOUS, READ_THROUGH
+from rmc.resources.resource_utils import MISSENSE, NONSENSES, READ_THROUGH, SYNONYMOUS
 from rmc.resources.rmc import (
     CURRENT_FREEZE,
     FINAL_ANNOTATIONS,
@@ -278,7 +277,7 @@ def create_filtered_context_ht(overwrite: bool = True) -> None:
         " annotations..."
     )
     # NOTE: Constraint outlier transcripts are not removed
-    csq = {MISSENSE, SYNONYMOUS, READ_THROUGH}.union(LOF_CSQ_SET)
+    csq = {MISSENSE, SYNONYMOUS, READ_THROUGH}.union(NONSENSES)
     ht = process_context_ht(filter_csq=True, csq=csq)
 
     logger.info(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -381,7 +381,7 @@ def create_constraint_prep_ht(
     ).drop("start", "stop")
     ht = ht.key_by("locus", "section").drop("transcript")
 
-    ht = ht.write(constraint_prep.path, overwrite=overwrite)
+    ht.write(constraint_prep.path, overwrite=overwrite)
     # TODO: Repartition?
 
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -391,7 +391,6 @@ def create_constraint_prep_ht(
     ht = ht.key_by("locus", "section").drop("start", "stop", "transcript")
 
     ht.write(constraint_prep.path, overwrite=overwrite)
-    # TODO: Repartition?
 
 
 def get_obs_exp_expr(
@@ -1196,7 +1195,8 @@ def get_oe_annotation(ht: hl.Table, freeze: int) -> hl.Table:
     :param freeze: RMC data freeze number.
     :return: Table with `oe` annotation.
     """
-    ht = constraint_prep.ht().select_globals()
+    # Repartition on read
+    ht = hl.read_table(constraint_prep.path, _n_partitions=15000).select_globals()
     group_ht = ht.group_by("transcript").aggregate(
         obs=hl.agg.sum(ht.observed),
         exp=hl.agg.sum(ht.expected),

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -22,7 +22,7 @@ from rmc.resources.reference_data import (
     gene_model,
     ndd_de_novo,
 )
-from rmc.resources.resource_utils import MISSENSE, NONSENSES, READ_THROUGH, SYNONYMOUS
+from rmc.resources.resource_utils import KEEP_CODING_CSQ, MISSENSE
 from rmc.resources.rmc import (
     CURRENT_FREEZE,
     FINAL_ANNOTATIONS,
@@ -239,7 +239,7 @@ def calculate_exp_from_mu(
 
 
 def create_filtered_context_ht(
-    csq: Set[str] = {MISSENSE, READ_THROUGH, SYNONYMOUS}.union(NONSENSES),
+    csq: Set[str] = KEEP_CODING_CSQ,
     n_partitions: int = 30000,
     overwrite: bool = False,
 ) -> None:
@@ -252,8 +252,7 @@ def create_filtered_context_ht(
     protein-coding transcripts as annotated by VEP. Table is filtered to alleles not found
     or rare in gnomAD exomes at covered sites.
 
-    :param csq: Variant consequences to filter Table to.
-        Default is the missense, read-through, synonymous, and nonsense consequences.
+    :param csq: Variant consequences to filter Table to. Default is `KEEP_CODING_CSQ`.
     :param n_partitions: Number of desired partitions for the Table. Default is 30000.
     :param overwrite: Whether to overwrite temporary data. Default is False.
     :return: None; writes Table to path.

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -293,6 +293,7 @@ def create_filtered_context_ht(
         overwrite=overwrite_temp,
     )
 
+    # TODO: Import models built in gnomad-constraint rather than rebuilding here
     logger.info("Building plateau and coverage models...")
     coverage_ht = prop_obs_coverage.ht()
     coverage_x_ht = hl.read_table(prop_obs_coverage.path.replace(".ht", "_x.ht"))

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -121,7 +121,9 @@ def get_fwd_cumulative_count_expr(
     """
     Return annotation with the cumulative number of variant counts (non-inclusive).
 
-    Value is non-inclusive (does not include value of row) due to the nature of `hl.scan`
+    Function can return either the cumulative expected and observed counts.
+    
+    Value returned is non-inclusive (does not include value of row) due to the nature of `hl.scan`
     and needs to be corrected later.
 
     This function can produce the scan when searching for the first break or when searching for additional break(s).
@@ -172,7 +174,7 @@ def calculate_exp_from_mu(
     groupings: List[str] = GROUPINGS,
 ) -> hl.Table:
     """
-    Annotate Table with the per-allele expected counts based on the per-allele mu.
+    Annotate Table with the per-variant (locus+allele) expected counts based on the per-variant mu.
 
     .. note::
         - Assumes that input Table is annotated with all of the fields in `groupings` and that
@@ -184,12 +186,12 @@ def calculate_exp_from_mu(
             (`coverage_model`, `plateau_models`).
         - Adds `expected` and `coverage_correction` annotations.
 
-    :param context_ht: Allele-level input context Table.
+    :param context_ht: Variant-level input context Table.
     :param locus_type: Locus type of input Table. One of "X", "Y", or "autosomes".
         NOTE: Will treat any input other than "X" or "Y" as autosomes.
     :param groupings: List of Table fields used to group Table to adjust mutation rate.
         Table must be annotated with these fields. Default is `GROUPINGS`.
-    :return: Table annotated with per-allele expected counts and coverage correction.
+    :return: Table annotated with per-variant expected counts and coverage correction.
     """
     logger.info(
         "Grouping by %s and aggregating mutation rates within groupings...", groupings

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -239,17 +239,22 @@ def calculate_exp_from_mu(
 
 
 def create_filtered_context_ht(
-    n_partitions: int = 30000, overwrite_temp: bool = False, overwrite: bool = True
+    csq: Set[str] = {MISSENSE, READ_THROUGH, SYNONYMOUS}.union(NONSENSES),
+    n_partitions: int = 30000,
+    overwrite_temp: bool = False,
+    overwrite: bool = True,
 ) -> None:
     """
     Create allele-level VEP context Table with constraint annotations including expected variant counts.
 
     This Table is used to create the constraint prep Table.
 
-    Table contains only missense, nonsense, and synonymous alleles in all canonical protein-coding
-    transcripts as annotated by VEP. Table is filtered to alleles not found or rare in gnomAD exomes
-    at covered sites.
+    Table contains only missense, nonsense, read-through, and synonymous alleles in all canonical
+    protein-coding transcripts as annotated by VEP. Table is filtered to alleles not found
+    or rare in gnomAD exomes at covered sites.
 
+    :param csq: Variant consequences to filter Table to.
+        Default is the missense, read-through, synonymous, and nonsense consequences.
     :param n_partitions: Number of desired partitions for the Table. Default is 30000.
     :param overwrite_temp: Whether to overwrite temporary data. Default is False.
     :param overwrite: Whether to overwrite output Table. Default is True.
@@ -261,7 +266,6 @@ def create_filtered_context_ht(
         " annotations..."
     )
     # NOTE: Constraint outlier transcripts are not removed
-    csq = {MISSENSE, SYNONYMOUS, READ_THROUGH}.union(NONSENSES)
     ht = process_context_ht(filter_csq=csq)
 
     logger.info(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -358,12 +358,8 @@ def create_constraint_prep_ht(
     # Context HT is keyed by locus and allele, which means there is one row for every possible missense variant
     # This means that any locus could be present up to three times (once for each possible missense)
     ht = ht.group_by("locus", "transcript").aggregate(
-        mu_snp=hl.sum(ht.mu_snp),
         observed=hl.sum(ht.observed),
         expected=hl.sum(ht.expected),
-        # Locus should have the same coverage across the possible variants
-        coverage=ht.coverage[0],
-        # TODO: Remove mu_snp and coverage fields since we don't use them
     )
 
     logger.info("Adding section annotation...")

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -136,7 +136,7 @@ def get_fwd_cumulative_count_expr(
     return hl.scan.group_by(group_expr, hl.scan.sum(count_expr))
 
 
-def adjust_cumulative_count_expr(
+def adjust_fwd_cumulative_count_expr(
     cumulative_count_expr: hl.expr.DictExpression,
     count_expr: hl.expr.Int64Expression,
     group_expr: hl.expr.StringExpression,
@@ -457,7 +457,7 @@ def annotate_fwd_exprs(ht: hl.Table) -> hl.Table:
     """
     logger.info("Getting forward cumulative observed and expected variant counts...")
     ht = ht.annotate(
-        fwd_cumulative_obs=adjust_cumulative_count_expr(
+        fwd_cumulative_obs=adjust_fwd_cumulative_count_expr(
             cumulative_count_expr=get_fwd_cumulative_count_expr(
                 group_expr=ht.section,
                 count_expr=ht.observed,
@@ -465,7 +465,7 @@ def annotate_fwd_exprs(ht: hl.Table) -> hl.Table:
             count_expr=ht.observed,
             group_expr=ht.section,
         ),
-        fwd_cumulative_exp=adjust_cumulative_count_expr(
+        fwd_cumulative_exp=adjust_fwd_cumulative_count_expr(
             cumulative_count_expr=get_fwd_cumulative_count_expr(
                 group_expr=ht.section,
                 count_expr=ht.expected,
@@ -1244,9 +1244,7 @@ def create_context_with_oe(
         .select_globals()
         .select("vep", "was_split")
     )
-    ht = process_vep(
-        ht, filter_csq={missense_str}, filter_outlier_transcripts=True
-    )
+    ht = process_vep(ht, filter_csq={missense_str}, filter_outlier_transcripts=True)
     ht = ht.filter(transcripts.contains(ht.transcript_consequences.transcript_id))
     ht = get_annotations_from_context_ht_vep(ht)
     # Save context Table to temporary path with specified deletion policy because this is a very large file

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -534,15 +534,15 @@ def get_dpois_expr(
     exp_expr: hl.expr.Float64Expression,
 ) -> hl.expr.StructExpression:
     """
-    Calculate probability density (natural log) of the observed values under a Poisson model.
+    Calculate probability densities (natural log) of the observed values under a Poisson model.
 
-    Rate in model given by expected * observed/expected values.
+    Poisson rate for each region is defined as expected * given observed/expected values.
 
     :param cond_expr: Conditional expression to check before calculating probability.
     :param oe_expr: Expression of observed/expected value.
     :param obs_expr: Expression containing observed variants count.
     :param exp_expr: Expression containing expected variants count.
-    :return: natural log of the probability under Poisson model.
+    :return: Natural log of the probability density under Poisson model.
     """
     # log_p = True returns the natural logarithm of the probability density
     return hl.or_missing(
@@ -1047,7 +1047,7 @@ def calculate_oe_neq_1_chisq(
     exp_expr: hl.expr.Float64Expression,
 ) -> hl.expr.Float64Expression:
     """
-    Check for significance of observed/expected being different from 1.
+    Check for significance that observed/expected values for regions are different from 1.
 
     Formula is: (obs - exp)^2 / exp.
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -280,7 +280,7 @@ def create_filtered_context_ht(overwrite: bool = True) -> None:
     )
     # NOTE: Constraint outlier transcripts are not removed
     csq = {MISSENSE, SYNONYMOUS, READ_THROUGH}.union(NONSENSES)
-    ht = process_context_ht(filter_csq=True, csq=csq)
+    ht = process_context_ht(filter_csq=csq)
 
     logger.info(
         "Filtering context HT to all covered sites not found or rare in gnomAD"
@@ -347,7 +347,7 @@ def create_filtered_context_ht(overwrite: bool = True) -> None:
 
 
 def create_constraint_prep_ht(
-    filter_csq: bool = True, csq: Set[str] = {MISSENSE}, overwrite: bool = True
+    filter_csq: Set[str] = {MISSENSE}, overwrite: bool = True
 ) -> None:
     """
     Create locus-level constraint prep Table from filtered context Table for all canonical protein-coding transcripts.
@@ -363,10 +363,8 @@ def create_constraint_prep_ht(
     """
     ht = filtered_context.ht()
     if filter_csq:
-        if not csq:
-            raise DataException("Need to specify consequence if filter_csq is True!")
-        logger.info("Filtering to %s...", csq)
-        ht = ht.filter(hl.literal(csq).contains(ht.annotation))
+        logger.info("Filtering to %s...", filter_csq)
+        ht = ht.filter(hl.literal(filter_csq).contains(ht.annotation))
 
     logger.info("Aggregating by locus...")
     # Context HT is keyed by locus and allele, which means there is one row for every possible missense variant
@@ -1247,7 +1245,7 @@ def create_context_with_oe(
         .select("vep", "was_split")
     )
     ht = process_vep(
-        ht, filter_csq=True, csq={missense_str}, filter_outlier_transcripts=True
+        ht, filter_csq={missense_str}, filter_outlier_transcripts=True
     )
     ht = ht.filter(transcripts.contains(ht.transcript_consequences.transcript_id))
     ht = get_annotations_from_context_ht_vep(ht)

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -187,10 +187,8 @@ def process_context_ht(
     ht = vep_context.ht().select_globals()
 
     logger.info(
-        (
-            "Filtering to canonical transcripts and annotating variants with most"
-            " severe consequence..."
-        ),
+        "Filtering to canonical transcripts and annotating variants with most"
+        " severe consequence...",
     )
     ht = process_vep(
         ht,

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -481,6 +481,7 @@ def process_vep(
         if not csq:
             raise DataException("Need to specify consequence if filter_csq is True!")
         logger.info("Filtering to %s...", csq)
+        csq = hl.literal(csq)
         ht = ht.filter(csq.contains(ht.transcript_consequences.most_severe_consequence))
     return ht
 

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -173,7 +173,7 @@ def process_context_ht(
     This function offers options to filter to specific variant consequences and add annotations
     to prepare for regional missense constraint calculations.
 
-    :param Set[str] csq: Specific consequences to keep. Default is None.
+    :param Set[str] filter_csq: Specific consequences to keep. Default is None.
     :param bool filter_outlier_transcripts: Whether to remove constraint outlier transcripts from Table. Default is False.
     :param bool add_annotations: Whether to add `context`, `ref`, `alt`, `methylation_level`, `cpg`,
         `mutation_type`, `annotation`, `modifier`, `coverage`, `transcript`, and `mu_snp` annotations.
@@ -475,7 +475,9 @@ def process_vep(
     if filter_csq:
         logger.info("Filtering to %s...", filter_csq)
         ht = ht.filter(
-            hl.literal(csq).contains(ht.transcript_consequences.most_severe_consequence)
+            hl.literal(filter_csq).contains(
+                ht.transcript_consequences.most_severe_consequence
+            )
         )
     return ht
 

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -182,7 +182,7 @@ def process_context_ht(
         NOTE: `coverage` replaces `exome_coverage` in name.
         Default is True.
     :return: VEP context HT filtered to canonical transcripts and optionally filtered to variants
-        in non-outlier transcripts with specific consequences annotated with mutation rate etc.
+        in non-outlier transcripts with specific consequences and annotated with mutation rate etc.
     :rtype: hl.Table
     """
     logger.info("Reading in SNPs-only, VEP-annotated context ht...")

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -481,8 +481,9 @@ def process_vep(
         if not csq:
             raise DataException("Need to specify consequence if filter_csq is True!")
         logger.info("Filtering to %s...", csq)
-        csq = hl.literal(csq)
-        ht = ht.filter(csq.contains(ht.transcript_consequences.most_severe_consequence))
+        ht = ht.filter(
+            hl.literal(csq).contains(ht.transcript_consequences.most_severe_consequence)
+        )
     return ht
 
 

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -163,8 +163,7 @@ def annotate_and_filter_codons(ht: hl.Table) -> hl.Table:
 ## Reference genome processing-related utils
 ####################################################################################
 def process_context_ht(
-    filter_csq: bool = False,
-    csq: Set[str] = None,
+    filter_csq: Set[str] = None,
     filter_outlier_transcripts: bool = False,
     add_annotations: bool = True,
 ) -> hl.Table:
@@ -174,8 +173,7 @@ def process_context_ht(
     This function offers options to filter to specific variant consequences and add annotations
     to prepare for regional missense constraint calculations.
 
-    :param bool filter_csq: Whether to filter Table to specific consequences. Default is False.
-    :param Set[str] csq: Desired consequences. Default is None. Must be specified if filter is True.
+    :param Set[str] csq: Specific consequences to keep. Default is None.
     :param bool filter_outlier_transcripts: Whether to remove constraint outlier transcripts from Table. Default is False.
     :param bool add_annotations: Whether to add `context`, `ref`, `alt`, `methylation_level`, `cpg`,
         `mutation_type`, `annotation`, `modifier`, `coverage`, `transcript`, and `mu_snp` annotations.
@@ -197,7 +195,6 @@ def process_context_ht(
     ht = process_vep(
         ht,
         filter_csq=filter_csq,
-        csq=csq,
         filter_outlier_transcripts=filter_outlier_transcripts,
     )
 
@@ -438,8 +435,7 @@ def keep_criteria(
 
 def process_vep(
     ht: hl.Table,
-    filter_csq: bool = False,
-    csq: Set[str] = None,
+    filter_csq: Set[str] = None,
     filter_outlier_transcripts: bool = False,
 ) -> hl.Table:
     """
@@ -448,8 +444,7 @@ def process_vep(
     Option to filter Table to specific variant consequences and remove constraint outlier transcripts.
 
     :param Table ht: Input Table.
-    :param bool filter_csq: Whether to filter Table to specific consequences. Default is False.
-    :param Set[str] csq: Desired consequences. Default is None. Must be specified if filter is True.
+    :param Set[str] filter_csq: Specific consequences to keep. Default is None.
     :param bool filter_outlier_transcripts: Whether to remove constraint outlier transcripts from Table.
         Default is False.
     :return: Table filtered to canonical transcripts with option to filter to specific variant consequences
@@ -478,9 +473,7 @@ def process_vep(
         )
 
     if filter_csq:
-        if not csq:
-            raise DataException("Need to specify consequence if filter_csq is True!")
-        logger.info("Filtering to %s...", csq)
+        logger.info("Filtering to %s...", filter_csq)
         ht = ht.filter(
             hl.literal(csq).contains(ht.transcript_consequences.most_severe_consequence)
         )

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -6,6 +6,7 @@ from gnomad.utils.file_utils import file_exists
 
 from rmc.resources.basics import TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.reference_data import FOLD_K, train_val_test_transcripts_path
+from rmc.resources.resource_utils import MISSENSE, NONSENSES, READ_THROUGH, SYNONYMOUS
 from rmc.resources.rmc import CURRENT_FREEZE, amino_acids_oe_path, misbad_path
 from rmc.utils.constraint import add_obs_annotation, get_oe_annotation
 from rmc.utils.generic import (
@@ -57,7 +58,9 @@ def prepare_amino_acid_ht(
     # NOTE: Keeping all variant types here because need synonymous and nonsense variants to calculate missense badness
     # Filter to non-outlier transcripts for missense badness calculation
     context_ht = process_context_ht(
-        filter_outlier_transcripts=True, add_annotations=False
+        filter_csq={MISSENSE, READ_THROUGH, SYNONYMOUS}.union(NONSENSES),
+        filter_outlier_transcripts=True,
+        add_annotations=False,
     )
 
     logger.info("Selecting relevant annotations...")

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -6,7 +6,7 @@ from gnomad.utils.file_utils import file_exists
 
 from rmc.resources.basics import TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.reference_data import FOLD_K, train_val_test_transcripts_path
-from rmc.resources.resource_utils import MISSENSE, NONSENSES, READ_THROUGH, SYNONYMOUS
+from rmc.resources.resource_utils import KEEP_CODING_CSQ
 from rmc.resources.rmc import CURRENT_FREEZE, amino_acids_oe_path, misbad_path
 from rmc.utils.constraint import add_obs_annotation, get_oe_annotation
 from rmc.utils.generic import (
@@ -58,7 +58,7 @@ def prepare_amino_acid_ht(
     # NOTE: Keeping all variant types here because need synonymous and nonsense variants to calculate missense badness
     # Filter to non-outlier transcripts for missense badness calculation
     context_ht = process_context_ht(
-        filter_csq={MISSENSE, READ_THROUGH, SYNONYMOUS}.union(NONSENSES),
+        filter_csq=KEEP_CODING_CSQ,
         filter_outlier_transcripts=True,
         add_annotations=False,
     )

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -57,7 +57,7 @@ def prepare_amino_acid_ht(
     # NOTE: Keeping all variant types here because need synonymous and nonsense variants to calculate missense badness
     # Filter to non-outlier transcripts for missense badness calculation
     context_ht = process_context_ht(
-        filter_csq=False, filter_outlier_transcripts=True, add_annotations=False
+        filter_outlier_transcripts=True, add_annotations=False
     )
 
     logger.info("Selecting relevant annotations...")

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -477,22 +477,20 @@ def get_min_aic_model(
 
     logger.info("Running joint regression with specific interactions...")
     # Currently hardcoded to be formula from ExAC
-    min_model_formulas[
-        "spec"
-    ] = "pop_v_path ~ oe + misbad + oe:misbad + polyphen + oe:polyphen"
+    min_model_formulas["spec"] = (
+        "pop_v_path ~ oe + misbad + oe:misbad + polyphen + oe:polyphen"
+    )
     min_models["spec"] = run_glm(df, min_model_formulas["spec"])
 
     min_model_aics = {x: min_models[x].aic for x in model_types}
     overall_min_aic = min(min_model_aics.values())
     logger.info("Lowest model AIC: %f", overall_min_aic)
     if list(min_model_aics.values()).count(overall_min_aic) > 1:
-        logger.warning(
-            """
+        logger.warning("""
             There is a tie for minimum AIC over model types.
             This function will use the first model it finds by default
             (single variable -> no interactions -> all interactions -> specific interactions)!
-            """
-        )
+            """)
     overall_min_model_type = list(min_model_aics.keys())[
         list(min_model_aics.values()).index(overall_min_aic)
     ]

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -247,11 +247,8 @@ def calculate_window_chisq(
                     # The missense values for this section are the cumulative values at
                     # one index smaller than index i
                     get_dpois_expr(
-                        cond_expr=True,
                         oe_expr=get_obs_exp_expr(
-                            True,
-                            cum_obs[i - 1],
-                            hl.max(cum_exp[i - 1], 1e-09),
+                            cum_obs[i - 1], hl.max(cum_exp[i - 1], 1e-09)
                         ),
                         obs_expr=cum_obs[i - 1],
                         exp_expr=hl.max(cum_exp[i - 1], 1e-09),
@@ -260,9 +257,7 @@ def calculate_window_chisq(
                     # The missense values for this section are the cumulative values at index j
                     # minus the cumulative values at index i -1
                     + get_dpois_expr(
-                        cond_expr=True,
                         oe_expr=get_obs_exp_expr(
-                            True,
                             (cum_obs[j] - cum_obs[i - 1]),
                             hl.max(cum_exp[j] - cum_exp[i - 1], 1e-09),
                         ),
@@ -273,9 +268,7 @@ def calculate_window_chisq(
                     # The missense values for this section are the cumulative values at the last index
                     # minus the cumulative values at index j
                     + get_dpois_expr(
-                        cond_expr=True,
                         oe_expr=get_obs_exp_expr(
-                            True,
                             (cum_obs[-1] - cum_obs[j]),
                             hl.max(cum_exp[-1] - cum_exp[j], 1e-09),
                         ),
@@ -286,19 +279,16 @@ def calculate_window_chisq(
                 # Create null distribution
                 - (
                     get_dpois_expr(
-                        cond_expr=True,
                         oe_expr=section_oe,
                         obs_expr=cum_obs[i - 1],
                         exp_expr=hl.max(cum_exp[i - 1], 1e-09),
                     )
                     + get_dpois_expr(
-                        cond_expr=True,
                         oe_expr=section_oe,
                         obs_expr=cum_obs[j] - cum_obs[i - 1],
                         exp_expr=hl.max(cum_exp[j] - cum_exp[i - 1], 1e-09),
                     )
                     + get_dpois_expr(
-                        cond_expr=True,
                         oe_expr=section_oe,
                         obs_expr=cum_obs[-1] - cum_obs[j],
                         exp_expr=hl.max(cum_exp[-1] - cum_exp[j], 1e-09),

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -16,8 +16,8 @@ from rmc.resources.rmc import (
     simul_sections_split_by_len_path,
 )
 from rmc.utils.constraint import (
-    get_dpois_expr,
     annotate_max_chisq_per_section,
+    get_dpois_expr,
     get_obs_exp_expr,
 )
 

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -110,10 +110,8 @@ def split_sections_by_len(
     ht = ht.annotate(missense_list_len=ht.max_idx + 1)
 
     logger.info(
-        (
-            "Splitting sections into two categories: list length < %i and list length"
-            " >= %i..."
-        ),
+        "Splitting sections into two categories: list length < %i and list length"
+        " >= %i...",
         missense_len_threshold,
         missense_len_threshold,
     )

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -71,7 +71,7 @@ def group_no_single_break_found_ht(
             ),
             key=lambda x: x.locus,
         ),
-        total_oe=hl.agg.take(ht.section_oe, 1)[0],
+        section_oe=hl.agg.take(ht.section_oe, 1)[0],
     )
     group_ht = group_ht.annotate(max_idx=hl.len(group_ht.values.positions) - 1)
     group_ht = group_ht.transmute(
@@ -209,7 +209,7 @@ def calculate_window_chisq(
     j: hl.expr.Int32Expression,
     cum_obs: hl.expr.ArrayExpression,
     cum_exp: hl.expr.ArrayExpression,
-    total_oe: hl.expr.Float64Expression,
+    section_oe: hl.expr.Float64Expression,
     min_num_exp_mis: hl.expr.Float64Expression,
 ) -> hl.expr.Float64Expression:
     """
@@ -224,7 +224,7 @@ def calculate_window_chisq(
     :param hl.expr.Int32Expression j: Larger list index value corresponding to the larger position of the two break window.
     :param hl.expr.ArrayExpression cum_obs: List containing cumulative observed missense values.
     :param hl.expr.ArrayExpression cum_exp: List containing cumulative expected missense values.
-    :param hl.expr.Float64Expression total_oe: Transcript/transcript section overall observed/expected (OE) missense ratio.
+    :param hl.expr.Float64Expression section_oe: Transcript/transcript section overall observed/expected (OE) missense ratio.
     :param hl.expr.Float64Expression min_num_exp_mis: Minimum expected missense value for all three windows defined by two possible
         simultaneous breaks.
     :return: Chi square significance value.
@@ -287,19 +287,19 @@ def calculate_window_chisq(
                 - (
                     get_dpois_expr(
                         cond_expr=True,
-                        oe_expr=total_oe,
+                        oe_expr=section_oe,
                         obs_expr=cum_obs[i - 1],
                         exp_expr=hl.max(cum_exp[i - 1], 1e-09),
                     )
                     + get_dpois_expr(
                         cond_expr=True,
-                        oe_expr=total_oe,
+                        oe_expr=section_oe,
                         obs_expr=cum_obs[j] - cum_obs[i - 1],
                         exp_expr=hl.max(cum_exp[j] - cum_exp[i - 1], 1e-09),
                     )
                     + get_dpois_expr(
                         cond_expr=True,
-                        oe_expr=total_oe,
+                        oe_expr=section_oe,
                         obs_expr=cum_obs[-1] - cum_obs[j],
                         exp_expr=hl.max(cum_exp[-1] - cum_exp[j], 1e-09),
                     )
@@ -361,7 +361,7 @@ def search_for_two_breaks(
                         j,
                         group_ht.cum_obs,
                         group_ht.cum_exp,
-                        group_ht.total_oe,
+                        group_ht.section_oe,
                         min_num_exp_mis,
                     ),
                     -1,

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -519,8 +519,8 @@ def process_section_group(
         )
         ht = ht.checkpoint(
             f"{prep_path}/{section_group[0]}.ht",
-            overwrite=not read_if_exists,
             _read_if_exists=read_if_exists,
+            overwrite=not read_if_exists,
         )
     else:
         # Add start_idx struct with i_start, j_start, i_max_idx, j_max_idx annotations


### PR DESCRIPTION
This PR does some major restructuring around the resources used to prepare for breakpoint search, particularly in discarding the workaround method to calculate expected values and adding some flexibility to add constraint-related annotations to synonymous and nonsense variants.


Major changes:
- Change expected value calculation from workaround method using `mu_snp` and `total_exp` to the actual formula as defined by Konrad in LoF constraint analyses, and remove code thus rendered obsolete
- Restructure `filtered_context` to contain missense, nonsense, and synonymous variants and all constraint annotations including `observed` and `expected`
    - This necessitates changes to `process_context_ht` and `process_vep`
- Command-line arguments can be used to determine whether `constraint_prep` contains missense, nonsense, and/or synonymous variants
- Perform break search on all transcripts, meaning constraint outliers are not filtered out of `filtered_context` or `constraint_prep`
- Add filtering downstream of RMC to remove constraint outliers from steps like MPC generation
- Move Table prep code out of `regional_constraint.py` pipeline script and into utils
- Change break search-associated util/annotation names and structures to be more intuitive

Minor changes:
- Update RMC freeze version to `7`
- Revise parser structure in `regional_constraint.py` to use subparsers for the different steps
- Update flagship LoF bucket path
- Remove unused resources and constants
- Add new constants for nonsense and synonymous VEP labels
- Save coverage and plateau models used to calculate expected values to HailExpression
- Remove `exome_coverage` field and retain `coverage` field for constraint annotations
- Remove `gene` from groupings used to calculate expected values (transcript should be sufficient)
- Remove unused lines in `add_obs_annotation`
- Move `section` annotation creation into constraint prep HT
- Change name of function + function parameters used to calculate chisq of section OE being different from 1 to be more intuitive
- Update some docstrings and spacing