### PR TITLE
Runtime branch for RMC freeze7

### DIFF
--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -81,7 +81,7 @@ def main(args):
                     "Pipeline is currently set up to run on missenses. Please make sure"
                     " all missense-relevant files are deleted before running."
                 )
-            n_partitions = 150000
+            n_partitions = 15000
             create_constraint_prep_ht(
                 filter_csq=csq,
                 n_partitions=args.n_partitions if args.n_partitions else n_partitions,

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -405,13 +405,13 @@ def main(args):
                 p_value = args.p_value
             rmc_ht = rmc_ht.annotate_globals(p_value=p_value)
 
-            logger.info("Writing out RMC results...")
-            rmc_ht.write(
-                rmc_results.versions[args.freeze].path, overwrite=args.overwrite
-            )
+            # logger.info("Writing out RMC results...")
+            # rmc_ht.write(
+            #     rmc_results.versions[args.freeze].path, overwrite=args.overwrite
+            # )
 
-            logger.info("Getting transcripts without evidence of RMC...")
-            create_no_breaks_he(freeze=args.freeze, overwrite=args.overwrite)
+            # logger.info("Getting transcripts without evidence of RMC...")
+            # create_no_breaks_he(freeze=args.freeze, overwrite=args.overwrite)
 
             logger.info("Creating OE-annotated context table...")
             create_context_with_oe(

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -81,7 +81,7 @@ def main(args):
                     "Pipeline is currently set up to run on missenses. Please make sure"
                     " all missense-relevant files are deleted before running."
                 )
-            n_partitions = 15000
+            n_partitions = 10000
             create_constraint_prep_ht(
                 filter_csq=csq,
                 n_partitions=args.n_partitions if args.n_partitions else n_partitions,
@@ -405,13 +405,13 @@ def main(args):
                 p_value = args.p_value
             rmc_ht = rmc_ht.annotate_globals(p_value=p_value)
 
-            # logger.info("Writing out RMC results...")
-            # rmc_ht.write(
-            #     rmc_results.versions[args.freeze].path, overwrite=args.overwrite
-            # )
+            logger.info("Writing out RMC results...")
+            rmc_ht.write(
+                rmc_results.versions[args.freeze].path, overwrite=args.overwrite
+            )
 
-            # logger.info("Getting transcripts without evidence of RMC...")
-            # create_no_breaks_he(freeze=args.freeze, overwrite=args.overwrite)
+            logger.info("Getting transcripts without evidence of RMC...")
+            create_no_breaks_he(freeze=args.freeze, overwrite=args.overwrite)
 
             logger.info("Creating OE-annotated context table...")
             create_context_with_oe(

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -126,7 +126,8 @@ def main(args):
                             constraint_prep.path,
                             _n_partitions=args.n_partitions,
                         )
-                    ht = constraint_prep.ht()
+                    else:
+                        ht = constraint_prep.ht()
 
             else:
                 logger.info(

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -121,6 +121,11 @@ def main(args):
                 else:
                     # Read `constraint_prep` resource HT if this is the first search
                     logger.info("Reading in constraint prep HT...")
+                    if args.n_partitions:
+                        ht = hl.read_table(
+                            constraint_prep.path,
+                            _n_partitions=args.n_partitions,
+                        )
                     ht = constraint_prep.ht()
 
             else:

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -374,7 +374,11 @@ def main(args):
             round_nums = check_break_search_round_nums(args.freeze)
 
             logger.info("Finalizing section-level RMC table...")
-            rmc_ht = merge_rmc_hts(round_nums=round_nums, freeze=args.freeze)
+            rmc_ht = merge_rmc_hts(
+                round_nums=round_nums,
+                freeze=args.freeze,
+                overwrite_temp=args.overwrite_temp,
+            )
             # Drop any unnecessary global fields
             rmc_ht = rmc_ht.select_globals()
             rmc_ht = rmc_ht.checkpoint(

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -291,10 +291,8 @@ def main(args):
             else:
                 simul_exists = False
                 logger.info(
-                    (
-                        "No sections in round %i had breakpoints in simultaneous breaks"
-                        " search."
-                    ),
+                    "No sections in round %i had breakpoints in simultaneous breaks"
+                    " search.",
                     args.search_num,
                 )
 
@@ -357,10 +355,8 @@ def main(args):
                 simul_break_ht.write(merged_path, overwrite=args.overwrite)
             else:
                 logger.info(
-                    (
-                        "No sections in round %i had breakpoints (neither in single nor"
-                        " in simultaneous search)."
-                    ),
+                    "No sections in round %i had breakpoints (neither in single nor"
+                    " in simultaneous search).",
                     args.search_num,
                 )
 

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -291,8 +291,10 @@ def main(args):
             else:
                 simul_exists = False
                 logger.info(
-                    "No sections in round %i had breakpoints in simultaneous breaks"
-                    " search.",
+                    (
+                        "No sections in round %i had breakpoints in simultaneous breaks"
+                        " search."
+                    ),
                     args.search_num,
                 )
 
@@ -355,8 +357,10 @@ def main(args):
                 simul_break_ht.write(merged_path, overwrite=args.overwrite)
             else:
                 logger.info(
-                    "No sections in round %i had breakpoints (neither in single nor"
-                    " in simultaneous search).",
+                    (
+                        "No sections in round %i had breakpoints (neither in single nor"
+                        " in simultaneous search)."
+                    ),
                     args.search_num,
                 )
 

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -706,7 +706,7 @@ def main(args):
                 j.memory(args.batch_memory)
                 j.cpu(args.batch_cpu)
                 j.storage(args.batch_storage)
-            
+
             j.call(
                 process_section_group,
                 ht_path=grouped_single_no_break_ht_path(args.search_num, args.freeze),

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -616,7 +616,7 @@ def main(args):
             )
         # Otherwise, use the default docker image
         else:
-            args.docker_image = "gcr.io/broad-mpg-gnomad/tgg-methods-vm:20230123"
+            args.docker_image = "us-central1-docker.pkg.dev/broad-mpg-gnomad/images/rmc_simul_search"
             logger.warning(
                 "Using %s image; please make sure Hail version in image is up to date",
                 args.docker_image,

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -664,6 +664,10 @@ def main(args):
             j.memory(args.batch_memory)
             j.cpu(args.batch_cpu)
             j.storage(args.batch_storage)
+            # NOTE: This section has been commented out due to a Hail bug
+            # The bug makes us unable to pass keyword args to a PythonJob
+            # See: https://hail.zulipchat.com/#narrow/stream/223457-Hail-Batch-support/topic/j.2Ecall.28.29.20ValueError.3A.20too.20many.20values.20to.20unpack.20.28expected.202.29
+            # TODO: Revert to keyword args when the above bug has been fixed
             # j.call(
             #     process_section_group,
             #     ht_path=grouped_single_no_break_ht_path(args.search_num, args.freeze),

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -759,7 +759,7 @@ def main(args):
                 args.freeze,
             )
             count += 1
-    b.run()
+    b.run(wait=False)
 
 
 if __name__ == "__main__":

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -610,13 +610,12 @@ def main(args):
         # Use a docker image that specifies spark memory allocation if --use-custom-machine was specified
         if args.use_custom_machine:
             args.docker_image = "gcr.io/broad-mpg-gnomad/rmc:20220930"
-            logger.warning(
-                "Using %s image; please make sure Hail version in image is up to date",
-                args.docker_image,
-            )
+            raise DataException(f"Hail in {args.docker_image} image is out of date!")
         # Otherwise, use the default docker image
         else:
-            args.docker_image = "us-central1-docker.pkg.dev/broad-mpg-gnomad/images/rmc_simul_search"
+            args.docker_image = (
+                "us-central1-docker.pkg.dev/broad-mpg-gnomad/images/rmc_simul_search"
+            )
             logger.warning(
                 "Using %s image; please make sure Hail version in image is up to date",
                 args.docker_image,
@@ -860,7 +859,7 @@ if __name__ == "__main__":
         "--docker-image",
         help="""
         Docker image to provide to hail Batch. Must have dill, hail, and python installed.
-        Suggested image: gcr.io/broad-mpg-gnomad/tgg-methods-vm:20230123.
+        Suggested image: us-central1-docker.pkg.dev/broad-mpg-gnomad/images/rmc_simul_search.
 
         If running with --use-custom-machine, Docker image must also contain this line:
         `ENV PYSPARK_SUBMIT_ARGS="--driver-memory 8g --executor-memory 8g pyspark-shell"`

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -146,7 +146,7 @@ def get_obs_exp_expr(
     """
     # Cap the o/e ratio at 1 to avoid pulling out regions that are enriched for missense variation
     # Code is looking for missense constraint, so regions with a ratio of >= 1.0 can be grouped together
-    return hl.min(obs_expr / exp_expr, 1)
+    return hl.nanmin(obs_expr / exp_expr, 1)
 
 
 def get_dpois_expr(
@@ -664,42 +664,24 @@ def main(args):
             j.memory(args.batch_memory)
             j.cpu(args.batch_cpu)
             j.storage(args.batch_storage)
-            # NOTE: This section has been commented out due to a Hail bug
-            # The bug makes us unable to pass keyword args to a PythonJob
+            # NOTE: This section was commented out due to a Hail bug
+            # The bug made us unable to pass keyword args to a PythonJob
             # See: https://hail.zulipchat.com/#narrow/stream/223457-Hail-Batch-support/topic/j.2Ecall.28.29.20ValueError.3A.20too.20many.20values.20to.20unpack.20.28expected.202.29
-            # TODO: Revert to keyword args when the above bug has been fixed
-            # j.call(
-            #     process_section_group,
-            #     ht_path=grouped_single_no_break_ht_path(args.search_num, args.freeze),
-            #     section_group=group,
-            #     count=group_num,
-            #     search_num=args.search_num,
-            #     over_threshold=False,
-            #     output_ht_path=f"{raw_path}/simul_break_{job_name}.ht",
-            #     output_n_partitions=args.output_n_partitions,
-            #     chisq_threshold=chisq_threshold,
-            #     split_list_len=args.group_size,
-            #     save_chisq_ht=args.save_chisq_ht,
-            #     google_project=args.google_project,
-            #     freeze=args.freeze,
-            # ) # TODO: Uncomment this once hail bug is fixed and remove the call below
+            # Revert to keyword args since the above bug is fixed in 0.2.122
             j.call(
                 process_section_group,
-                grouped_single_no_break_ht_path(args.search_num, args.freeze),
-                group,
-                group_num,
-                args.search_num,
-                False,
-                f"{raw_path}/simul_break_{job_name}.ht",
-                args.output_n_partitions,
-                chisq_threshold,
-                MIN_EXP_MIS,
-                args.group_size,
-                False,
-                args.save_chisq_ht,
-                RMC_PREFIX,
-                args.google_project,
-                args.freeze,
+                ht_path=grouped_single_no_break_ht_path(args.search_num, args.freeze),
+                section_group=group,
+                count=group_num,
+                search_num=args.search_num,
+                over_threshold=False,
+                output_ht_path=f"{raw_path}/simul_break_{job_name}.ht",
+                output_n_partitions=args.output_n_partitions,
+                chisq_threshold=chisq_threshold,
+                split_list_len=args.group_size,
+                save_chisq_ht=args.save_chisq_ht,
+                google_project=args.google_project,
+                freeze=args.freeze,
             )
             count += 1
 
@@ -724,39 +706,21 @@ def main(args):
                 j.memory(args.batch_memory)
                 j.cpu(args.batch_cpu)
                 j.storage(args.batch_storage)
-            # See note above
-            # j.call(
-            #     process_section_group,
-            #     ht_path=grouped_single_no_break_ht_path(args.search_num, args.freeze),
-            #     section_group=group,
-            #     count=group_num,
-            #     search_num=args.search_num,
-            #     over_threshold=True,
-            #     output_ht_path=f"{raw_path}/simul_break_{group[0]}.ht",
-            #     output_n_partitions=args.output_n_partitions,
-            #     chisq_threshold=chisq_threshold,
-            #     split_list_len=args.group_size,
-            #     save_chisq_ht=args.save_chisq_ht,
-            #     google_project=args.google_project,
-            #     freeze=args.freeze,
-            # ) # TODO: Uncomment this once hail bug is fixed and remove the call below
+            
             j.call(
                 process_section_group,
-                grouped_single_no_break_ht_path(args.search_num, args.freeze),
-                group,
-                group_num,
-                args.search_num,
-                True,
-                f"{raw_path}/simul_break_{group[0]}.ht",
-                args.output_n_partitions,
-                chisq_threshold,
-                MIN_EXP_MIS,
-                args.group_size,
-                False,
-                args.save_chisq_ht,
-                RMC_PREFIX,
-                args.google_project,
-                args.freeze,
+                ht_path=grouped_single_no_break_ht_path(args.search_num, args.freeze),
+                section_group=group,
+                count=group_num,
+                search_num=args.search_num,
+                over_threshold=True,
+                output_ht_path=f"{raw_path}/simul_break_{group[0]}.ht",
+                output_n_partitions=args.output_n_partitions,
+                chisq_threshold=chisq_threshold,
+                split_list_len=args.group_size,
+                save_chisq_ht=args.save_chisq_ht,
+                google_project=args.google_project,
+                freeze=args.freeze,
             )
             count += 1
     b.run(wait=False)

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -724,6 +724,7 @@ def main(args):
                 j.memory(args.batch_memory)
                 j.cpu(args.batch_cpu)
                 j.storage(args.batch_storage)
+            # See note above
             # j.call(
             #     process_section_group,
             #     ht_path=grouped_single_no_break_ht_path(args.search_num, args.freeze),

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -622,7 +622,8 @@ def main(args):
             )
             # NOTE: Python version on your local machine must match the Python version in this image
             logger.warning(
-                "Using %s image; please make sure Hail and Python versions in image are up to date",
+                "Using %s image; please make sure Hail and Python versions in image are"
+                " up to date",
                 args.docker_image,
             )
 

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -627,7 +627,7 @@ def main(args):
     backend = hb.ServiceBackend(
         billing_project=args.billing_project,
         remote_tmpdir=args.batch_bucket,
-        google_project=args.google_project,
+        gcs_requester_pays_configuration=args.google_project,
     )
     b = hb.Batch(
         name="simul_breaks",

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -716,7 +716,7 @@ def main(args):
                 freeze=args.freeze,
             )
             count += 1
-    b.run(wait=False)
+    b.run()
 
 
 if __name__ == "__main__":

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -51,6 +51,7 @@ def main(args):
             chisq_threshold = hl.eval(hl.qchisqtail(args.p_value, 2))
 
         if args.run_sections_over_threshold:
+            over_threshold = True
             sections_to_run = list(
                 hl.eval(
                     hl.experimental.read_expression(
@@ -64,6 +65,7 @@ def main(args):
             )
 
         if args.run_sections_under_threshold:
+            over_threshold = False
             sections_to_run = list(
                 hl.eval(
                     hl.experimental.read_expression(
@@ -100,7 +102,11 @@ def main(args):
             freeze=args.freeze,
         )
         for counter, group in enumerate(section_groups):
-            output_ht_path = f"{raw_path}/simul_break_dataproc_{counter}.ht"
+            output_ht_path = (
+                f"{raw_path}/simul_break_dataproc_{counter}.ht"
+                if over_threshold
+                else f"{raw_path}/simul_break_dataproc_under_{counter}.ht"
+            )
             if file_exists(output_ht_path):
                 raise DataException(
                     f"Output already exists at {output_ht_path}! Double check before"

--- a/rmc/resources/basics.py
+++ b/rmc/resources/basics.py
@@ -36,7 +36,7 @@ Path to bucket for temporary files.
 Used when checkpointing intermediate files that can't be deleted immediately.
 """
 
-TEMP_PATH_WITH_FAST_DEL = "gs://panchal-sandbox-tmp-4day/rmc"
+TEMP_PATH_WITH_FAST_DEL = "gs://gnomad-tmp-4day/rmc"
 """
 Path to bucket for temporary files.
 

--- a/rmc/resources/basics.py
+++ b/rmc/resources/basics.py
@@ -36,7 +36,7 @@ Path to bucket for temporary files.
 Used when checkpointing intermediate files that can't be deleted immediately.
 """
 
-TEMP_PATH_WITH_FAST_DEL = "gs://gnomad-tmp-4day/rmc"
+TEMP_PATH_WITH_FAST_DEL = "gs://panchal-sandbox-tmp-4day/rmc"
 """
 Path to bucket for temporary files.
 

--- a/rmc/resources/docker/Dockerfile
+++ b/rmc/resources/docker/Dockerfile
@@ -23,9 +23,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 # Install Java 8 for hail
-RUN wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - \
-    && add-apt-repository -y https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ \
-    && apt-get update && apt-get install -y adoptopenjdk-8-hotspot
+RUN mkdir -p /etc/apt/keyrings
+RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
+    && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" \
+    | tee /etc/apt/sources.list.d/adoptium.list && apt-get update && apt install -y --no-install-recommends temurin-8-jdk
 
 RUN mkdir tools
 WORKDIR /tools
@@ -46,17 +47,12 @@ RUN apt-get update \
     libssl-dev \
     openssl \
     python3-smbus \
-    python3 \
-    python3-pip
+    python3 python3-pip
 
 # Upgrade pip to latest version
 RUN python3 -m pip install --upgrade pip
 
 # Install hail and other python libraries
-# Install hail and other python libraries
-# Including packages needed for VRS annotation functionality
-# Also include version for ga4gh.vrs-python to be most recent and supporting their new variant schema
-# Please update the constant VRS_VERSION in vrs_annotation_batch.py accordingly when GA4GH_VRS_VERSION is changed
 ENV HAIL_VERSION="0.2.120"
 RUN python3 --version
 RUN python3 -m pip install \
@@ -72,7 +68,6 @@ RUN python3 -m pip install \
     pybedtools \
     dill
 
-# Install GCS Connector
 # Install GCS Connector
 RUN curl -sSL broad.io/install-gcs-connector > install-gcs-connector.py && \
     python3 install-gcs-connector.py --key-file-path /gsa-key/key.json

--- a/rmc/resources/docker/Dockerfile
+++ b/rmc/resources/docker/Dockerfile
@@ -3,25 +3,10 @@ FROM 'python:3.11-slim'
 
 # install packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    apt-utils \
     curl \
-    g++ \
-    gawk \
-    less \
-    libbz2-dev \
-    libcurl4-openssl-dev \
-    liblzma-dev \
-    libncurses5-dev \
-    liblz4-dev \
-    man-db \
-    pkg-config \
-    python3-venv \
-    software-properties-common \
-    unzip \
     wget \
-    zlib1g-dev \
     && \
-    # clean up apt cache
+	# clean up apt cache
     rm -rf /var/lib/apt/lists/*
 
 # Install Java 8 for hail
@@ -30,34 +15,11 @@ RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee
     && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" \
     | tee /etc/apt/sources.list.d/adoptium.list && apt-get update && apt install -y --no-install-recommends temurin-8-jdk
 
-RUN mkdir tools
-WORKDIR /tools
-
-# Install python packages
-RUN apt-get update \
-    && apt-get dist-upgrade -y \
-    && apt-get install -y --no-install-recommends\
-    openssl \
-    python3-smbus \
-    python3 python3-pip
-
-# Upgrade pip to latest version
-RUN python3 -m pip install --upgrade pip
-
 # Install hail and other python libraries
 ENV HAIL_VERSION="0.2.120"
 RUN python3 --version
 RUN python3 -m pip install \
-    wheel \
-    pypandoc \
     hail==${HAIL_VERSION} \
-    scipy \
-    numpy \
-    pandas \
-    matplotlib \
-    seaborn \
-    ipython \
-    pybedtools \
     dill
 
 # Install GCS Connector

--- a/rmc/resources/docker/Dockerfile
+++ b/rmc/resources/docker/Dockerfile
@@ -1,8 +1,9 @@
 FROM 'google/cloud-sdk:slim'
 
 # install packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get -y update && apt-get install -y --no-install-recommends \
     apt-utils \
+    docker-compose \
     g++ \
     gawk \
     less \
@@ -10,7 +11,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcurl4-openssl-dev \
     liblzma-dev \
     libncurses5-dev \
-    liblz4-dev \
     man-db \
     pkg-config \
     python3-venv \
@@ -18,11 +18,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \
     wget \
     zlib1g-dev \
+    libpq-dev \
+    python-dev\
     && \
-    # clean up apt cache
+	# clean up apt cache
     rm -rf /var/lib/apt/lists/*
 
-#install Java 8 for hail
+# Install Java 8 for hail
 RUN wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - \
     && add-apt-repository -y https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ \
     && apt-get update && apt-get install -y adoptopenjdk-8-hotspot
@@ -32,8 +34,8 @@ WORKDIR /tools
 
 # Install python packages
 RUN apt-get update \
-    && apt-get dist-upgrade -y \
-    && apt-get install -y --no-install-recommends\
+	&& apt-get dist-upgrade -y \
+	&& apt-get install -y --no-install-recommends\
     libc6-dev \
     libffi-dev \
     libgdbm-dev \
@@ -45,15 +47,18 @@ RUN apt-get update \
     libsqlite3-dev \
     libssl-dev \
     openssl \
-    python-smbus \
-    python3 \
-    python-pip
+    python3-smbus \
+    python3 python3-pip
 
 # Upgrade pip to latest version
 RUN python3 -m pip install --upgrade pip
 
 # Install hail and other python libraries
-ENV HAIL_VERSION="0.2.100"
+# Install hail and other python libraries
+# Including packages needed for VRS annotation functionality
+# Also include version for ga4gh.vrs-python to be most recent and supporting their new variant schema
+# Please update the constant VRS_VERSION in vrs_annotation_batch.py accordingly when GA4GH_VRS_VERSION is changed
+ENV HAIL_VERSION="0.2.120"
 RUN python3 --version
 RUN python3 -m pip install \
     wheel \
@@ -67,17 +72,12 @@ RUN python3 -m pip install \
     ipython \
     pybedtools \
     dill \
-    gnomad
+    git+https://github.com/broadinstitute/gnomad_methods.git@main \
+    git+https://github.com/broadinstitute/gnomad_qc.git@main
 
 # Install GCS Connector
-RUN export SPARK_HOME=$(find_spark_home.py) && \
-    curl https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.0.1.jar \
-         >$SPARK_HOME/jars/gcs-connector-hadoop2-2.0.1.jar && \
-    mkdir -p $SPARK_HOME/conf && \
-    touch $SPARK_HOME/conf/spark-defaults.conf && \
-    sed -i $SPARK_HOME/conf/spark-defaults.conf \
-        -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.enable.*:spark.hadoop.google.cloud.auth.service.account.enable true:' \
-        -e 's:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile.*:spark\.hadoop\.google\.cloud\.auth\.service\.account\.json\.keyfile /gsa-key/key.json:'
+# Install GCS Connector
+RUN curl -sSL broad.io/install-gcs-connector > install-gcs-connector.py && \
+    python3 install-gcs-connector.py --key-file-path /gsa-key/key.json
 
 WORKDIR /home
-ENV PYSPARK_SUBMIT_ARGS="--driver-memory 8g --executor-memory 8g pyspark-shell"

--- a/rmc/resources/docker/Dockerfile
+++ b/rmc/resources/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM 'google/cloud-sdk:slim'
 FROM 'python:3.11-slim'
+FROM 'hailgenetics/hail:0.2.120'
 
 # install packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -14,13 +15,6 @@ RUN mkdir -p /etc/apt/keyrings
 RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
     && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" \
     | tee /etc/apt/sources.list.d/adoptium.list && apt-get update && apt install -y --no-install-recommends temurin-8-jdk
-
-# Install hail and other python libraries
-ENV HAIL_VERSION="0.2.120"
-RUN python3 --version
-RUN python3 -m pip install \
-    hail==${HAIL_VERSION} \
-    dill
 
 # Install GCS Connector
 RUN curl -sSL broad.io/install-gcs-connector > install-gcs-connector.py && \

--- a/rmc/resources/docker/Dockerfile
+++ b/rmc/resources/docker/Dockerfile
@@ -70,7 +70,7 @@ RUN python3 -m pip install \
     seaborn \
     ipython \
     pybedtools \
-    dill \
+    dill
 
 # Install GCS Connector
 # Install GCS Connector

--- a/rmc/resources/docker/Dockerfile
+++ b/rmc/resources/docker/Dockerfile
@@ -1,9 +1,8 @@
 FROM 'google/cloud-sdk:slim'
 
 # install packages
-RUN apt-get -y update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-utils \
-    docker-compose \
     g++ \
     gawk \
     less \
@@ -11,6 +10,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
     libcurl4-openssl-dev \
     liblzma-dev \
     libncurses5-dev \
+    liblz4-dev \
     man-db \
     pkg-config \
     python3-venv \
@@ -18,10 +18,8 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
     unzip \
     wget \
     zlib1g-dev \
-    libpq-dev \
-    python-dev\
     && \
-	# clean up apt cache
+    # clean up apt cache
     rm -rf /var/lib/apt/lists/*
 
 # Install Java 8 for hail
@@ -34,8 +32,8 @@ WORKDIR /tools
 
 # Install python packages
 RUN apt-get update \
-	&& apt-get dist-upgrade -y \
-	&& apt-get install -y --no-install-recommends\
+    && apt-get dist-upgrade -y \
+    && apt-get install -y --no-install-recommends\
     libc6-dev \
     libffi-dev \
     libgdbm-dev \
@@ -47,8 +45,9 @@ RUN apt-get update \
     libsqlite3-dev \
     libssl-dev \
     openssl \
-    python3-smbus \
-    python3 python3-pip
+    python-smbus \
+    python3 \
+    python-pip
 
 # Upgrade pip to latest version
 RUN python3 -m pip install --upgrade pip
@@ -71,7 +70,7 @@ RUN python3 -m pip install \
     seaborn \
     ipython \
     pybedtools \
-    dill
+    dill \
 
 # Install GCS Connector
 # Install GCS Connector

--- a/rmc/resources/docker/Dockerfile
+++ b/rmc/resources/docker/Dockerfile
@@ -71,9 +71,7 @@ RUN python3 -m pip install \
     seaborn \
     ipython \
     pybedtools \
-    dill \
-    git+https://github.com/broadinstitute/gnomad_methods.git@main \
-    git+https://github.com/broadinstitute/gnomad_qc.git@main
+    dill
 
 # Install GCS Connector
 # Install GCS Connector

--- a/rmc/resources/docker/Dockerfile
+++ b/rmc/resources/docker/Dockerfile
@@ -45,9 +45,9 @@ RUN apt-get update \
     libsqlite3-dev \
     libssl-dev \
     openssl \
-    python-smbus \
+    python3-smbus \
     python3 \
-    python-pip
+    python3-pip
 
 # Upgrade pip to latest version
 RUN python3 -m pip install --upgrade pip

--- a/rmc/resources/docker/Dockerfile
+++ b/rmc/resources/docker/Dockerfile
@@ -1,7 +1,8 @@
 FROM 'google/cloud-sdk:slim'
 FROM 'hailgenetics/python-dill:3.11-slim'
 
-# install packages
+# TODO: Double check if all of these packages are necessary
+# Install packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-utils \
     curl \

--- a/rmc/resources/docker/Dockerfile
+++ b/rmc/resources/docker/Dockerfile
@@ -1,20 +1,37 @@
 FROM 'google/cloud-sdk:slim'
-FROM 'python:3.11-slim'
-FROM 'hailgenetics/hail:0.2.120'
+FROM 'hailgenetics/python-dill:3.11-slim'
 
 # install packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
     curl \
+    g++ \
+    gawk \
+    less \
+    libbz2-dev \
+    libcurl4-openssl-dev \
+    liblzma-dev \
+    libncurses5-dev \
+    liblz4-dev \
+    man-db \
+    pkg-config \
+    python3-venv \
+    software-properties-common \
+    unzip \
     wget \
+    zlib1g-dev \
     && \
-	# clean up apt cache
+    # clean up apt cache
     rm -rf /var/lib/apt/lists/*
 
 # Install Java 8 for hail
 RUN mkdir -p /etc/apt/keyrings
-RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc \
-    && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" \
-    | tee /etc/apt/sources.list.d/adoptium.list && apt-get update && apt install -y --no-install-recommends temurin-8-jdk
+RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list && apt-get update && apt install -y --no-install-recommends temurin-8-jdk
+
+# Intall Hail
+ENV HAIL_VERSION="0.2.120"
+RUN python3 --version
+RUN python3 -m pip install hail==${HAIL_VERSION}
 
 # Install GCS Connector
 RUN curl -sSL broad.io/install-gcs-connector > install-gcs-connector.py && \

--- a/rmc/resources/docker/Dockerfile
+++ b/rmc/resources/docker/Dockerfile
@@ -1,8 +1,10 @@
 FROM 'google/cloud-sdk:slim'
+FROM 'python:3.11-slim'
 
 # install packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-utils \
+    curl \
     g++ \
     gawk \
     less \
@@ -35,16 +37,6 @@ WORKDIR /tools
 RUN apt-get update \
     && apt-get dist-upgrade -y \
     && apt-get install -y --no-install-recommends\
-    libc6-dev \
-    libffi-dev \
-    libgdbm-dev \
-    liblapack-dev \
-    liblapack3 \
-    libncursesw5-dev \
-    libopenblas-base \
-    libopenblas-dev \
-    libsqlite3-dev \
-    libssl-dev \
     openssl \
     python3-smbus \
     python3 python3-pip

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -335,13 +335,13 @@ Bucket structure:
                 success_files/
 """
 
-SIMUL_SEARCH_ANNOTATIONS = {"max_chisq", "breakpoints"}
+SIMUL_SEARCH_ANNOTATIONS = {"chisq", "breakpoints"}
 """
 Set of annotations to keep from two simultaneous breaks search.
 
 Used when merging sections found in over and under length threshold search.
 
-`max_chisq`: Chi square value associated with two breaks.
+`chisq`: Chi square value associated with two breaks.
 `breakpoints`: Tuple of breakpoints with adjusted inclusiveness/exclusiveness.
 
 Note that this field will also be kept (`section` is a key field):

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -123,7 +123,7 @@ for each canonical transcript in Gencode v19.
 ####################################################################################
 ## RMC-related resources
 ####################################################################################
-coverage_plateau_models_path = "{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{CURRENT_FREEZE}/coverage_plateau_models.he"
+coverage_plateau_models_path = f"{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{CURRENT_FREEZE}/coverage_plateau_models.he"
 """
 Path to HailExpression containing struct for coverage correction model and plateau models.
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -252,7 +252,7 @@ def create_filtered_context_ht(
     :param csq: Variant consequences to filter Table to. Default is `KEEP_CODING_CSQ`.
     :param n_partitions: Number of desired partitions for the Table. Default is 30000.
     :param overwrite: Whether to overwrite temporary data. Default is False.
-    :param build_models_from_scratch: Whether to build plateau and coverage models from scratch. Default is False.
+    :param build_models_from_scratch: Whether to build plateau and coverage models from scratch. If False, will attempt to read models from resource path. Default is False.
     :return: None; writes Table to path.
     """
     logger.info(
@@ -276,7 +276,7 @@ def create_filtered_context_ht(
         overwrite=overwrite,
     )
 
-    # TODO: Import models built in gnomad-constraint rather than rebuilding here
+    # TODO: Import models built in gnomad-constraint (update models at resource path)
     if build_models_from_scratch:
         logger.info("Building plateau and coverage models...")
         coverage_ht = prop_obs_coverage.ht()

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -252,6 +252,7 @@ def create_filtered_context_ht(
     :param csq: Variant consequences to filter Table to. Default is `KEEP_CODING_CSQ`.
     :param n_partitions: Number of desired partitions for the Table. Default is 30000.
     :param overwrite: Whether to overwrite temporary data. Default is False.
+    :param build_models_from_scratch: Whether to build plateau and coverage models from scratch. Default is False. 
     :return: None; writes Table to path.
     """
     logger.info(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1160,6 +1160,8 @@ def get_oe_annotation(ht: hl.Table, freeze: int) -> hl.Table:
     :return: Table with `oe` annotation.
     """
     ht = constraint_prep.ht().select_globals()
+    # Add transcript annotation from section field as this is required for joins to other tables
+    ht = ht.annotate(transcript=ht.section.split("_")[0])
     group_ht = ht.group_by("transcript").aggregate(
         obs=hl.agg.sum(ht.observed),
         exp=hl.agg.sum(ht.expected),

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -752,9 +752,7 @@ def process_sections(
 
     logger.info("Annotating reverse cumulative observed, expected, and obs/exp...")
     ht = annotate_reverse_exprs(ht)
-    tmp_path = (
-        f"{TEMP_PATH_WITH_FAST_DEL}/rmc/freeze{freeze}_single_search_prep_round{search_num}_chisq{chisq_threshold}.ht",
-    )
+    tmp_path = f"{TEMP_PATH_WITH_FAST_DEL}/rmc/freeze{freeze}_single_search_prep_round{search_num}_chisq{chisq_threshold}.ht"
     ht = ht.checkpoint(tmp_path, overwrite=True)
 
     logger.info("Searching for a break in each section and returning...")

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1112,7 +1112,8 @@ def merge_rmc_hts(
     rmc_ht = hts[0].union(*hts[1:])
     rmc_ht = rmc_ht.checkpoint(
         f"{TEMP_PATH_WITH_FAST_DEL}/freeze{freeze}_search_union.ht",
-        overwrite=True,
+        _read_if_exists=not overwrite_temp,
+        overwrite=overwrite_temp,
     )
     # Calculate chi-square value for each section having O/E different from 1
     rmc_ht = rmc_ht.annotate(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -8,7 +8,7 @@ import scipy
 from gnomad.resources.grch37.gnomad import coverage, public_release
 from gnomad.resources.grch37.reference_data import vep_context
 from gnomad.resources.resource_utils import DataException
-from gnomad.utils.file_utils import file_exists
+from gnomad.utils.file_utils import file_exists, check_file_exists_raise_error
 
 from rmc.resources.basics import (
     SINGLE_BREAK_TEMP_PATH,

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -252,7 +252,7 @@ def create_filtered_context_ht(
     :param csq: Variant consequences to filter Table to. Default is `KEEP_CODING_CSQ`.
     :param n_partitions: Number of desired partitions for the Table. Default is 30000.
     :param overwrite: Whether to overwrite temporary data. Default is False.
-    :param build_models_from_scratch: Whether to build plateau and coverage models from scratch. Default is False. 
+    :param build_models_from_scratch: Whether to build plateau and coverage models from scratch. Default is False.
     :return: None; writes Table to path.
     """
     logger.info(
@@ -309,7 +309,8 @@ def create_filtered_context_ht(
         error_if_not_exists_msg=(
             "Coverage and plateau models HailExpression does not exist!"
             " Please double check and/or rerun with"
-            " `build_models_from_scratch` = True"            
+            " `build_models_from_scratch` = True"
+        ),
     )
     models = hl.experimental.read_expression(coverage_plateau_models_path)
 
@@ -631,8 +632,10 @@ def search_for_break(
         " and alt (evidence of domains of missense constraint) probability densities..."
     )
     logger.info(
-        "Skipping breakpoints that create at least one section that has < %i"
-        " expected missense variants...",
+        (
+            "Skipping breakpoints that create at least one section that has < %i"
+            " expected missense variants..."
+        ),
         min_num_exp_mis,
     )
     ht = ht.annotate(
@@ -1037,8 +1040,10 @@ def merge_round_no_break_ht(
         ht = ht.filter(~hl.literal(simul_sections).contains(ht.section))
     else:
         logger.warning(
-            "Simul breaks results HT (round %i) did not exist. Please double check"
-            " that this was expected!",
+            (
+                "Simul breaks results HT (round %i) did not exist. Please double check"
+                " that this was expected!"
+            ),
             search_num,
         )
     return ht

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -303,7 +303,14 @@ def create_filtered_context_ht(
             coverage_plateau_models_path,
             overwrite=overwrite,
         )
-    # TODO: perform a check if models exist and throw exception if they don't
+    check_file_exists_raise_error(
+        coverage_plateau_models_path,
+        error_if_not_exists=True,
+        error_if_not_exists_msg=(
+            "Coverage and plateau models HailExpression does not exist!"
+            " Please double check and/or rerun with"
+            " `build_models_from_scratch` = True"            
+    )
     models = hl.experimental.read_expression(coverage_plateau_models_path)
 
     # Also annotate as HT globals
@@ -753,8 +760,8 @@ def process_sections(
 
     logger.info("Annotating reverse cumulative observed, expected, and obs/exp...")
     ht = annotate_reverse_exprs(ht)
-    tmp_path = f"{TEMP_PATH_WITH_FAST_DEL}/rmc/freeze{freeze}_single_search_prep_round{search_num}_chisq{chisq_threshold}.ht"
-    ht = ht.checkpoint(tmp_path, overwrite=True)
+    tmp_obs_exp_annot_path = f"{TEMP_PATH_WITH_FAST_DEL}/rmc/freeze{freeze}_single_search_prep_round{search_num}_chisq{chisq_threshold}.ht"
+    ht = ht.checkpoint(tmp_obs_exp_annot_path, overwrite=True)
 
     logger.info("Searching for a break in each section and returning...")
     ht = search_for_break(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -295,21 +295,22 @@ def create_filtered_context_ht(
         hl.experimental.write_expression(
             hl.struct(
                 coverage=coverage_model,
-                plateau_autosomes=plateau_models,
+                plateau_models=plateau_models,
                 plateau_X=plateau_x_models,
                 plateau_Y=plateau_y_models,
             ),
             coverage_plateau_models_path,
             overwrite=overwrite,
         )
-    # TODO: Import models built in gnomad-constraint
+    # TODO: perform a check if models exist and throw exception if they don't
     models = hl.experimental.read_expression(coverage_plateau_models_path)
+    
     # Also annotate as HT globals
     ht = ht.annotate_globals(
-        plateau_models=plateau_models,
-        plateau_x_models=plateau_x_models,
-        plateau_y_models=plateau_y_models,
-        coverage_model=coverage_model,
+        plateau_models=models.plateau_models,
+        plateau_x_models=models.plateau_X,
+        plateau_y_models=models.plateau_Y,
+        coverage_model=models.coverage,
     )
 
     logger.info("Calculating expected values per allele and checkpointing...")

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -8,7 +8,7 @@ import scipy
 from gnomad.resources.grch37.gnomad import coverage, public_release
 from gnomad.resources.grch37.reference_data import vep_context
 from gnomad.resources.resource_utils import DataException
-from gnomad.utils.file_utils import file_exists, check_file_exists_raise_error
+from gnomad.utils.file_utils import check_file_exists_raise_error, file_exists
 
 from rmc.resources.basics import (
     SINGLE_BREAK_TEMP_PATH,
@@ -632,10 +632,8 @@ def search_for_break(
         " and alt (evidence of domains of missense constraint) probability densities..."
     )
     logger.info(
-        (
-            "Skipping breakpoints that create at least one section that has < %i"
-            " expected missense variants..."
-        ),
+        "Skipping breakpoints that create at least one section that has < %i"
+        " expected missense variants...",
         min_num_exp_mis,
     )
     ht = ht.annotate(
@@ -1040,10 +1038,8 @@ def merge_round_no_break_ht(
         ht = ht.filter(~hl.literal(simul_sections).contains(ht.section))
     else:
         logger.warning(
-            (
-                "Simul breaks results HT (round %i) did not exist. Please double check"
-                " that this was expected!"
-            ),
+            "Simul breaks results HT (round %i) did not exist. Please double check"
+            " that this was expected!",
             search_num,
         )
     return ht

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1052,12 +1052,19 @@ def calculate_oe_neq_1_chisq(
     return ((obs_expr - exp_expr) ** 2) / exp_expr
 
 
-def merge_rmc_hts(round_nums: List[int], freeze: int) -> hl.Table:
+def merge_rmc_hts(
+    round_nums: List[int],
+    freeze: int,
+    overwrite_temp: bool = False,
+) -> hl.Table:
     """
     Get table of final RMC sections after all break searches are complete.
 
     :param round_nums: List of round numbers to merge results across.
     :param freeze: RMC data freeze number.
+    :param overwrite_temp: Whether to overwrite intermediate temporary data if it already exists.
+        If False, will read existing intermediate temporary data rather than overwriting.
+        Default is False.
     :return: Table of final RMC sections. Schema:
         ----------------------------------------
         Row fields:

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -267,7 +267,7 @@ def create_filtered_context_ht(
     )
     ht = filter_context_using_gnomad(ht, "exomes")
     # Reducing number of partitions as the VEP context table has 62k
-    ht = ht.naive_coalsece(n_partitions)
+    ht = ht.naive_coalesce(n_partitions)
     ht = ht.checkpoint(
         f"{TEMP_PATH_WITH_FAST_DEL}/processed_context.ht",
         _read_if_exists=not overwrite,

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -238,7 +238,7 @@ def create_filtered_context_ht(
     csq: Set[str] = KEEP_CODING_CSQ,
     n_partitions: int = 30000,
     overwrite: bool = False,
-    build_models_from_scratch: bool = False
+    build_models_from_scratch: bool = False,
 ) -> None:
     """
     Create allele-level VEP context Table with constraint annotations including expected variant counts.
@@ -304,7 +304,7 @@ def create_filtered_context_ht(
         )
     # TODO: perform a check if models exist and throw exception if they don't
     models = hl.experimental.read_expression(coverage_plateau_models_path)
-    
+
     # Also annotate as HT globals
     ht = ht.annotate_globals(
         plateau_models=models.plateau_models,
@@ -752,6 +752,10 @@ def process_sections(
 
     logger.info("Annotating reverse cumulative observed, expected, and obs/exp...")
     ht = annotate_reverse_exprs(ht)
+    tmp_path = (
+        f"{TEMP_PATH_WITH_FAST_DEL}/rmc/freeze{freeze}_single_search_prep_round{search_num}_chisq{chisq_threshold}.ht",
+    )
+    ht = ht.checkpoint(tmp_path, overwrite=True)
 
     logger.info("Searching for a break in each section and returning...")
     ht = search_for_break(

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -452,6 +452,7 @@ def process_vep(
     or add additional annotations.
 
     Additional annotations (taken from `prepare_ht_for_constraint_calculations`) are:
+        - context (will always convert trimer context)
         - ref
         - alt
         - methylation
@@ -471,7 +472,7 @@ def process_vep(
     :param bool filter_outlier_transcripts: Whether to remove constraint outlier transcripts from Table.
         Default is False.
     :param bool add_annotations: Whether to add annotations from `prepare_ht_for_constraint_calculations`
-        beyond most severe consequence .Default is False.
+        beyond most severe consequence. Default is False.
     :return: Table filtered to canonical transcripts with option to filter to specific variant consequences
         and remove constraint outlier transcripts.
     :rtype: hl.Table

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -188,10 +188,8 @@ def process_context_ht(
 
     if not add_annotations:
         logger.info(
-            (
-                "Filtering to canonical transcripts and annotating variants with most"
-                " severe consequence..."
-            ),
+            "Filtering to canonical transcripts and annotating variants with most"
+            " severe consequence...",
         )
         ht = process_vep(
             ht,
@@ -200,11 +198,9 @@ def process_context_ht(
         )
     else:
         logger.info(
-            (
-                "Filtering to canonical transcripts, annotating variants with most"
-                " severe consequence, and adding annotations for constraint"
-                " calculation..."
-            ),
+            "Filtering to canonical transcripts, annotating variants with most"
+            " severe consequence, and adding annotations for constraint"
+            " calculation...",
         )
         # NOTE: `prepare_ht_for_constraint_calculations` annotates HT with:
         # `ref`, `alt`, `methylation_level`, `exome_coverage`, and annotations added by
@@ -279,6 +275,8 @@ def filter_context_using_gnomad(
     """
     Filter VEP context Table to sites that aren't seen in gnomAD or are rare in gnomAD.
 
+    Also filter sites with zero coverage in gnomAD.
+
     :param context_ht: VEP context Table.
     :param gnomad_data_type: gnomAD data type. Used to retrieve public release and coverage resources.
         Must be one of "exomes" or "genomes" (check is done within `public_release`).
@@ -289,6 +287,7 @@ def filter_context_using_gnomad(
     :return: Filtered VEP context Table.
     """
     gnomad = get_gnomad_public_release(gnomad_data_type, adj_freq_index)
+    gnomad_cov = coverage(gnomad_data_type).ht()
 
     # Filter to sites not seen in gnomAD or to rare sites in gnomAD
     gnomad_join = gnomad[context_ht.key]
@@ -302,6 +301,7 @@ def filter_context_using_gnomad(
             cov_threshold=cov_threshold,
         )
     )
+    context_ht = context_ht.filter(gnomad_cov[context_ht.locus].median > cov_threshold)
     return context_ht
 
 

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -545,7 +545,7 @@ def process_section_group(
             ht = ht.filter(ht.chisq == ht.section_max_chisq)
 
     ht = ht.annotate_globals(chisq_threshold=chisq_threshold)
-    ht = ht.naive_coalesce(output_n_partitions)
+    # ht = ht.naive_coalesce(output_n_partitions)
     # TODO: Restructure ht to match locus-level formats from single breaks
     ht.write(output_ht_path, overwrite=True)
     # TODO: Consider whether we want to write out temp information on chisq values for each potential break combination

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -110,8 +110,10 @@ def split_sections_by_len(
     ht = ht.annotate(missense_list_len=ht.max_idx + 1)
 
     logger.info(
-        "Splitting sections into two categories: list length < %i and list length"
-        " >= %i...",
+        (
+            "Splitting sections into two categories: list length < %i and list length"
+            " >= %i..."
+        ),
         missense_len_threshold,
         missense_len_threshold,
     )

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -110,10 +110,8 @@ def split_sections_by_len(
     ht = ht.annotate(missense_list_len=ht.max_idx + 1)
 
     logger.info(
-        (
-            "Splitting sections into two categories: list length < %i and list length"
-            " >= %i..."
-        ),
+        "Splitting sections into two categories: list length < %i and list length"
+        " >= %i...",
         missense_len_threshold,
         missense_len_threshold,
     )

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -545,6 +545,9 @@ def process_section_group(
             ht = ht.filter(ht.chisq == ht.section_max_chisq)
 
     ht = ht.annotate_globals(chisq_threshold=chisq_threshold)
+    # NOTE: Changed `naive_coalesce` to `repartition` here to fix Hail bug:
+    # https://discuss.hail.is/t/zip-length-mismatch-error/3548/7
+    # TODO: Revert when bug has been resolved
     # ht = ht.naive_coalesce(output_n_partitions)
     ht = ht.repartition(output_n_partitions)
     # TODO: Restructure ht to match locus-level formats from single breaks

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -545,11 +545,9 @@ def process_section_group(
             ht = ht.filter(ht.chisq == ht.section_max_chisq)
 
     ht = ht.annotate_globals(chisq_threshold=chisq_threshold)
-    # NOTE: Changed `naive_coalesce` to `repartition` here to fix Hail bug:
+    # NOTE: Change `naive_coalesce` to `repartition` below to fix a Hail bug (see below):
     # https://discuss.hail.is/t/zip-length-mismatch-error/3548/7
-    # TODO: Revert when bug has been resolved
-    # ht = ht.naive_coalesce(output_n_partitions)
-    ht = ht.repartition(output_n_partitions)
+    ht = ht.naive_coalesce(output_n_partitions)
     # TODO: Restructure ht to match locus-level formats from single breaks
     ht.write(output_ht_path, overwrite=True)
     # TODO: Consider whether we want to write out temp information on chisq values for each potential break combination

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -545,7 +545,7 @@ def process_section_group(
             ht = ht.filter(ht.chisq == ht.section_max_chisq)
 
     ht = ht.annotate_globals(chisq_threshold=chisq_threshold)
-    # NOTE: Change `naive_coalesce` to `repartition` below to fix a Hail bug (see below):
+    # NOTE: Change `naive_coalesce` to `repartition` below if you run into this Hail bug:
     # https://discuss.hail.is/t/zip-length-mismatch-error/3548/7
     ht = ht.naive_coalesce(output_n_partitions)
     # TODO: Restructure ht to match locus-level formats from single breaks

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -371,7 +371,7 @@ def search_for_two_breaks(
         )
     )
     group_ht = group_ht.transmute(
-        max_chisq=group_ht.best_break.chisq,
+        chisq=group_ht.best_break.chisq,
         # Adjust breakpoint inclusive/exclusiveness to be consistent with single break breakpoints, i.e.
         # so that the breakpoint site itself is the last site in the left subsection. Thus, the resulting
         # subsections will be divided as follows:
@@ -389,7 +389,7 @@ def search_for_two_breaks(
     group_ht = group_ht.checkpoint(group_ht_path, overwrite=True)
 
     # Remove rows with maximum chi square values below the threshold
-    group_ht = group_ht.filter(group_ht.max_chisq >= chisq_threshold)
+    group_ht = group_ht.filter(group_ht.chisq >= chisq_threshold)
     return group_ht
 
 
@@ -542,7 +542,7 @@ def process_section_group(
         # find the one "best" breakpoint (breakpoint with largest chi square value)
         if ht.count() > 0:
             ht = annotate_max_chisq_per_section(ht, freeze)
-            ht = ht.filter(ht.max_chisq == ht.section_max_chisq)
+            ht = ht.filter(ht.chisq == ht.section_max_chisq)
 
     ht = ht.annotate_globals(chisq_threshold=chisq_threshold)
     ht = ht.naive_coalesce(output_n_partitions)

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -546,6 +546,7 @@ def process_section_group(
 
     ht = ht.annotate_globals(chisq_threshold=chisq_threshold)
     # ht = ht.naive_coalesce(output_n_partitions)
+    ht = ht.repartition(output_n_partitions)
     # TODO: Restructure ht to match locus-level formats from single breaks
     ht.write(output_ht_path, overwrite=True)
     # TODO: Consider whether we want to write out temp information on chisq values for each potential break combination


### PR DESCRIPTION
This PR includes various bug fixes for running RMC pipeline on freeze 7 including:
1. Fixing use of `prepare_ht_for_constraint_calculations`, adding an option to switch to adding annotations in `process_context_ht` and in `process_vep`. This was to avoid a bug later which was trying to read a non-existent column in HT.
2. Move another annotation function into `process_vep`.
3. Fix a typo in `create_filtered_context`.
4. Add a toggle for building plateau models or use the existing models if available.
5. Fix model naming to avoid inconsistencies.
6. Fix a bug in resource path to plateau model.
7. Update Hail in docker file.
8. Change number of partitions for performance improvement.
9. Adding additional checkpoint in `process_sections` and fix some logic.
10. Remove `gnomad` and `gnomad_qc` from docker and fix python versioning in Dockerfile
11. Update `search_for_two_breaks` function to use `chisq` annotation throughout instead of `max_chisq`.
12. Update default docker image path to reflect newer image.
13. remove `wait=False` from `b.run()` in `run_batches.py`.
14. Temporary workaround changes due to a hail bug and updating docstring for future to-do in `run_batches.py`.