### PR TITLE
Continue working to support build 38

### DIFF
--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -719,7 +719,7 @@ def search_for_break(
     )
     if save_chisq_ht:
         all_loci_chisq_ht_path = (
-            f"{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/constraint_prep.ht"
+            f"{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/all_loci_chisq.ht"
         )
     ht = ht.checkpoint(all_loci_chisq_ht_path, overwrite=True)
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -282,6 +282,15 @@ def create_possible_hts(
     """
     Create Table with possible variants per variant type for each locus type.
 
+    Function adds the following annotations required for expected variants calculation downstream:
+        - `possible_variants`: Number of possible variants per variant type.
+        - `mu_snp`: Mutation rate.
+        - `cpg`: CpG status.
+        - `predicted_proportion_observed`: Precursor to expected variants annotation.
+            Calculated by multiplying aggregated `mu_snp` against plateau model slope and
+            adding plateau model intercept.
+        - `expected_variants`: Expected number of variants.
+
     Region types are:
         - autosome/PAR
         - chrX nonPAR

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -190,8 +190,8 @@ def calculate_exp_from_mu(
     .. note::
         - Assumes that input Table is annotated with all of the fields in `groupings` and that
             the names match exactly.
-        - Assumes that input Table is annotated with `cpg` and `mu_snp` (raw mutation rate probability
-            without coverage correction).
+        - Assumes that input Table is annotated with `cpg`, `mu_snp` (raw mutation rate probability
+            without coverage correction), and `possible_variants`.
         - Assumes that input Table is filtered to autosomes/PAR only, X nonPAR only, or Y nonPAR only.
         - Assumes that input Table contains coverage and plateau models in its global annotations
             (`coverage_model`, `plateau_models`).

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -260,7 +260,7 @@ def calculate_exp_from_mu(
         **group_ht.index(*[context_ht[g] for g in groupings])
     )
     context_ht = context_ht.checkpoint(
-        f"{TEMP_PATH_WITH_SLOW_DEL}/{locus_type}_context_exp.ht",
+        f"{TEMP_PATH_WITH_FAST_DEL}/{locus_type}_context_exp.ht",
         _read_if_exists=not overwrite,
         overwrite=overwrite,
     )
@@ -442,7 +442,8 @@ def create_filtered_context_ht(
         )
     if zero_exp.count() > 0:
         raise DataException(
-            f"Found {zero_exp.count() - negative_exp} variants with zero expected values!"
+            f"Found {zero_exp.count() - negative_exp} variants with zero expected"
+            " values!"
         )
 
     logger.info(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -295,6 +295,7 @@ def create_possible_hts(
         Default is ["annotation", "modifier", "transcript", "coverage"].
     :param mu_ht_partitions: Number of desired partitions for mutation rate HT. Default is 100.
     :param overwrite: Whether to overwrite temporary data. Default is False.
+    :return: Table filtered to `locus_type` with possible variants per variant type.
     """
     logger.info("Filtering to region: %s", locus_type)
     ht = filter_to_region_type(ht, locus_type)

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -12,9 +12,7 @@ from gnomad.utils.constraint import (
     compute_expected_variants,
     count_variants_by_group,
 )
-from gnomad.utils.file_utils import file_exists
-
-# check_file_exists_raise_error,
+from gnomad.utils.file_utils import check_file_exists_raise_error, file_exists
 from gnomad_constraint.resources.resource_utils import get_models, get_mutation_ht
 
 from rmc.resources.basics import (
@@ -1042,10 +1040,13 @@ def merge_round_no_break_ht(
         is_breakpoint_only=False,
         freeze=freeze,
     )
-    if not file_exists(single_no_break_path):
-        raise DataException(
+    check_file_exists_raise_error(
+        single_no_break_path,
+        error_if_not_exists=True,
+        error_if_not_exists_msg=(
             f"No table found at {single_no_break_path}. Please double-check!"
-        )
+        ),
+    )
     ht = hl.read_table(single_no_break_path)
 
     # Check that all fields in `keep_annotations` are in the table
@@ -1236,8 +1237,11 @@ def get_oe_annotation(ht: hl.Table, freeze: int) -> hl.Table:
         transcript_oe=hl.coalesce(ht.rmc_transcript_oe, ht.gnomad_transcript_oe)
     )
 
-    if not file_exists(rmc_results.versions[freeze].path):
-        raise DataException("Merged RMC results table does not exist!")
+    check_file_exists_raise_error(
+        rmc_results.versions[freeze].path,
+        error_if_not_exists=True,
+        error_if_not_exists_msg="Merged RMC results table does not exist!",
+    )
     rmc_ht = rmc_results.versions[freeze].ht().key_by("interval")
     ht = ht.annotate(
         section_oe=rmc_ht.index(ht.locus, all_matches=True)

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -186,17 +186,19 @@ def calculate_exp_from_mu(
     n_partitions: int = 5000,
 ) -> hl.Table:
     """
-    Annotate Table with the per-variant (locus-allele) expected counts based on the per-variant mu.
+    Annotate context Table with the per-variant (locus-allele) expected counts based on the per-variant mu.
 
     .. note::
-        - Assumes that input Table is annotated with all of the fields in `groupings` and that
+        - Assumes that input Tables (context and possible) are annotated with all of the fields in `groupings` and that
             the names match exactly.
         - Assumes that input Table is annotated with `cpg`, `mu_snp` (raw mutation rate probability
             without coverage correction), and `possible_variants`.
         - Assumes that input Table is filtered to autosomes/PAR only, X nonPAR only, or Y nonPAR only.
         - Assumes that input Table contains coverage and plateau models in its global annotations
             (`coverage_model`, `plateau_models`).
-        - Adds `expected` annotation.
+        - Adds `expected` annotation to context Table. Note that the `expected` variant annotation added to `possible_ht`
+            reflects the total proportion of expected variant for a given variant type across the exome. The `expected` annotation
+            added to the context Table reflects the proportion of expected variation for a given variant per transcript.
 
     :param context_ht: Variant-level input context Table.
     :param possible_ht: Table containing the number of possible and predicted proportion observed

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -5,7 +5,6 @@ from typing import List, Set, Tuple, Union
 
 import hail as hl
 import scipy
-from gnomad.resources.grch37.gnomad import coverage, public_release
 from gnomad.resources.grch37.reference_data import vep_context
 from gnomad.resources.resource_utils import DataException
 from gnomad.utils.file_utils import check_file_exists_raise_error, file_exists
@@ -56,6 +55,7 @@ from rmc.utils.generic import (
     get_annotations_from_context_ht_vep,
     get_constraint_transcripts,
     get_coverage_correction_expr,
+    get_gnomad_public_release,
     get_ref_aa,
     import_clinvar,
     import_de_novo_variants,
@@ -105,14 +105,7 @@ def add_obs_annotation(
     :return: Table with observed variant annotation.
     """
     logger.info("Adding observed annotation...")
-    gnomad_ht = public_release(gnomad_data_type).ht()
-    gnomad_cov = coverage(gnomad_data_type).ht()
-    gnomad_ht = gnomad_ht.select(
-        "filters",
-        ac=gnomad_ht.freq[0].AC,
-        af=gnomad_ht.freq[0].AF,
-        gnomad_coverage=gnomad_cov[gnomad_ht.locus].median,
-    )
+    gnomad_ht = get_gnomad_public_release(gnomad_data_type)
     gnomad_ht = gnomad_ht.filter(
         keep_criteria(
             gnomad_ht.ac, gnomad_ht.af, gnomad_ht.filters, gnomad_ht.gnomad_coverage

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -5,7 +5,7 @@ from typing import List, Set, Tuple, Union
 
 import hail as hl
 import scipy
-from gnomad.resources.grch37.reference_data import vep_context
+from gnomad.resources.grch38.reference_data import vep_context
 from gnomad.resources.resource_utils import DataException
 from gnomad.utils.constraint import (
     annotate_with_mu,

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -16,7 +16,7 @@ from gnomad.utils.file_utils import check_file_exists_raise_error, file_exists
 from gnomad_constraint.resources.resource_utils import get_models, get_mutation_ht
 
 from rmc.resources.basics import (
-    SINGLE_BREAK_TEMP_PATH,
+    MODEL_PREFIX,
     TEMP_PATH,
     TEMP_PATH_WITH_FAST_DEL,
     TEMP_PATH_WITH_SLOW_DEL,
@@ -31,7 +31,11 @@ from rmc.resources.reference_data import (
     transcript_cds,
     transcript_ref,
 )
-from rmc.resources.resource_utils import KEEP_CODING_CSQ, MISSENSE
+from rmc.resources.resource_utils import (
+    CURRENT_GNOMAD_VERSION,
+    KEEP_CODING_CSQ,
+    MISSENSE,
+)
 from rmc.resources.rmc import (
     CURRENT_FREEZE,
     FINAL_ANNOTATIONS,
@@ -714,7 +718,9 @@ def search_for_break(
         f"{TEMP_PATH_WITH_FAST_DEL}/freeze{freeze}_round{search_num}_all_loci_chisq.ht"
     )
     if save_chisq_ht:
-        all_loci_chisq_ht_path = f"{SINGLE_BREAK_TEMP_PATH}/all_loci_chisq.ht"
+        all_loci_chisq_ht_path = (
+            f"{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/constraint_prep.ht"
+        )
     ht = ht.checkpoint(all_loci_chisq_ht_path, overwrite=True)
 
     ht = annotate_max_chisq_per_section(ht, freeze)

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -13,6 +13,7 @@ from gnomad.utils.constraint import (
     count_variants_by_group,
 )
 from gnomad.utils.file_utils import check_file_exists_raise_error, file_exists
+from gnomad.utils.vep import filter_vep_transcript_csqs
 from gnomad_constraint.resources.resource_utils import get_models, get_mutation_ht
 
 from rmc.resources.basics import (
@@ -69,7 +70,6 @@ from rmc.utils.generic import (
     import_de_novo_variants,
     keep_criteria,
     process_context_ht,
-    process_vep,
 )
 
 logging.basicConfig(
@@ -1411,7 +1411,15 @@ def create_context_with_oe(
         .select_globals()
         .select("vep", "was_split")
     )
-    ht = process_vep(ht, filter_csq={missense_str}, filter_outlier_transcripts=True)
+    ht = filter_vep_transcript_csqs(
+        t=ht,
+        vep_root="vep",
+        synonymous=False,
+        canonical=True,
+        ensembl_only=True,
+        filter_empty_csq=True,
+        csqs={missense_str},
+    )
     ht = ht.filter(transcripts.contains(ht.transcript_consequences.transcript_id))
     ht = get_annotations_from_context_ht_vep(ht)
     # Save context Table to temporary path with specified deletion policy because this is a very large file

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -259,6 +259,11 @@ def calculate_exp_from_mu(
     context_ht = context_ht.annotate(
         **group_ht.index(*[context_ht[g] for g in groupings])
     )
+    context_ht = context_ht.checkpoint(
+        f"{TEMP_PATH_WITH_SLOW_DEL}/{locus_type}_context_exp.ht",
+        _read_if_exists=not overwrite,
+        overwrite=overwrite,
+    )
     return context_ht
 
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -17,7 +17,7 @@ from gnomad.utils.vep import filter_vep_transcript_csqs
 from gnomad_constraint.resources.resource_utils import get_models, get_mutation_ht
 
 from rmc.resources.basics import (
-    MODEL_PREFIX,
+    CONSTRAINT_PREFIX,
     TEMP_PATH,
     TEMP_PATH_WITH_FAST_DEL,
     TEMP_PATH_WITH_SLOW_DEL,
@@ -806,7 +806,7 @@ def search_for_break(
     )
     if save_chisq_ht:
         all_loci_chisq_ht_path = (
-            f"{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/all_loci_chisq.ht"
+            f"{CONSTRAINT_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/all_loci_chisq.ht"
         )
     ht = ht.checkpoint(all_loci_chisq_ht_path, overwrite=True)
 

--- a/rmc/utils/mpc.py
+++ b/rmc/utils/mpc.py
@@ -1070,13 +1070,13 @@ def liftover_mpc(
     # Deduplicate MPC annotation by keeping largest MPC value per variant (locus/alleles) combination
     ht = dedup_annot(ht, annot="mpc", get_min=False)
     # Rename transcript information
-    ht = ht.transmute(transcript_grch37=ht.transcript)
     ht = ht.checkpoint(
         f"{TEMP_PATH_WITH_FAST_DEL}/mpc_dedup.ht",
         _read_if_exists=not overwrite_temp,
         overwrite=overwrite_temp,
     )
 
+    ht = ht.transmute(transcript_grch37=ht.transcript)
     ht = default_lift_data(ht, remove_failed_sites=remove_failed_sites)
     # Drop unnecessary annotation if removing sites that failed liftover
     if remove_failed_sites:


### PR DESCRIPTION
This PR updates `rmc/utils/constraint.py` to support GRCh38.

Major changes:
- Updated code in `create_filtered_context_ht` and `calculate_exp_from_mu` to use code from gnomad_methods or gnomad_constraint where possible

Minor changes:
- Removed redundant code from `add_obs_annotation`
- Updated `file_exists` to `check_file_exists_raise_error` where appropriate
- Update GRCh37 > GRCh38 import for `vep_context`
- Updated path for `all_loci_chisq_ht` (for more permanent storage, also consistency with upcoming PR updating pipeline script)