### PR TITLE
Begin supporting GRCh38

### DIFF
--- a/rmc/pipeline/calculate_missense_badness.py
+++ b/rmc/pipeline/calculate_missense_badness.py
@@ -28,6 +28,7 @@ def main(args):
     try:
         if args.command == "prepare-ht":
             hl.init(log="/calc_misbad_prep_context_gamma_ht.log", tmp_dir=temp_dir)
+            # TODO: Add support for outlier transcript filtering if desired
             prepare_amino_acid_ht(
                 overwrite_temp=args.overwrite_temp,
                 do_k_fold_training=args.do_k_fold_training,

--- a/rmc/resources/basics.py
+++ b/rmc/resources/basics.py
@@ -1,6 +1,8 @@
 """Script containing generic resources and Google cloud bucket paths."""
 
-from rmc.resources.resource_utils import CURRENT_BUILD
+from gnomad.resources.resource_utils import DataException
+
+from rmc.resources.resource_utils import BUILDS, CURRENT_BUILD
 
 ######################################################################
 ## Google bucket resources
@@ -19,10 +21,18 @@ RESOURCE_PREFIX = f"{RMC_PREFIX}/resources"
 Path to any non-gnomAD or VEP context resource files required for RMC or MPC.
 """
 
-RESOURCE_BUILD_PREFIX = f"{RESOURCE_PREFIX}/{CURRENT_BUILD}"
-"""
-Path to bucket for genome build-specific resource files required for RMC or MPC.
-"""
+
+def get_resource_build_prefix(build: str = CURRENT_BUILD) -> str:
+    """
+    Get the path to the bucket for genome build-specific resource files required for RMC or MPC.
+
+    :param build: Reference genome build; must be one of `BUILDS`.
+    :return: Path to bucket for genome build-specific resource files.
+    """
+    if build not in BUILDS:
+        raise DataException(f"Invalid build: {build}. Must be one of {BUILDS}!")
+    return f"{RESOURCE_PREFIX}/{build}"
+
 
 LOGGING_PATH = f"{RMC_PREFIX}/logs"
 """

--- a/rmc/resources/basics.py
+++ b/rmc/resources/basics.py
@@ -29,7 +29,7 @@ LOGGING_PATH = f"{RMC_PREFIX}/logs"
 Path to bucket for hail logs.
 """
 
-TEMP_PATH = f"{RMC_PREFIX}/temp-30day"
+TEMP_PATH = f"{RMC_PREFIX}/temp"
 """
 Path to bucket for temporary files.
 

--- a/rmc/resources/basics.py
+++ b/rmc/resources/basics.py
@@ -29,7 +29,7 @@ LOGGING_PATH = f"{RMC_PREFIX}/logs"
 Path to bucket for hail logs.
 """
 
-TEMP_PATH = f"{RMC_PREFIX}/temp"
+TEMP_PATH = f"{RMC_PREFIX}/temp-30day"
 """
 Path to bucket for temporary files.
 

--- a/rmc/resources/gnomad.py
+++ b/rmc/resources/gnomad.py
@@ -3,61 +3,20 @@ from gnomad.resources.resource_utils import TableResource, VersionedTableResourc
 
 from rmc.resources.resource_utils import CURRENT_GNOMAD_VERSION
 
-FLAGSHIP_LOF = "gs://gcp-public-data--gnomad/papers/2019-flagship-lof/v1.0"
-"""
-Path to bucket with gnomAD v2 loss-of-function (LoF) constraint results.
-"""
-
-FLAGSHIP_LOF_MODEL_PREFIX = f"{FLAGSHIP_LOF}/model"
-
-prop_obs_coverage = TableResource(
-    path=f"{FLAGSHIP_LOF_MODEL_PREFIX}/prop_observed_by_coverage_no_common_pass_filtered_bins.ht"
-)
-"""
-Table with proportion of variants observed by coverage.
-
-Calculated using `get_proportion_observed_by_coverage`.
-Input for `build_models`.
-"""
-
-possible_variants_ht = TableResource(
-    path=(
-        f"{FLAGSHIP_LOF_MODEL_PREFIX}/possible_data/possible_transcript_pop_standard.ht"
-    )
-)
-"""
-Table with all observed SNPs in hg19 fasta (context) Table.
-
-Calculated using `get_proportion_observed`.
-
-Contains multiple mutation rate annotations:
-	- mu_snp: Raw mutation rate calculated using gnomAD v2 genomes.
-	- mu_agg: `mu_snp` multiplied by the number of times the variant was seen in the context HT (`possible_variants`).
-	- adjusted_mutation_rate: `mu_agg` corrected with plateau model.
-	- mu: `mu_agg` multipled by coverage correction.
-"""
-
-mutation_rate = TableResource(
-    path=f"{FLAGSHIP_LOF_MODEL_PREFIX}/mutation_rate_methylation_bins.ht",
-)
-"""
-Table with mutation rate recalculated for gnomAD constraint.
-
-This was calculated with `calculate_mu_by_downsampling` in
-https://github.com/macarthur-lab/gnomad_lof/blob/master/constraint_utils/constraint_basics.py.
-"""
-
 constraint_ht = VersionedTableResource(
     default_version=CURRENT_GNOMAD_VERSION,
     versions={
-        CURRENT_GNOMAD_VERSION: TableResource(
+        "2.1.1": TableResource(
             path="gs://gcp-public-data--gnomad/release/2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_transcript.ht"
-        )
+        ),
+        "4.1": TableResource(
+            path="gs://gcp-public-data--gnomad/release/4.1/constraint/gnomad.v4.1.constraint_metrics.ht"
+        ),
     },
 )
 """
-Table with total observed and expected variant counts per transcript.
+Public gnomAD gene constraint Table.
 
-Calculated as part of gnomAD LoF release for v2.1.1.
-Observed variants count is annotated as `obs_mis` and expected variants count is annotated as `exp_mis`.
+v2.1.1: Observed variants count is annotated as `ht.obs_mis` and expected variants count is annotated as `ht.exp_mis`.
+v4.1: Observed variants count is annotated as `ht.mis.obs` and expected variants count is annotated as `ht.mis.exp`.
 """

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -279,7 +279,7 @@ cadd = VersionedTableResource(
     default_version="GRCh37",
     versions={
         "GRCh37": TableResource(
-            path=f"gs://seqr-reference-data/{CURRENT_BUILD}/CADD/CADD_snvs_and_indels.v1.6.ht"
+            path=f"gs://seqr-reference-data/GRCh37/CADD/CADD_snvs_and_indels.v1.6.ht"
         ),
         "GRCh38": TableResource(
             path="gs://gcp-public-data--gnomad/resources/grch38/CADD-v1.6-SNVs.ht"

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -1,5 +1,9 @@
 """Script containing reference resources."""
-from gnomad.resources.resource_utils import DataException, TableResource
+from gnomad.resources.resource_utils import (
+    DataException,
+    TableResource,
+    VersionedTableResource,
+)
 
 from rmc.resources.basics import AMINO_ACIDS_PREFIX, RESOURCE_BUILD_PREFIX
 from rmc.resources.resource_utils import CURRENT_BUILD
@@ -13,37 +17,62 @@ Path to bucket containing reference data resources.
 ####################################################################################
 ## Reference genome related resources
 ####################################################################################
-GENCODE_VERSION = "19"
+GENCODE_VERSION = "39"
 """
 GENCODE version used to annotate variants.
 
 gnomAD v2 used GENCODE v19 and VEP v85.
+gnomAD v4 used GENCODE v39 and VEP v105.
 See: https://gnomad.broadinstitute.org/help/what-version-of-gencode-was-used-to-annotate-variants.
 """
 
-VEP_VERSION = "85"
+VEP_VERSION = "105"
 """
 VEP version used to annotate variants.
 """
 
-gene_model = TableResource(path=f"{RESOURCE_BUILD_PREFIX}/browser/b37_transcripts.ht")
+gene_model = VersionedTableResource(
+    default_version=CURRENT_BUILD,
+    versions={
+        "GRCh37": TableResource(
+            path=f"{RESOURCE_BUILD_PREFIX}/browser/b37_transcripts.ht"
+        ),
+        # TODO: Update this path when the gene model table is publicly available
+        "GRCh38": TableResource(
+            path="gs://gnomad-v4-data-pipeline/output/genes/genes_grch38_annotated_5.ht"
+        ),
+    },
+)
 """
 Table containing transcript start and stop positions displayed in the browser.
 
 Contains all transcripts displayed in the browser (more than `transcript_ref` below).
 """
 
-transcript_ref = TableResource(
-    path=f"{REF_DATA_PREFIX}/ht/canonical_transcripts_genes_coordinates.ht"
+transcript_ref = VersionedTableResource(
+    default_version="GRCh37",
+    versions={
+        "GRCh37": TableResource(
+            path=f"{REF_DATA_PREFIX}/ht/canonical_transcripts_genes_coordinates.ht"
+        ),
+        # TODO: Add when GRCh38 table has been created
+    },
 )
 """
 Table containing canonical transcripts with key reference info:
-gene name from gnomAD annotations, gene name from GENCODE v19,
-Ensembl gene ID in GENCODE v19, overall and CDS start and end
+
+gene name from gnomAD annotations, gene name from GENCODE version (v19 for gnomAD v2.1.1),
+Ensembl gene ID, overall and CDS start and end
 coordinates from gnomAD annotations, and transcript strand.
 """
 
-transcript_cds = TableResource(path=f"{REF_DATA_PREFIX}/ht/b37_cds_coords.ht")
+transcript_cds = VersionedTableResource(
+    default_version="GRCh37",
+    versions={
+        "GRCh37": TableResource(path=f"{REF_DATA_PREFIX}/ht/b37_cds_coords.ht"),
+        # TODO: Add when GRCh38 table has been created
+    },
+)
 """
 Table containing coordinates for coding parts of transcripts excluding introns and UTRs.
 """
@@ -143,26 +172,40 @@ List of triplosensitive genes was determined by filtering to genes with pTriplo 
 ####################################################################################
 ## Assessment related resources
 ####################################################################################
-clinvar = TableResource(
-    path=f"{REF_DATA_PREFIX}/ht/clinvar.GRCh37.ht",
+clinvar = VersionedTableResource(
+    default_version="GRCh37",
+    versions={
+        "GRCh37": TableResource(path=f"{REF_DATA_PREFIX}/ht/clinvar.GRCh37.ht"),
+        # TODO: Add when GRCh38 table has been created
+    },
 )
 """
-
 Table of ClinVar variants.
 
-HT corresponds to 20230305 ClinVar release.
+GRCh37 HT corresponds to 20230305 ClinVar release.
 """
 
-clinvar_plp_mis_haplo = TableResource(
-    path=f"{REF_DATA_PREFIX}/ht/clinvar_pathogenic_missense_haplo.ht",
+clinvar_plp_mis_haplo = VersionedTableResource(
+    default_version="GRCh37",
+    versions={
+        "GRCh37": TableResource(
+            path=f"{REF_DATA_PREFIX}/ht/clinvar_pathogenic_missense_haplo.ht"
+        ),
+        # TODO: Add when GRCh38 table has been created
+    },
 )
 """
-ClinVar pathogenic/likely pathogenic missense variants in haploinsufficient (HI)
-genes.
+ClinVar pathogenic/likely pathogenic (P/LP) missense variants in haploinsufficient (HI) genes.
 """
 
-clinvar_plp_mis_triplo = TableResource(
-    path=f"{REF_DATA_PREFIX}/ht/clinvar_pathogenic_missense_triplo.ht",
+clinvar_plp_mis_triplo = VersionedTableResource(
+    default_version="GRCh37",
+    versions={
+        "GRCh37": TableResource(
+            path=f"{REF_DATA_PREFIX}/ht/clinvar_pathogenic_missense_triplo.ht"
+        ),
+        # TODO: Add when GRCh38 table has been created
+    },
 )
 """
 ClinVar pathogenic/likely pathogenic missense variants in triplosensitive (TS) genes.
@@ -211,8 +254,12 @@ Fu et al. Rare coding variation provides insight into the genetic architecture
 and phenotypic context of autism (2022)
 """
 
-ndd_de_novo = TableResource(
-    path=f"{REF_DATA_PREFIX}/ht/ndd_de_novo.ht",
+ndd_de_novo = VersionedTableResource(
+    default_version="GRCh37",
+    versions={
+        "GRCh37": TableResource(path=f"{REF_DATA_PREFIX}/ht/ndd_de_novo.ht"),
+        # TODO: Add when GRCh38 table has been created
+    },
 )
 """
 De novo missense variants from 46,094 neurodevelopmental disorder (NDD) cases and 5,492 controls.
@@ -228,8 +275,16 @@ Controls:
 ####################################################################################
 ## MPC related resources
 ####################################################################################
-cadd = TableResource(
-    path=f"gs://seqr-reference-data/{CURRENT_BUILD}/CADD/CADD_snvs_and_indels.v1.6.ht"
+cadd = VersionedTableResource(
+    default_version="GRCh37",
+    versions={
+        "GRCh37": TableResource(
+            path=f"gs://seqr-reference-data/{CURRENT_BUILD}/CADD/CADD_snvs_and_indels.v1.6.ht"
+        ),
+        "GRCh38": TableResource(
+            path="gs://gcp-public-data--gnomad/resources/grch38/CADD-v1.6-SNVs.ht"
+        ),
+    },
 )
 """
 Table with CADD (v1.6) raw and phredd scores.

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -6,7 +6,7 @@ from gnomad.resources.resource_utils import (
 )
 
 from rmc.resources.basics import AMINO_ACIDS_PREFIX, get_resource_build_prefix
-from rmc.resources.resource_utils import BUILDS, CURRENT_BUILD
+from rmc.resources.resource_utils import CURRENT_BUILD
 
 
 def get_ref_data_prefix(build: str = CURRENT_BUILD) -> str:
@@ -16,8 +16,6 @@ def get_ref_data_prefix(build: str = CURRENT_BUILD) -> str:
     :param build: Reference genome build. Default is `CURRENT_BUILD`.
     :return: Path to bucket for reference data resources.
     """
-    if build not in BUILDS:
-        raise DataException(f"Invalid build: {build}. Must be one of {BUILDS}!")
     return f"{get_resource_build_prefix(build)}/reference_data"
 
 

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -5,13 +5,20 @@ from gnomad.resources.resource_utils import (
     VersionedTableResource,
 )
 
-from rmc.resources.basics import AMINO_ACIDS_PREFIX, RESOURCE_BUILD_PREFIX
-from rmc.resources.resource_utils import CURRENT_BUILD
+from rmc.resources.basics import AMINO_ACIDS_PREFIX, get_resource_build_prefix
+from rmc.resources.resource_utils import BUILDS, CURRENT_BUILD
 
-REF_DATA_PREFIX = f"{RESOURCE_BUILD_PREFIX}/reference_data"
-"""
-Path to bucket containing reference data resources.
-"""
+
+def get_ref_data_prefix(build: str = CURRENT_BUILD) -> str:
+    """
+    Get the path to the bucket for reference data resources.
+
+    :param build: Reference genome build. Default is `CURRENT_BUILD`.
+    :return: Path to bucket for reference data resources.
+    """
+    if build not in BUILDS:
+        raise DataException(f"Invalid build: {build}. Must be one of {BUILDS}!")
+    return f"{get_resource_build_prefix(build)}/reference_data"
 
 
 ####################################################################################
@@ -35,7 +42,7 @@ gene_model = VersionedTableResource(
     default_version=CURRENT_BUILD,
     versions={
         "GRCh37": TableResource(
-            path=f"{RESOURCE_BUILD_PREFIX}/browser/b37_transcripts.ht"
+            path=f"{get_resource_build_prefix('GRCh37')}/browser/b37_transcripts.ht"
         ),
         # TODO: Update this path when the gene model table is publicly available
         "GRCh38": TableResource(
@@ -53,7 +60,7 @@ transcript_ref = VersionedTableResource(
     default_version="GRCh37",
     versions={
         "GRCh37": TableResource(
-            path=f"{REF_DATA_PREFIX}/ht/canonical_transcripts_genes_coordinates.ht"
+            path=f"{get_ref_data_prefix('GRCh37')}/ht/canonical_transcripts_genes_coordinates.ht"
         ),
         # TODO: Add when GRCh38 table has been created
     },
@@ -69,7 +76,9 @@ coordinates from gnomAD annotations, and transcript strand.
 transcript_cds = VersionedTableResource(
     default_version="GRCh37",
     versions={
-        "GRCh37": TableResource(path=f"{REF_DATA_PREFIX}/ht/b37_cds_coords.ht"),
+        "GRCh37": TableResource(
+            path=f"{get_ref_data_prefix('GRCh37')}/ht/b37_cds_coords.ht"
+        ),
         # TODO: Add when GRCh38 table has been created
     },
 )
@@ -91,6 +100,7 @@ def train_val_test_transcripts_path(
     is_test: bool = False,
     fold: int = None,
     is_val: bool = False,
+    build: str = CURRENT_BUILD,
 ) -> str:
     """
     Return path to HailExpression of transcripts used for model training or testing.
@@ -114,6 +124,7 @@ def train_val_test_transcripts_path(
         If False, training transcripts from the specified fold of the training set will be returned.
         If True, validation transcripts from the specified fold of the training set will be returned.
         Default is False.
+    :param build: Reference genome build. Default is `CURRENT_BUILD`.
     :return: Path to Table.
     """
     if is_test and is_val:
@@ -129,12 +140,10 @@ def train_val_test_transcripts_path(
 
     transcript_type = "test" if is_test else ("val" if is_val else "train")
     fold_name = f"_fold{fold}" if fold is not None else ""
-    return f"{RESOURCE_BUILD_PREFIX}/{transcript_type}_transcripts{fold_name}.he"
+    return f"{get_resource_build_prefix(build)}/{transcript_type}_transcripts{fold_name}.he"
 
 
-dosage_tsv_path = (
-    f"{REF_DATA_PREFIX}/Collins_rCNV_2022.dosage_sensitivity_scores.tsv.gz"
-)
+dosage_tsv_path = f"{get_ref_data_prefix('GRCh37')}/Collins_rCNV_2022.dosage_sensitivity_scores.tsv.gz"
 """
 Path to TSV of genes and dosage sensitivity scores.
 
@@ -147,21 +156,23 @@ Data are from Collins et al. A cross-disorder dosage sensitivity map of the huma
 (2022)
 """
 
-dosage_ht = TableResource(path=f"{REF_DATA_PREFIX}/ht/dosage_sensitivity.ht")
+dosage_ht = TableResource(
+    path=f"{get_ref_data_prefix('GRCh37')}/ht/dosage_sensitivity.ht"
+)
 """
 HT of genes and genes and dosage sensitivity scores.
 
 Imported from TSV at `dosage_tsv_path`.
 """
 
-haplo_genes_path = f"{REF_DATA_PREFIX}/ht/phaplo_genes.he"
+haplo_genes_path = f"{get_ref_data_prefix('GRCh37')}/ht/phaplo_genes.he"
 """
 Path to HailExpression of haploinsufficient genes.
 
 List of HI genes was determined by filtering to genes with pHaplo >= 0.86.
 """
 
-triplo_genes_path = f"{REF_DATA_PREFIX}/ht/ptriplo_genes.he"
+triplo_genes_path = f"{get_ref_data_prefix('GRCh37')}/ht/ptriplo_genes.he"
 """
 Path to HailExpression of triplosensitive genes.
 
@@ -175,7 +186,9 @@ List of triplosensitive genes was determined by filtering to genes with pTriplo 
 clinvar = VersionedTableResource(
     default_version="GRCh37",
     versions={
-        "GRCh37": TableResource(path=f"{REF_DATA_PREFIX}/ht/clinvar.GRCh37.ht"),
+        "GRCh37": TableResource(
+            path=f"{get_ref_data_prefix('GRCh37')}/ht/clinvar.GRCh37.ht"
+        ),
         # TODO: Add when GRCh38 table has been created
     },
 )
@@ -189,7 +202,7 @@ clinvar_plp_mis_haplo = VersionedTableResource(
     default_version="GRCh37",
     versions={
         "GRCh37": TableResource(
-            path=f"{REF_DATA_PREFIX}/ht/clinvar_pathogenic_missense_haplo.ht"
+            path=f"{get_ref_data_prefix('GRCh37')}/ht/clinvar_pathogenic_missense_haplo.ht"
         ),
         # TODO: Add when GRCh38 table has been created
     },
@@ -202,7 +215,7 @@ clinvar_plp_mis_triplo = VersionedTableResource(
     default_version="GRCh37",
     versions={
         "GRCh37": TableResource(
-            path=f"{REF_DATA_PREFIX}/ht/clinvar_pathogenic_missense_triplo.ht"
+            path=f"{get_ref_data_prefix('GRCh37')}/ht/clinvar_pathogenic_missense_triplo.ht"
         ),
         # TODO: Add when GRCh38 table has been created
     },
@@ -211,9 +224,7 @@ clinvar_plp_mis_triplo = VersionedTableResource(
 ClinVar pathogenic/likely pathogenic missense variants in triplosensitive (TS) genes.
 """
 
-ndd_de_novo_2020_tsv_path = (
-    f"{REF_DATA_PREFIX}/fordist_KES_combined_asc_dd_dnms_2020_04_21_annotated.txt"
-)
+ndd_de_novo_2020_tsv_path = f"{get_ref_data_prefix('GRCh37')}/fordist_KES_combined_asc_dd_dnms_2020_04_21_annotated.txt"
 """
 Path to de novo variants from 39,667 samples.
 
@@ -230,7 +241,7 @@ Satterstrom et al. Large-Scale Exome Sequencing Study Implicates Both Developmen
 and Functional Changes in the Neurobiology of Autism. (2020)
 """
 
-autism_de_novo_2022_tsv_path = f"{REF_DATA_PREFIX}/fu_2022_supp20.txt"
+autism_de_novo_2022_tsv_path = f"{get_ref_data_prefix('GRCh37')}/fu_2022_supp20.txt"
 """
 Path to de novo variants from 20,528 samples.
 
@@ -257,7 +268,9 @@ and phenotypic context of autism (2022)
 ndd_de_novo = VersionedTableResource(
     default_version="GRCh37",
     versions={
-        "GRCh37": TableResource(path=f"{REF_DATA_PREFIX}/ht/ndd_de_novo.ht"),
+        "GRCh37": TableResource(
+            path=f"{get_ref_data_prefix('GRCh37')}/ht/ndd_de_novo.ht"
+        ),
         # TODO: Add when GRCh38 table has been created
     },
 )
@@ -279,7 +292,7 @@ cadd = VersionedTableResource(
     default_version="GRCh37",
     versions={
         "GRCh37": TableResource(
-            path=f"gs://seqr-reference-data/GRCh37/CADD/CADD_snvs_and_indels.v1.6.ht"
+            path="gs://seqr-reference-data/GRCh37/CADD/CADD_snvs_and_indels.v1.6.ht"
         ),
         "GRCh38": TableResource(
             path="gs://gcp-public-data--gnomad/resources/grch38/CADD-v1.6-SNVs.ht"

--- a/rmc/resources/resource_utils.py
+++ b/rmc/resources/resource_utils.py
@@ -1,9 +1,9 @@
 """Script containing resource utility constants."""
-CURRENT_BUILD = "GRCh37"
-BUILDS = ["GRCh37"]
+CURRENT_BUILD = "GRCh38"
+BUILDS = ["GRCh37", "GRCh38"]
 
-CURRENT_GNOMAD_VERSION = "2.1.1"
-GNOMAD_VERSIONS = ["2.1.1"]
+CURRENT_GNOMAD_VERSION = "4.1"
+GNOMAD_VERSIONS = ["2.1.1", "4.1"]
 
 MISSENSE = "missense_variant"
 """

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -197,10 +197,6 @@ Global fields:
     'plateau_y_models': struct {
         total: dict<bool, array<float64>>
     }
-    'coverage_model': tuple (
-        float64,
-        float64
-    )
 ----------------------------------------
 
 NOTE: The content of the v2.1.1 freeze 1 HT for RMC is slightly different:

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -6,7 +6,6 @@ MPC: Missense badness, Polyphen-2, and Constraint score
 """
 from typing import Set
 
-import hail as hl
 import scipy
 from gnomad.resources.resource_utils import (
     DataException,
@@ -18,7 +17,6 @@ from rmc.resources.basics import (
     CONSTRAINT_PREFIX,
     MODEL_PREFIX,
     MPC_PREFIX,
-    RESOURCE_PREFIX,
     SIMUL_BREAK_TEMP_PATH,
     SINGLE_BREAK_TEMP_PATH,
     TEMP_PATH,
@@ -26,14 +24,18 @@ from rmc.resources.basics import (
 from rmc.resources.reference_data import FOLD_K
 from rmc.resources.resource_utils import CURRENT_GNOMAD_VERSION
 
-FREEZES = [1, 2, 3, 4, 5, 6, 7]
+FREEZES = [1]
 """
 RMC/MPC data versions computed with current gnomAD version.
+
+gnomAD v2.1.1 freezes: [1, 2, 3, 4, 5, 6, 7].
 """
 
-CURRENT_FREEZE = 7
+CURRENT_FREEZE = 1
 """
 Current RMC/MPC data version.
+
+Last gnomAD v2.1.1 freeze: 7.
 """
 
 P_VALUE = 0.001
@@ -88,67 +90,9 @@ simultaneous breaks searches.
 
 
 ####################################################################################
-## Original regional missense constraint resource files
-####################################################################################
-EXAC_PREFIX = f"{RESOURCE_PREFIX}/GRCh37/exac"
-"""
-Path to bucket containing ExAC constraint files.
-"""
-
-MUTATION_RATE_TABLE_PATH = f"{EXAC_PREFIX}/mutation_rate_table.tsv"
-"""
-Path to TSV containing ExAC mutation rates.
-"""
-
-DIVERGENCE_SCORES_TSV_PATH = f"{EXAC_PREFIX}/divsites_gencodev19_all_transcripts.txt"
-"""
-Path to text file with divergence scores per transcript.
-"""
-
-divergence_scores = TableResource(
-    path=f"{EXAC_PREFIX}/ht/div_scores.ht",
-    import_func=hl.import_table,
-    import_args={
-        "path": DIVERGENCE_SCORES_TSV_PATH,
-        "key": "transcript",
-        "min_partitions": 50,
-        "impute": True,
-    },
-)
-"""
-Table with divergence score between humans and macaques
-for each canonical transcript in Gencode v19.
-"""
-
-####################################################################################
 ## RMC-related resources
 ####################################################################################
-coverage_plateau_models_path = f"{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{CURRENT_FREEZE}/coverage_plateau_models.he"
-"""
-Path to HailExpression containing struct for coverage correction model and plateau models.
-
-Schema:
-    struct {
-        'plateau_models': struct {
-            total: dict<bool, array<float64>>
-        }
-        'plateau_x_models': struct {
-            total: dict<bool, array<float64>>
-        }
-        'plateau_y_models': struct {
-            total: dict<bool, array<float64>>
-        }
-        'coverage_model': tuple (
-            float64,
-            float64
-        )
-    }
-
-Used to compute expected variant counts.
-"""
-
-
-# TODO: Delete current version
+# TODO: Delete v2 freeze 7 filtered context
 filtered_context = VersionedTableResource(
     default_version=CURRENT_FREEZE,
     versions={
@@ -166,7 +110,7 @@ Table contains constraint-related annotations, including observed variant counts
 expected variant counts, probability of mutation, CpG status, gnomAD exome coverage,
 and methylation level.
 
-Schema:
+v2.1.1 schema:
 ----------------------------------------
 Global fields:
     'plateau_models': struct {
@@ -221,7 +165,7 @@ Locus-level Table used in first step of regional constraint calculation.
 
 Filtered to only one specific coding variant consequence but contains all canonical, protein-coding transcripts.
 
-Schema:
+v2.1.1 schema:
 ----------------------------------------
 Global fields:
     'plateau_models': struct {
@@ -247,7 +191,7 @@ Row fields:
 Key: ['locus', 'section']
 ----------------------------------------
 
-NOTE: The content of the freeze 1 HT for RMC is slightly different:
+NOTE: The content of the v2.1.1 freeze 1 HT for RMC is slightly different:
     - Expected counts were calculated using the workaround method instead of directly from the plateau model.
     - `mu_snp` contains the coverage-corrected not raw mutation rates.
 """
@@ -751,6 +695,8 @@ mpc_liftover_release = VersionedTableResource(
 )
 """
 Table containing gnomAD v2.1.1 MPC values lifted over to GRCh38.
+
+Only applies to gnomAD v2.1.1 MPC (we will not lift v4.1 MPC back to GRCh37).
 """
 
 ####################################################################################
@@ -765,4 +711,6 @@ TSV with RMC regions grouped by obs/exp (OE) bin.
 Annotated with proportion coding base pairs, proportion de novo missense (controls),
 proportion de novo missense (case), and proportion ClinVar pathogenic/likely pathogenic
 severe haploinsufficient missense.
+
+Currently only exists for gnomAD v2.1.1 RMC.
 """

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -110,7 +110,29 @@ Table contains constraint-related annotations, including observed variant counts
 expected variant counts, probability of mutation, CpG status, gnomAD exome coverage,
 and methylation level.
 
-v2.1.1 schema:
+v4.1 schema:
+----------------------------------------
+Row fields:
+    'locus': locus<GRCh38>
+    'alleles': array<str>
+    'context': str
+    'ref': str
+    'alt': str
+    'methylation_level': int32
+    'cpg': bool
+    'mutation_type': str
+    'annotation': str
+    'modifier': str
+    'coverage': int32
+    'transcript': str
+    'expected': float64
+    'coverage_correction': float64 # TODO: I'm assuming this will exist; will need to update if not
+    'observed': int32
+----------------------------------------
+Key: ['locus', 'alleles']
+----------------------------------------
+
+v2.1.1 schema: same as above, but in GRCh37 and with the additional global fields:
 ----------------------------------------
 Global fields:
     'plateau_models': struct {
@@ -126,25 +148,6 @@ Global fields:
         float64,
         float64
     )
-----------------------------------------
-Row fields:
-    'locus': locus<GRCh37>
-    'alleles': array<str>
-    'context': str
-    'ref': str
-    'alt': str
-    'methylation_level': int32
-    'cpg': bool
-    'mutation_type': str
-    'annotation': str
-    'modifier': str
-    'coverage': int32
-    'transcript': str
-    'expected': float64
-    'coverage_correction': float64
-    'observed': int32
-----------------------------------------
-Key: ['locus', 'alleles']
 ----------------------------------------
 
 Used to create the constraint prep Table.
@@ -165,30 +168,34 @@ Locus-level Table used in first step of regional constraint calculation.
 
 Filtered to only one specific coding variant consequence but contains all canonical, protein-coding transcripts.
 
-v2.1.1 schema:
+v4.1 schema:
 ----------------------------------------
 Global fields:
     'plateau_models': struct {
         total: dict<bool, array<float64>>
     }
-    'plateau_x_models': struct {
-        total: dict<bool, array<float64>>
-    }
-    'plateau_y_models': struct {
-        total: dict<bool, array<float64>>
-    }
-    'coverage_model': tuple (
+    'coverage_model': tuple ( # TODO: update if this doesn't exist
         float64,
         float64
     )
 ----------------------------------------
 Row fields:
-    'locus': locus<GRCh37>
+    'locus': locus<GRCh38>
     'section': str
     'observed': int32
     'expected': float64
 ----------------------------------------
 Key: ['locus', 'section']
+----------------------------------------
+
+v2.1.1 schema: same as above, but in GRCh37 and with the additional globals
+----------------------------------------
+Global fields:
+    'plateau_x_models': struct {
+        total: dict<bool, array<float64>>
+    }
+    'plateau_y_models': struct {
+        total: dict<bool, array<float64>>
 ----------------------------------------
 
 NOTE: The content of the v2.1.1 freeze 1 HT for RMC is slightly different:

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -196,11 +196,11 @@ Global fields:
     }
     'plateau_y_models': struct {
         total: dict<bool, array<float64>>
-}
-'coverage_model': tuple (
-         float64,
-         float64
-     )
+    }
+    'coverage_model': tuple (
+        float64,
+        float64
+    )
 ----------------------------------------
 
 NOTE: The content of the v2.1.1 freeze 1 HT for RMC is slightly different:

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -196,6 +196,7 @@ Global fields:
     }
     'plateau_y_models': struct {
         total: dict<bool, array<float64>>
+}
 'coverage_model': tuple (
          float64,
          float64

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -142,8 +142,8 @@ def process_context_ht(
     logger.info("Reading in gene constraint preprocessed context ht...")
     # Created using
     # https://github.com/broadinstitute/gnomad-constraint/blob/0acd2815e59c04d642bb705e6d1ca166f5d79e5f/gnomad_constraint/utils/constraint.py#L78
-    # NOTE: This table is autosome-PAR only
-    # TODO: Add allosomes
+    # NOTE: The v4.1 constraint table currently only contains autosomes
+    # TODO: Add allosomes and PAR
     ht = get_preprocessed_ht("context").ht().select_globals()
 
     logger.info("Filtering to ENSEMBL transcripts only...")

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -217,9 +217,10 @@ def get_aa_from_context(
     :return: VEP context HT filtered to keep only transcript ID, protein number, and amino acid information.
     """
     logger.info(
-        "Reading in VEP context HT and filtering to coding effects in non-outlier"
-        " canonical transcripts..."
+        "Reading in VEP context HT and filtering to coding effects in canonical"
+        " transcripts..."
     )
+    # TODO: Add option to filter to non-outliers if still desired
     # Drop globals and select only VEP transcript consequences field
     ht = process_context_ht().select_globals()
     ht = ht.select("transcript_consequences")

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -823,7 +823,7 @@ def import_kaplanis_data(overwrite: bool, liftover: bool = True) -> None:
         case_control=hl.agg.collect(kap_ht.case_control)
     )
     if liftover:
-        logger.info("Lifting data from b38 to b37...")
+        logger.info("Lifting data from b37 to b38...")
         kap_ht = default_lift_data(kap_ht)
     kap_ht.write(f"{TEMP_PATH_WITH_FAST_DEL}/kaplanis_dn.ht", overwrite=overwrite)
 

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -142,6 +142,8 @@ def process_context_ht(
     logger.info("Reading in gene constraint preprocessed context ht...")
     # Created using
     # https://github.com/broadinstitute/gnomad-constraint/blob/0acd2815e59c04d642bb705e6d1ca166f5d79e5f/gnomad_constraint/utils/constraint.py#L78
+    # NOTE: This table is autosome-PAR only
+    # TODO: Add allosomes
     ht = get_preprocessed_ht("context").ht().select_globals()
 
     logger.info("Filtering to ENSEMBL transcripts only...")

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -61,7 +61,9 @@ def prepare_amino_acid_ht(
     """
     logger.info("Reading in VEP context HT...")
     # NOTE: Keeping all variant types here because need synonymous and nonsense variants to calculate missense badness
-    # Filter to non-outlier transcripts for missense badness calculation
+    # NOTE: v2 filtered to non-outlier transcripts here for missense badness calculation
+    # However, `process_context_ht` no longer supports outlier transcript filtering;
+    # will need to add filtering logic if still desired
     context_ht = process_context_ht(filter_csq=KEEP_CODING_CSQ)
 
     logger.info("Selecting relevant annotations...")

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -62,11 +62,7 @@ def prepare_amino_acid_ht(
     logger.info("Reading in VEP context HT...")
     # NOTE: Keeping all variant types here because need synonymous and nonsense variants to calculate missense badness
     # Filter to non-outlier transcripts for missense badness calculation
-    context_ht = process_context_ht(
-        filter_csq=KEEP_CODING_CSQ,
-        filter_outlier_transcripts=True,
-        add_annotations=False,
-    )
+    context_ht = process_context_ht(filter_csq=KEEP_CODING_CSQ)
 
     logger.info("Selecting relevant annotations...")
     context_ht = context_ht.select(


### PR DESCRIPTION
This PR is the start of moving this repo to support GRCh38.

Major changes:
- Updated `process_context_ht` and removed `process_vep` to reflect updated inputs for GRCh38 and updated utility functions in gnomad_methods repo (`rmc/utils/generic.py`)

Minor changes:
- Removed all references to v2 flagship LoF resources (no longer needed; `rmc/resources/gnomad.py`)
- Bumped GENCODE and VEP versions; also converted TableResources to VersionedTableResources (with TODOs; `rmc/resources/reference_data.py`)
- Updated default reference and gnomAD versions (`rmc/resources/resource_utils.py`)
- Updated freezes and removed references to obsolete ExAC resources (`rmc/resources/rmc.py`)
- Removed obsolete ExAC functions (`rmc/utils/generic.py`)
- Updated liftover options for de novo reference data (`rmc/utils/generic.py`)
- [NEW] Fixed pylint errors associated with `process_context_ht` call in `rmc/utils/missense_badness.py`