### PR TITLE
PR adding code to create public release (downloadable files)

### DIFF
--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -29,6 +29,7 @@ from rmc.utils.constraint import (
     create_context_with_oe,
     create_filtered_context_ht,
     create_no_breaks_he,
+    create_rmc_release_downloads,
     format_rmc_browser_ht,
     merge_rmc_hts,
     process_sections,
@@ -425,6 +426,13 @@ def main(args):
             logger.info("Reformatting RMC results for browser release...")
             format_rmc_browser_ht(args.freeze, args.overwrite_temp)
 
+        if args.command == "create-release":
+            logger.info(
+                "Creating versions of files to be publicly released on gnomAD"
+                " browser..."
+            )
+            create_rmc_release_downloads(args.freeze, args.overwrite)
+
     finally:
         logger.info("Copying hail log to logging bucket...")
         hl.copy_log(LOGGING_PATH)
@@ -561,6 +569,10 @@ if __name__ == "__main__":
         help="Remove constraint outlier transcripts from RMC output.",
     )
 
+    create_release = subparsers.add_parser(
+        "create-release",
+        help="Create RMC release files (to be publicly shared on gnomAD browser).",
+    )
     args = parser.parse_args()
 
     if args.slack_channel:

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -570,7 +570,7 @@ if __name__ == "__main__":
     )
 
     create_release = subparsers.add_parser(
-        "create-rmc-ßrelease",
+        "create-rmc-release",
         help="Create RMC release files (to be publicly shared on gnomAD browser).",
     )
     args = parser.parse_args()

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -426,7 +426,7 @@ def main(args):
             logger.info("Reformatting RMC results for browser release...")
             format_rmc_browser_ht(args.freeze, args.overwrite_temp)
 
-        if args.command == "create-release":
+        if args.command == "create-rmc-release":
             logger.info(
                 "Creating versions of files to be publicly released on gnomAD"
                 " browser..."
@@ -570,7 +570,7 @@ if __name__ == "__main__":
     )
 
     create_release = subparsers.add_parser(
-        "create-release",
+        "create-rmc-ßrelease",
         help="Create RMC release files (to be publicly shared on gnomAD browser).",
     )
     args = parser.parse_args()

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -13,6 +13,19 @@ Path to bucket containing reference data resources.
 ####################################################################################
 ## Reference genome related resources
 ####################################################################################
+GENCODE_VERSION = "19"
+"""
+GENCODE version used to annotate variants.
+
+gnomAD v2 used GENCODE v19 and VEP v85.
+See: https://gnomad.broadinstitute.org/help/what-version-of-gencode-was-used-to-annotate-variants.
+"""
+
+VEP_VERSION = "85"
+"""
+VEP version used to annotate variants.
+"""
+
 gene_model = TableResource(path=f"{RESOURCE_BUILD_PREFIX}/browser/b37_transcripts.ht")
 """
 Table containing transcript start and stop positions displayed in the browser.

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -562,8 +562,7 @@ def rmc_downloads_resource_paths(
     """
     Return resource path for specified RMC downloadable file.
 
-    Function returns path to file that will get copied to public release bucket
-    .
+    Function returns path to file that will get copied to public release bucket.
     There are three file types:
     - Hail Table
     - TSV containing transcripts with evidence of RMC

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -556,6 +556,23 @@ Contains same information as `rmc_results` but has different formatting for gnom
 """
 
 
+def rmc_downloadable_tsv_paths(has_rmc: bool, freeze: int = CURRENT_FREEZE) -> str:
+    """
+    Return resource path for specified RMC TSV.
+
+    These TSVs are intended for release on the gnomAD browser and have two types:
+    - TSV containing transcripts with evidence of RMC
+    - TSV containing transcripts that were searched for but did not have evidence of RMC
+
+    :param has_rmc: Whether to return path to TSV with RMC results.
+        If False, will return path to TSV with transcripts that don't have evidence of RMC.
+    :param freeze: RMC data freeze number.
+    :return: String of resource TSV path.
+    """
+    tsv_name = "transcripts_with_rmc.tsv" if has_rmc else "transcripts_without_rmc.tsv"
+    return f"{CONSTRAINT_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/{tsv_name}"
+
+
 ####################################################################################
 ## Missense badness related resources
 ####################################################################################

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -557,7 +557,10 @@ Contains same information as `rmc_results` but has different formatting for gnom
 
 
 def rmc_downloads_resource_paths(
-    get_ht_path: bool, has_rmc: bool = True, freeze: int = CURRENT_FREEZE
+    get_ht_path: bool,
+    has_rmc: bool = True,
+    freeze: int = CURRENT_FREEZE,
+    gnomad_version: str = CURRENT_GNOMAD_VERSION,
 ) -> str:
     """
     Return resource path for specified RMC downloadable file.
