### PR TITLE
Deduplicate MPC prior to liftover

### DIFF
--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1257,7 +1257,7 @@ def dedup_annot(
     :param keep_transcript: Whether to retain transcript ID.
     :param key_fields: Key fields to use for deduplication.
     """
-    ht = ht.select(annot).key_by(*(key_fields))
+    ht = ht.key_by(*(key_fields)).select(annot)
     ht = ht.collect_by_key()
 
     if get_min:

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1243,7 +1243,6 @@ def dedup_annot(
     ht: hl.Table,
     annot: str,
     get_min: bool,
-    keep_transcript: bool,
     key_fields: Tuple[str, str] = ("locus", "alleles"),
 ) -> hl.Table:
     """
@@ -1260,15 +1259,15 @@ def dedup_annot(
     """
     ht = ht.select(annot).key_by(*(key_fields))
     ht = ht.collect_by_key()
+
     if get_min:
         ht = ht.annotate(**{annot: hl.nanmin(ht.values[annot])})
     else:
         ht = ht.annotate(**{annot: hl.nanmax(ht.values[annot])})
 
-    if keep_transcript:
-        ht = ht.annotate(
-            **{"transcript": ht.values.find(lambda x: x[annot] == ht[annot]).transcript}
-        )
+    ht = ht.annotate(
+        **{"transcript": ht.values.find(lambda x: x[annot] == ht[annot]).transcript}
+    )
     return ht.drop("values")
 
 
@@ -1341,7 +1340,7 @@ def create_context_with_oe(
     logger.info(
         "Creating dedup context with oe (with oe and transcript annotations only)..."
     )
-    ht = dedup_annot(ht, annot="oe", get_min=True, keep_transcript=True)
+    ht = dedup_annot(ht, annot="oe", get_min=True)
     ht.write(
         context_with_oe_dedup.versions[freeze].path,
         overwrite=True,

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -416,6 +416,9 @@ def get_ref_aa(
     return ht.transmute(ref_aa=ht.aa_info[0].ref_aa)
 
 
+####################################################################################
+## gnomAD and context HT processing-related utils
+####################################################################################
 def get_gnomad_public_release(
     gnomad_data_type: str = "exomes", adj_freq_index: int = 0
 ) -> hl.Table:

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -520,67 +520,6 @@ def get_annotations_from_context_ht_vep(
     return annotate_and_filter_codons(ht)
 
 
-# def filter_context_to_transcript_cds(
-#     context_ht: hl.Table, transcripts: hl.expr.SetExpression
-# ) -> hl.Table:
-#     """
-#     Filter VEP context Table to coding sites in the input transcripts.
-
-#     :param hl.Table context_ht: VEP context Table.
-#     :param hl.expr.SetExpression transcripts: Transcripts to filter to.
-#     :return: VEP context Table with rows filtered to only coding sites in the input transcripts.
-#     """
-#     # Get coordinate intervals of coding sequences of transcripts
-#     cds_ht = transcript_cds.ht()
-#     filter_intervals = cds_ht.aggregate(
-#         hl.agg.filter(
-#             transcripts.contains(cds_ht.transcript),
-#             hl.agg.collect(cds_ht.interval),
-#         ),
-#         _localize=False,
-#     )
-#     # Filter context HT to sites in these intervals
-#     return hl.filter_intervals(context_ht, filter_intervals)
-
-
-####################################################################################
-## Observed and expected-related utils
-####################################################################################
-# def get_exome_bases() -> int:
-#     """
-#     Get number of bases in the exome.
-
-#     Read in context HT (containing all coding bases in the genome), remove outlier transcripts, and filter to median coverage >= 5.
-
-#     :return: Number of bases in the exome.
-#     :rtype: int
-#     """
-#     logger.info("Reading in SNPs-only, VEP-annotated context ht...")
-#     ht = vep_context.ht()
-
-#     logger.info("Filtering to canonical transcripts...")
-#     ht = filter_vep_to_canonical_transcripts(ht, vep_root="vep", filter_empty_csq=True)
-
-#     logger.info("Removing outlier transcripts...")
-#     outlier_transcripts = get_constraint_transcripts(outlier=True)
-#     ht = ht.transmute(transcript_consequences=ht.vep.transcript_consequences)
-#     ht = ht.explode(ht.transcript_consequences)
-#     ht = ht.filter(
-#         ~outlier_transcripts.contains(ht.transcript_consequences.transcript_id)
-#     )
-
-#     logger.info(
-#         "Collecting context HT by key (to make sure each locus only gets counted once)..."
-#     )
-#     ht = ht.key_by("locus").collect_by_key()
-
-#     logger.info("Removing positions with median coverage < 5...")
-#     # Taking just the first value since the coverage should be the same for all entries at a locus
-#     ht = ht.filter(ht.values[0].coverage.exomes.median >= 5)
-#     ht = ht.select()
-#     return ht.count()
-
-
 def keep_criteria(
     ac_expr: hl.expr.Int32Expression,
     af_expr: hl.expr.Float64Expression,


### PR DESCRIPTION
- Created new function `dedup_annot` to deduplicate OE annotation when creating `context_with_oe` resource and MPC when lifting over MPC release
- Minor clean up of `generic.py`; removed unused code and added missing section header
- Minor improvements to `liftover_mpc`: rename transcript to reflect that this was the GRCh37 transcript ID and remove unnecessary field `locus_fail_liftover` from liftover MPC release