### PR TITLE
Add argument to control MPC dedup prior to liftover

### DIFF
--- a/rmc/pipeline/calculate_mpc.py
+++ b/rmc/pipeline/calculate_mpc.py
@@ -100,7 +100,7 @@ def main(args):
                 "Note that this command was built only to lift gnomAD v2.1.1"
                 " data to GRCh38!"
             )
-            liftover_mpc(args.freeze)
+            liftover_mpc(args.freeze, args.dedup)
 
     finally:
         logger.info("Copying hail log to logging bucket...")
@@ -251,6 +251,11 @@ if __name__ == "__main__":
 
     liftover = subparsers.add_parser(
         "liftover", help="Liftover MPC from GRCh37 to GRCh38."
+    )
+    liftover.add_argument(
+        "--dedup",
+        help="Deduplicate MPC by selecting max score per locus prior to liftover.",
+        action="store_true",
     )
 
     args = parser.parse_args()

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -1064,6 +1064,7 @@ def liftover_mpc(
         Default is False.
     :param failed_sites_str: Name of the field containing Boolean for whether site failed liftover.
         Default is 'locus_fail_liftover'.
+        Only relevant if remove_failed_sites is True.
     :param remove_liftover_annotations: Set of lifted over annotations to remove.
         Default is `{"new_locus", "new_alleles"}` as these fields are the lifted over
         versions of the original loci and alleles and are the new keys of the lifted over

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -1067,7 +1067,7 @@ def liftover_mpc(
         Only relevant if remove_failed_sites is True.
     :param remove_liftover_annotations: Set of lifted over annotations to remove.
         Default is `{"new_locus", "new_alleles"}` as these fields are the lifted over
-        versions of the original loci and alleles and are the new keys of the lifted over
+        versions of the original loci and alleles and are already copied to the new keys of the lifted over
         table.
     :return: None; function writes HT to resource path.
     """

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -1040,6 +1040,7 @@ def liftover_mpc(
     freeze: int = CURRENT_FREEZE,
     gnomad_version: str = CURRENT_GNOMAD_VERSION,
     remove_failed_sites: bool = True,
+    dedup_mpc: bool = False,
     overwrite_temp: bool = False,
 ) -> None:
     """
@@ -1052,7 +1053,11 @@ def liftover_mpc(
     :param gnomad_version: Current gnomAD version. Default is CURRENT_GNOMAD_VERSION.
     :param remove_failed_sites: Whether to remove sites that failed to liftover from input Table.
         Default is True.
+    :param dedup_mpc: Whether to deduplicate MPC scores per duplicate loci prior to liftover.
+        If True, will take the maxmimum MPC per duplicated locus.
+        Default is False.
     :param overwrite_temp: Whether to overwrite intermediate HT with deduplicated MPC scores.
+        Only relevant if dedup_mpc is True.
         If False, will read from existing temporary path.
         Default is False.
     :return: None; function writes HT to resource path.
@@ -1067,15 +1072,17 @@ def liftover_mpc(
             " to GRCh38."
         )
     ht = hl.read_table(mpc_release.versions[freeze].path)
-    # Deduplicate MPC annotation by keeping largest MPC value per variant (locus/alleles) combination
-    ht = dedup_annot(ht, annot="mpc", get_min=False)
-    # Rename transcript information
-    ht = ht.transmute(transcript_grch37=ht.transcript)
-    ht = ht.checkpoint(
-        f"{TEMP_PATH_WITH_FAST_DEL}/mpc_dedup.ht",
-        _read_if_exists=not overwrite_temp,
-        overwrite=overwrite_temp,
-    )
+
+    if dedup_mpc:
+        # Deduplicate MPC annotation by keeping largest MPC value per variant (locus/alleles) combination
+        ht = dedup_annot(ht, annot="mpc", get_min=False)
+        # Rename transcript information
+        ht = ht.transmute(transcript_grch37=ht.transcript)
+        ht = ht.checkpoint(
+            f"{TEMP_PATH_WITH_FAST_DEL}/mpc_dedup.ht",
+            _read_if_exists=not overwrite_temp,
+            overwrite=overwrite_temp,
+        )
 
     ht = default_lift_data(ht, remove_failed_sites=remove_failed_sites)
     # Drop unnecessary annotation if removing sites that failed liftover

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -1076,14 +1076,14 @@ def liftover_mpc(
     if dedup_mpc:
         # Deduplicate MPC annotation by keeping largest MPC value per variant (locus/alleles) combination
         ht = dedup_annot(ht, annot="mpc", get_min=False)
-        # Rename transcript information
-        ht = ht.transmute(transcript_grch37=ht.transcript)
         ht = ht.checkpoint(
             f"{TEMP_PATH_WITH_FAST_DEL}/mpc_dedup.ht",
             _read_if_exists=not overwrite_temp,
             overwrite=overwrite_temp,
         )
 
+    # Rename transcript information
+    ht = ht.transmute(transcript_grch37=ht.transcript)
     ht = default_lift_data(ht, remove_failed_sites=remove_failed_sites)
     # Drop unnecessary annotation if removing sites that failed liftover
     if remove_failed_sites:

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -1042,6 +1042,8 @@ def liftover_mpc(
     remove_failed_sites: bool = True,
     dedup_mpc: bool = False,
     overwrite_temp: bool = False,
+    failed_sites_str: str = "locus_fail_liftover",
+    remove_liftover_annotations: Set[str] = {"new_locus", "new_alleles"},
 ) -> None:
     """
     Liftover MPC release from one genome build to another.
@@ -1060,6 +1062,12 @@ def liftover_mpc(
         Only relevant if dedup_mpc is True.
         If False, will read from existing temporary path.
         Default is False.
+    :param failed_sites_str: Name of the field containing Boolean for whether site failed liftover.
+        Default is 'locus_fail_liftover'.
+    :param remove_liftover_annotations: Set of lifted over annotations to remove.
+        Default is `{"new_locus", "new_alleles"}` as these fields are the lifted over
+        versions of the original loci and alleles and are the new keys of the lifted over
+        table.
     :return: None; function writes HT to resource path.
     """
     logger.warning(
@@ -1087,5 +1095,11 @@ def liftover_mpc(
     ht = default_lift_data(ht, remove_failed_sites=remove_failed_sites)
     # Drop unnecessary annotation if removing sites that failed liftover
     if remove_failed_sites:
-        ht = ht.drop("locus_fail_liftover")
+        ht = ht.drop(failed_sites_str)
+
+    # Drop additional unnecessary annotations if specified
+    # The defaults (`new_locus`, `new_alleles`) are already the new keys
+    # of the lifted over resource
+    if remove_liftover_annotations:
+        ht = ht.drop(*remove_liftover_annotations)
     ht.write(mpc_liftover_release.versions[freeze].path, overwrite=True)

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -1099,7 +1099,7 @@ def liftover_mpc(
         ht = ht.drop(failed_sites_str)
 
     # Drop additional unnecessary annotations if specified
-    # The defaults (`new_locus`, `new_alleles`) are already the new keys
+    # The defaults (`new_locus`, `new_alleles`) are already copied to the new keys
     # of the lifted over resource
     if remove_liftover_annotations:
         ht = ht.drop(*remove_liftover_annotations)

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -1056,7 +1056,7 @@ def liftover_mpc(
     :param remove_failed_sites: Whether to remove sites that failed to liftover from input Table.
         Default is True.
     :param dedup_mpc: Whether to deduplicate MPC scores per duplicate loci prior to liftover.
-        If True, will take the maxmimum MPC per duplicated locus.
+        If True, will take the maximum MPC per duplicated locus.
         Default is False.
     :param overwrite_temp: Whether to overwrite intermediate HT with deduplicated MPC scores.
         Only relevant if dedup_mpc is True.


### PR DESCRIPTION
Make default behavior not to deduplicate MPC prior to liftover, but maintain option to do so in the future