@@ -565,25 +568,26 @@ def rmc_downloads_resource_paths(
     Function returns path to file that will get copied to public release bucket.
     There are three file types:
     - Hail Table
-    - TSV containing transcripts with evidence of RMC
-    - TSV containing transcripts that were searched for but did not have evidence of RMC
+    - TSV containing results for transcripts with evidence of RMC
+    - TSV listing all transcripts that were searched for but did not have evidence of RMC
 
-    :param get_ht_path: Whehter to return path to HT.
+    :param get_ht_path: Whether to return path to HT.
         If False, will return path to one of the two TSV files.
     :param has_rmc: Whether to return path to TSV with RMC results.
         If False, will return path to TSV with transcripts that don't have evidence of RMC.
     :param freeze: RMC data freeze number.
-    :return: String of resource TSV path.
+    :param gnomad_version: gnomAD version.ß
+    :return: String of resource path.
     """
     if get_ht_path:
-        return f"{CONSTRAINT_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/gnomAD_v2.1.1_rmc.ht"
+        return f"{CONSTRAINT_PREFIX}/{gnomad_version}/{freeze}/gnomad_v{gnomad_version}_rmc.ht"
 
     tsv_name = (
-        "gnomAD_v2.1.1_transcripts_with_rmc.tsv"
+        f"gnomAD_v{gnomad_version}_transcripts_with_rmc.tsv"
         if has_rmc
-        else "gnomAD_v2.1.1_rmc_transcripts_without_rmc.tsv"
+        else f"gnomAD_v{gnomad_version}_rmc_transcripts_without_rmc.tsv"
     )
-    return f"{CONSTRAINT_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/{tsv_name}"
+    return f"{CONSTRAINT_PREFIX}/{gnomad_version}/{freeze}/{tsv_name}"
 
 
 ####################################################################################

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -556,20 +556,34 @@ Contains same information as `rmc_results` but has different formatting for gnom
 """
 
 
-def rmc_downloadable_tsv_paths(has_rmc: bool, freeze: int = CURRENT_FREEZE) -> str:
+def rmc_downloads_resource_paths(
+    get_ht_path: bool, has_rmc: bool = True, freeze: int = CURRENT_FREEZE
+) -> str:
     """
-    Return resource path for specified RMC TSV.
+    Return resource path for specified RMC downloadable file.
 
-    These TSVs are intended for release on the gnomAD browser and have two types:
+    Function returns path to file that will get copied to public release bucket
+    .
+    There are three file types:
+    - Hail Table
     - TSV containing transcripts with evidence of RMC
     - TSV containing transcripts that were searched for but did not have evidence of RMC
 
+    :param get_ht_path: Whehter to return path to HT.
+        If False, will return path to one of the two TSV files.
     :param has_rmc: Whether to return path to TSV with RMC results.
         If False, will return path to TSV with transcripts that don't have evidence of RMC.
     :param freeze: RMC data freeze number.
     :return: String of resource TSV path.
     """
-    tsv_name = "transcripts_with_rmc.tsv" if has_rmc else "transcripts_without_rmc.tsv"
+    if get_ht_path:
+        return f"{CONSTRAINT_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/gnomAD_v2.1.1_rmc.ht"
+
+    tsv_name = (
+        "gnomAD_v2.1.1_transcripts_with_rmc.tsv"
+        if has_rmc
+        else "gnomAD_v2.1.1_rmc_transcripts_without_rmc.tsv"
+    )
     return f"{CONSTRAINT_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/{tsv_name}"
 
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1913,7 +1913,7 @@ def create_rmc_release_downloads(
     gene_constraint_ht = gene_constraint_ht.filter(
         transcripts_no_rmc.contains(gene_constraint_ht.transcript)
     )
-    gene_constraint_ht = _get_gene_ids(gene_constraint_ht)
+    gene_constraint_ht = _annotate_gene_ids(gene_constraint_ht)
     gene_constraint_ht = gene_constraint_ht.select(
         "gene_name",
         "gene_id",

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1876,7 +1876,7 @@ def create_rmc_release_downloads(
         Default is `VEP_VERSION`.
     :return: None; writes TSVs to resource paths.
     """
-    logger.info("Preparing browser reformatted HT for release...")
+    logger.info("Preparing browser-reformatted HT for release...")
     ht = rmc_browser.versions[freeze].ht()
 
     # Add gene IDs from `transcript_ref` resource

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1898,7 +1898,7 @@ def create_rmc_release_downloads(
     ht = rmc_browser.versions[freeze].ht()
     # Add gene IDs from `transcript_ref` resource
     ht = _annotate_gene_ids(ht)
-    # Add GENCODE and VEP versions to globalsÍ
+    # Add GENCODE and VEP versions to globals
     ht = ht.annotate_globals(gencode_version=gencode_version, vep_version=vep_version)
     ht = ht.checkpoint(
         rmc_downloads_resource_paths(get_ht_path=True, freeze=freeze),

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1846,7 +1846,7 @@ def create_rmc_release_downloads(
     Function adds gene IDs to RMC HT and exports RMC results to TSVs for release.
 
     The two TSV types are:
-    - TSV with transcripts that had evidence of RMC
+    - TSV with region results for transcripts that had evidence of RMC
     - TSV listing all transcripts that were searched for but did not have evidence of RMC
 
     .. note::

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1877,7 +1877,7 @@ def create_rmc_release_downloads(
     :return: None; writes TSVs to resource paths.
     """
 
-    def _get_gene_ids(ht: hl.Table) -> hl.Table:
+    def _annotate_gene_ids(ht: hl.Table) -> hl.Table:
         """
         Annotate input HT with GENCODE gene information using `transcript_ref`.
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1895,7 +1895,7 @@ def create_rmc_release_downloads(
 
     # Get transcripts that were searched for but had no evidence of RMC
     transcripts_no_rmc = ht.transcripts_no_rmc
-    # Filter gene constraint results to keep only trascripts without evidence of RMC
+    # Filter gene constraint results to keep only transcripts without evidence of RMC
     gene_constraint_ht = constraint_ht.ht().select_globals().key_by("transcript")
     gene_constraint_ht = gene_constraint_ht.filter(
         transcripts_no_rmc.contains(gene_constraint_ht.transcript)

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1897,7 +1897,7 @@ def create_rmc_release_downloads(
     logger.info("Preparing browser-reformatted HT for release...")
     ht = rmc_browser.versions[freeze].ht()
     # Add gene IDs from `transcript_ref` resource
-    ht = _get_gene_ids(ht)
+    ht = _annotate_gene_ids(ht)
     # Add GENCODE and VEP versions to globalsÍ
     ht = ht.annotate_globals(gencode_version=gencode_version, vep_version=vep_version)
     ht = ht.checkpoint(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -18,6 +18,8 @@ from rmc.resources.basics import (
 )
 from rmc.resources.gnomad import constraint_ht, prop_obs_coverage
 from rmc.resources.reference_data import (
+    GENCODE_VERSION,
+    VEP_VERSION,
     clinvar_plp_mis_haplo,
     gene_model,
     ndd_de_novo,
@@ -39,6 +41,7 @@ from rmc.resources.rmc import (
     no_breaks_he_path,
     oe_bin_counts_tsv,
     rmc_browser,
+    rmc_downloads_resource_paths,
     rmc_results,
     simul_search_bucket_path,
     simul_search_round_bucket_path,
@@ -1829,6 +1832,98 @@ def format_rmc_browser_ht(freeze: int, overwrite_temp: bool) -> None:
     # Annotate globals and write
     ht = add_globals_rmc_browser(ht)
     ht.write(rmc_browser.versions[freeze].path, overwrite=True)
+
+
+def create_rmc_release_downloads(
+    freeze: int,
+    overwrite: bool,
+    gencode_version: str = GENCODE_VERSION,
+    vep_version: str = VEP_VERSION,
+) -> None:
+    """
+    Create downloadable files to be publicly released on the gnomAD browser.
+
+    Function adds gene IDs to RMC HT and exports RMC results to TSVs for release.
+
+    The two TSV types are:
+    - TSV with transcripts that had evidence of RMC
+    - TSV listing all transcripts that were searched for but did not have evidence of RMC
+
+    .. note::
+        - Function assumes the global annotation `transcripts_no_rmc` exists
+        in `rmc_browser.ht()`
+        - Function assumes the following fields exist in `regions` struct on `rmc_browser.ht()`:
+            - start_coordinate
+            - stop_coordinate
+            - start_aa
+            - stop_aa
+            - obs
+            - exp
+            - oe
+            - chisq
+            - p
+        - Function assumes the following fields exist on the gene constraint HT:
+            - obs_mis
+            - exp_mis
+            - oe_mis
+            - mis_z
+
+    :param freeze: RMC data freeze number.
+    :param overwrite: Whether to overwrite RMC download HT.
+    :param gencode_version: Version of GENCODE used to annotate variants.
+        Default is `GENCODE_VERSION`.
+    :param vep_version: Version of VEP used to annotate variants.
+        Default is `VEP_VERSION`.
+    :return: None; writes TSVs to resource paths.
+    """
+    logger.info("Preparing browser reformatted HT for release...")
+    ht = rmc_browser.versions[freeze].ht()
+
+    # Add gene IDs from `transcript_ref` resource
+    transcript_ref_ht = transcript_ref.ht()
+    ht = ht.annotate(
+        gene_name=transcript_ref[ht.transcript].gnomad_gene,
+        gene_id=transcript_ref[ht.transcript].gencode_gene_id,
+    )
+    # Add GENCODE and VEP versions to globals
+    ht = ht.annotate_globals(gencode_version=gencode_version, vep_version=vep_version)
+    ht = ht.checkpoint(
+        rmc_downloads_resource_paths(get_ht_path=True, freeze=freeze),
+        overwrite=overwrite,
+        _read_if_exists=not overwrite,
+    )
+
+    # Get transcripts that were searched for but had no evidence of RMC
+    transcripts_no_rmc = ht.transcripts_no_rmc
+    # Filter gene constraint results to keep only trascripts without evidence of RMC
+    gene_constraint_ht = constraint_ht.ht().select_globals().key_by("transcript")
+    gene_constraint_ht = gene_constraint_ht.filter(
+        transcripts_no_rmc.contains(gene_constraint_ht.transcript)
+    )
+    gene_constraint_ht = gene_constraint_ht.select(
+        obs=gene_constraint_ht.obs_mis,
+        exp=gene_constraint_ht.exp_mis,
+        oe=gene_constraint_ht.oe_mis,
+        z_score=gene_constraint_ht.mis_z,
+    )
+    # Export to TSV
+    gene_constraint_ht.export(
+        rmc_downloads_resource_paths(get_ht_path=False, has_rmc=False, freeze=freeze)
+    )
+
+    # Drop globals and explode nested struct to flatten results for TSV export
+    ht = ht.select_globals()
+    ht = ht.explode("regions")
+    # Unnest annotations from region struct to make TSV header more pleasant
+    # (Avoid column headers like `regions.start_coordinate`)
+    ht = ht.transmute(**ht.regions)
+    # Also rename `p` to `p_value` since there are no name conflicts in the TSV
+    # (HT has conflict between row and global annotations)
+    ht = ht.transmute(p_value=ht.p)
+    # Export to TSV
+    ht.export(
+        rmc_downloads_resource_paths(get_ht_path=False, has_rmc=True, freeze=freeze)
+    )
 
 
 def check_loci_existence(ht1: hl.Table, ht2: hl.Table, annot_str: str) -> hl.Table:

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1882,8 +1882,8 @@ def create_rmc_release_downloads(
     # Add gene IDs from `transcript_ref` resource
     transcript_ref_ht = transcript_ref.ht()
     ht = ht.annotate(
-        gene_name=transcript_ref[ht.transcript].gnomad_gene,
-        gene_id=transcript_ref[ht.transcript].gencode_gene_id,
+        gene_name=transcript_ref_ht[ht.transcript].gnomad_gene,
+        gene_id=transcript_ref_ht[ht.transcript].gencode_gene_id,
     )
     # Add GENCODE and VEP versions to globals
     ht = ht.annotate_globals(gencode_version=gencode_version, vep_version=vep_version)


### PR DESCRIPTION
PR adds code to create three release files:
- HT
- TSV with RMC results
- TSV of transcripts searched for but without RMC results

Note that the current browser release HT exists at this temp path `gs://regional_missense_constraint/temp/demo_release.ht` with the following schema:
```
----------------------------------------
Global fields:
    'p_value': float64 
    'all_canonical_transcripts': set<str> 
    'qc_pass_transcripts': set<str> 
    'outlier_transcripts': set<str> 
    'extra_transcripts': set<str> 
    'outlier_transcripts_searched': set<str> 
    'transcripts_searched': set<str> 
    'transcripts_no_rmc_all': set<str> 
    'transcripts_no_rmc_qc': set<str> 
    'rmc_transcripts_all': set<str> 
    'rmc_transcripts_qc': set<str> 
----------------------------------------
Row fields:
    'transcript': str 
    'regions': array<struct {
        start_coordinate: locus<GRCh37>, 
        stop_coordinate: locus<GRCh37>, 
        start_aa: str, 
        stop_aa: str, 
        obs: int64, 
        exp: float64, 
        oe: float64, 
        chisq: float64, 
        p: float64
    }> 
----------------------------------------
Key: ['transcript']
```

My current plan to run this code is to:
- Read in the temp HT above
- Update the names of the globals so they are consistent with the globals listed [here](https://github.com/broadinstitute/regional_missense_constraint/blob/main/rmc/utils/constraint.py#L1764)
- Write the HT to its [resource path](https://github.com/broadinstitute/regional_missense_constraint/blob/main/rmc/resources/rmc.py#L543)
- Run `regional_constraint.py` with `create-release` command