### PR TITLE
Small runtime fix for RMC release

### DIFF
--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -585,7 +585,10 @@ def rmc_downloads_resource_paths(
     tsv_name = (
         f"gnomAD_v{gnomad_version}_transcripts_with_rmc.tsv"
         if has_rmc
-        else f"gnomAD_v{gnomad_version}_rmc_transcripts_without_rmc.tsv"
+        # NOTE: RMC freeze 7 results were exported as
+        # f"gnomAD_v{gnomad_version}_rmc_transcripts_without_rmc.tsv"
+        # (extra 'rmc' was removed when copying file to public path)
+        else f"gnomAD_v{gnomad_version}_transcripts_without_rmc.tsv"
     )
     return f"{CONSTRAINT_PREFIX}/{gnomad_version}/{freeze}/{tsv_name}"
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1907,11 +1907,11 @@ def create_rmc_release_downloads(
     )
 
     # Get transcripts that were searched for but had no evidence of RMC
-    transcripts_no_rmc = ht.transcripts_no_rmc
+    transcripts_no_rmc = hl.eval(ht.transcripts_no_rmc)
     # Filter gene constraint results to keep only transcripts without evidence of RMC
     gene_constraint_ht = constraint_ht.ht().select_globals().key_by("transcript")
     gene_constraint_ht = gene_constraint_ht.filter(
-        transcripts_no_rmc.contains(gene_constraint_ht.transcript)
+        hl.literal(transcripts_no_rmc).contains(gene_constraint_ht.transcript)
     )
     gene_constraint_ht = _annotate_gene_ids(gene_constraint_ht)
     gene_constraint_ht = gene_constraint_ht.select(


### PR DESCRIPTION
Added fix for "cannot combine expressions from different source objects error" (see https://github.com/broadinstitute/rmc_production/issues/120)