### PR TITLE
Final PR to migrate region code to GRCh38

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,6 @@
 # and gnomad-constraint (==main branch)
 git+https://github.com/broadinstitute/gnomad_methods@main
 git+https://github.com/broadinstitute/gnomad-constraint.git@main
-# Add gnomad_qc
-# NOTE: our repo does not rely on gnomad_qc,
-# but gnomad-constraint does, and gnomad_qc is not listed as a requirement
-# in gnomad-constraint
-git+https://github.com/broadinstitute/gnomad_qc.git@main
 hail
 patsy
 statsmodels

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -59,6 +59,7 @@ def main(args):
                 tmp_dir=TEMP_PATH_WITH_FAST_DEL,
                 quiet=args.quiet,
             )
+            hl.default_reference("GRCh38")
             logger.info("Creating filtered context HT...")
             n_partitions = 10000
             create_filtered_context_ht(
@@ -72,6 +73,7 @@ def main(args):
                 tmp_dir=TEMP_PATH_WITH_FAST_DEL,
                 quiet=args.quiet,
             )
+            hl.default_reference("GRCh38")
             logger.info("Creating constraint prep HT...")
             # Constraint prep HT is filtered to missense variants by default
             # Use these args to run constraint prep on other variant consequences
@@ -101,6 +103,7 @@ def main(args):
                 tmp_dir=TEMP_PATH_WITH_FAST_DEL,
                 quiet=args.quiet,
             )
+            hl.default_reference("GRCh38")
             chisq_threshold = hl.eval(hl.qchisqtail(P_VALUE, 1))
             if args.p_value:
                 chisq_threshold = hl.eval(hl.qchisqtail(args.p_value, 1))
@@ -226,6 +229,7 @@ def main(args):
                 tmp_dir=TEMP_PATH_WITH_FAST_DEL,
                 quiet=args.quiet,
             )
+            hl.default_reference("GRCh38")
             # Get locus input to this simultaneous break search round from single search no-break HT
             single_no_break_ht = hl.read_table(
                 single_search_round_ht_path(
@@ -372,6 +376,7 @@ def main(args):
                 tmp_dir=TEMP_PATH_WITH_FAST_DEL,
                 quiet=args.quiet,
             )
+            hl.default_reference("GRCh38")
             logger.info("Checking round paths...")
             round_nums = check_break_search_round_nums(args.freeze)
 

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -7,11 +7,16 @@ from gnomad.utils.slack import slack_notifications
 
 from rmc.resources.basics import (
     LOGGING_PATH,
-    SINGLE_BREAK_TEMP_PATH,
+    MODEL_PREFIX,
     TEMP_PATH_WITH_FAST_DEL,
     TEMP_PATH_WITH_SLOW_DEL,
 )
-from rmc.resources.resource_utils import MISSENSE, NONSENSES, SYNONYMOUS
+from rmc.resources.resource_utils import (
+    CURRENT_GNOMAD_VERSION,
+    MISSENSE,
+    NONSENSES,
+    SYNONYMOUS,
+)
 from rmc.resources.rmc import (
     CURRENT_FREEZE,
     P_VALUE,
@@ -54,9 +59,8 @@ def main(args):
                 tmp_dir=TEMP_PATH_WITH_FAST_DEL,
                 quiet=args.quiet,
             )
-            logger.warning("Code currently only processes b37 data!")
             logger.info("Creating filtered context HT...")
-            n_partitions = 30000
+            n_partitions = 10000
             create_filtered_context_ht(
                 n_partitions=args.n_partitions if args.n_partitions else n_partitions,
                 overwrite=args.overwrite_temp,
@@ -107,8 +111,7 @@ def main(args):
                 " significant break..."
             )
             if args.search_num == 1:
-                # TODO: Move existing HT to a different path so this can be remade
-                all_loci_chisq_ht_path = f"{SINGLE_BREAK_TEMP_PATH}/all_loci_chisq.ht"
+                all_loci_chisq_ht_path = f"{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{args.freeze}/constraint_prep.ht"
                 if file_exists(all_loci_chisq_ht_path) and not args.save_chisq_ht:
                     logger.info("Reading in all loci chisq HT...")
                     ht = hl.read_table(all_loci_chisq_ht_path)

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -6,8 +6,8 @@ from gnomad.utils.file_utils import file_exists
 from gnomad.utils.slack import slack_notifications
 
 from rmc.resources.basics import (
+    CONSTRAINT_PREFIX,
     LOGGING_PATH,
-    MODEL_PREFIX,
     TEMP_PATH_WITH_FAST_DEL,
     TEMP_PATH_WITH_SLOW_DEL,
 )
@@ -114,7 +114,7 @@ def main(args):
                 " significant break..."
             )
             if args.search_num == 1:
-                all_loci_chisq_ht_path = f"{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{args.freeze}/constraint_prep.ht"
+                all_loci_chisq_ht_path = f"{CONSTRAINT_PREFIX}/{CURRENT_GNOMAD_VERSION}/{args.freeze}/constraint_prep.ht"
                 if file_exists(all_loci_chisq_ht_path) and not args.save_chisq_ht:
                     logger.info("Reading in all loci chisq HT...")
                     ht = hl.read_table(all_loci_chisq_ht_path)

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -188,7 +188,7 @@ def main(args):
                 " checkpointing..."
             )
             ht = ht.annotate(breakpoint=breakpoint_ht[ht.section].locus.position)
-            # Possible checkpoint here if necessary
+
             logger.info(
                 "Splitting at breakpoints and re-annotating section starts, stops, and"
                 " names..."
@@ -243,8 +243,8 @@ def main(args):
                 freeze=args.freeze,
             )
             simul_break_by_section_path = f"{simul_results_path}/merged.ht"
-            if file_exists(simul_break_by_section_path):
-                simul_exists = True
+            simul_exists = file_exists(simul_break_by_section_path)
+            if simul_exists:
                 logger.info(
                     "Converting merged simultaneous breaks HT from section-level to"
                     " locus-level..."
@@ -295,7 +295,6 @@ def main(args):
                     "locus", section=simul_break_ht.section_1
                 ).drop("section_1", "breakpoints")
             else:
-                simul_exists = False
                 logger.info(
                     "No sections in round %i had breakpoints in simultaneous breaks"
                     " search.",
@@ -309,8 +308,8 @@ def main(args):
                 freeze=args.freeze,
             )
 
-            if file_exists(single_break_path):
-                single_exists = True
+            single_exists = file_exists(single_break_path)
+            if single_exists:
                 logger.info(
                     "Annotating single breaks with new sections and re-keying for next"
                     " search..."
@@ -337,7 +336,6 @@ def main(args):
                     "locus", section=single_break_ht.section_1
                 ).drop("section_1", "breakpoint")
             else:
-                single_exists = False
                 logger.info(
                     "No sections in round %i had breakpoints in single search.",
                     args.search_num,
@@ -374,8 +372,6 @@ def main(args):
                 tmp_dir=TEMP_PATH_WITH_FAST_DEL,
                 quiet=args.quiet,
             )
-            # TODO: Check that all downstream usages of RMC results table filter out
-            # constraint outliers appropriately
             logger.info("Checking round paths...")
             round_nums = check_break_search_round_nums(args.freeze)
 

--- a/rmc/pipeline/two_breaks/merge_hts.py
+++ b/rmc/pipeline/two_breaks/merge_hts.py
@@ -29,6 +29,7 @@ def main(args):
             log=f"/round{args.search_num}_search_for_two_breaks_merge_hts.log",
             tmp_dir=TEMP_PATH_WITH_FAST_DEL,
         )
+        hl.default_reference("GRCh38")
 
         logger.info("Merging all temp HTs...")
         raw_path = simul_search_round_bucket_path(

--- a/rmc/pipeline/two_breaks/prepare_transcripts.py
+++ b/rmc/pipeline/two_breaks/prepare_transcripts.py
@@ -46,6 +46,7 @@ def main(args):
                 log=f"/round{args.search_num}_search_for_two_breaks_create_grouped_ht.log",
                 tmp_dir=TEMP_PATH_WITH_FAST_DEL,
             )
+            hl.default_reference("GRCh38")
 
             logger.info(
                 "Creating grouped HT with lists of cumulative observed and expected"
@@ -67,6 +68,7 @@ def main(args):
                 log=f"/round{args.search_num}_search_for_two_breaks_split_sections.log",
                 tmp_dir=TEMP_PATH_WITH_FAST_DEL,
             )
+            hl.default_reference("GRCh38")
             split_sections_by_len(
                 ht_path=grouped_ht_path,
                 search_num=args.search_num,

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -1,15 +1,24 @@
 """
 This script searches for two simultaneous breaks in groups of transcripts using Hail Batch.
 
-# TODO: Add RMC repo to docker image and make sure it's up to date
-NOTE: `process_section_group` has been copied here to make sure Hail initializes properly
-(and can read from requester-pays buckets) in Batch.
+Note that a couple functions have been copied into this script from `constraint.py`:
+- `get_obs_exp_expr`
+- `get_dpois_expr`
+
+Note also that a few functions have been copied into this script from `simultaneous_breaks.py`:
+- `calculate_window_chisq`
+- `search_for_two_breaks`
+- `process_section_group`
+
+This is because python imports do not work in Hail Batch PythonJobs unless
+the python scripts are included within the provided Dockerfile, and this
+script currently relies on Hail's docker image.
 
 This script should be run locally because it submits jobs to the Hail Batch service.
 """
 import argparse
 import logging
-from typing import List
+from typing import List, Optional, Set
 
 import hail as hl
 import hailtop.batch as hb
@@ -17,17 +26,16 @@ import scipy
 from gnomad.utils.slack import slack_notifications
 from tqdm import tqdm
 
-from rmc.resources.basics import RMC_PREFIX, TEMP_PATH_WITH_FAST_DEL
+from rmc.resources.basics import TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.rmc import (
     CURRENT_FREEZE,
+    MIN_CHISQ_THRESHOLD,
     MIN_EXP_MIS,
     P_VALUE,
     grouped_single_no_break_ht_path,
-    simul_search_round_bucket_path,
     simul_sections_split_by_len_path,
 )
 from rmc.slack_creds import slack_token
-from rmc.utils.simultaneous_breaks import search_for_two_breaks
 
 logging.basicConfig(
     format="%(asctime)s (%(name)s %(lineno)s): %(message)s",
@@ -35,6 +43,321 @@ logging.basicConfig(
 )
 logger = logging.getLogger("run_batches")
 logger.setLevel(logging.INFO)
+
+
+RMC_PREFIX = "gs://regional_missense_constraint"
+"""
+Path to bucket attached to regional missense constraint (RMC) project.
+
+Adding this constant here to avoid ModuleNotFound errors in the
+PythonJobs. See `rmc.resources.basics` for full docstring.
+"""
+
+TEMP_PATH_WITH_FAST_DEL = "gs://gnomad-tmp-4day/rmc"
+"""
+Path to bucket for temporary files.
+
+Adding this constant here to avoid ModuleNotFound errors in the
+PythonJobs. See `rmc.resources.basics` for full docstring.
+"""
+
+SIMUL_BREAK_TEMP_PATH = f"{RMC_PREFIX}/temp/simul_breaks"
+"""
+Path to bucket to store temporary results for simultaneous searches.
+
+Adding this constant here to avoid ModuleNotFound errors in the
+PythonJobs. See `rmc.resources.basics` for full docstring.
+"""
+
+
+SIMUL_SEARCH_BUCKET_NAMES = {"prep", "raw_results", "final_results", "success_files"}
+"""
+Names of buckets nested within round bucket of `SIMUL_BREAK_TEMP_PATH`.
+
+Adding this constant here to avoid ModuleNotFound errors in the
+PythonJobs. See `rmc.resources.rmc` for full docstring.
+"""
+
+
+def simul_search_bucket_path(
+    search_num: Optional[int] = None,
+    freeze: int = CURRENT_FREEZE,
+) -> str:
+    """
+    Return path to bucket associated with simultaneous break search inputs and results.
+
+    Adding this constant here to avoid ModuleNotFound errors in the
+    PythonJobs. See `rmc.resources.rmc` for full docstring.
+
+    :param search_num: Search iteration number
+        (e.g., second round of searching for simultaneous break would be 2).
+        Default is None.
+    :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
+    :return: Path to simultaneous break search round bucket.
+    """
+    return (
+        f"{SIMUL_BREAK_TEMP_PATH}/{freeze}/round{search_num}"
+        if search_num
+        else f"{SIMUL_BREAK_TEMP_PATH}/{freeze}"
+    )
+
+
+def simul_search_round_bucket_path(
+    search_num: int,
+    bucket_type: str,
+    bucket_names: Set[str] = SIMUL_SEARCH_BUCKET_NAMES,
+    freeze: int = CURRENT_FREEZE,
+) -> str:
+    """
+    Return path to bucket with  Tables resulting from a specific round of simultaneous break search.
+
+    Adding this constant here to avoid ModuleNotFound errors in the
+    PythonJobs. See `rmc.resources.rmc` for full docstring.
+
+    :param search_num: Search iteration number
+        (e.g., second round of searching for single break would be 2).
+    :param bucket_type: Bucket type.
+        Must be in `bucket_names`.
+    :param bucket_names: Possible bucket names for simultaneous search bucket type.
+        Default is `SIMUL_SEARCH_BUCKET_NAMES`.
+    :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
+    :return: Path to a bucket in the simultaneous break search round bucket.
+    """
+    assert bucket_type in bucket_names, f"Bucket type must be one of {bucket_names}!"
+    return f"{simul_search_bucket_path(search_num, freeze)}/{bucket_type}"
+
+
+def get_obs_exp_expr(
+    obs_expr: hl.expr.Int64Expression,
+    exp_expr: hl.expr.Float64Expression,
+) -> hl.expr.Float64Expression:
+    """
+    Return observed/expected annotation based on inputs.
+
+    Typically imported from `constraint.py`. See `constraint.py` for full docstring.
+
+    :param hl.expr.Int64Expression obs_expr: Expression containing number of observed variants.
+    :param hl.expr.Float64Expression exp_expr: Expression containing number of expected variants.
+    :return: Observed/expected expression.
+    :rtype: hl.expr.Float64Expression
+    """
+    # Cap the o/e ratio at 1 to avoid pulling out regions that are enriched for missense variation
+    # Code is looking for missense constraint, so regions with a ratio of >= 1.0 can be grouped together
+    return hl.nanmin(obs_expr / exp_expr, 1)
+
+
+def get_dpois_expr(
+    oe_expr: hl.expr.Float64Expression,
+    obs_expr: hl.expr.Int64Expression,
+    exp_expr: hl.expr.Float64Expression,
+) -> hl.expr.StructExpression:
+    """
+    Calculate probability densities (natural log) of the observed values under a Poisson model.
+
+    Typically imported from `constraint.py`. See `constraint.py` for full docstring.
+
+    :param oe_expr: Expression of observed/expected value.
+    :param obs_expr: Expression containing observed variants count.
+    :param exp_expr: Expression containing expected variants count.
+    :return: Natural log of the probability density under Poisson model.
+    """
+    # log_p = True returns the natural logarithm of the probability density
+    return hl.dpois(obs_expr, exp_expr * oe_expr, log_p=True)
+
+
+def calculate_window_chisq(
+    max_idx: hl.expr.Int32Expression,
+    i: hl.expr.Int32Expression,
+    j: hl.expr.Int32Expression,
+    cum_obs: hl.expr.ArrayExpression,
+    cum_exp: hl.expr.ArrayExpression,
+    section_oe: hl.expr.Float64Expression,
+    min_num_exp_mis: hl.expr.Float64Expression,
+) -> hl.expr.Float64Expression:
+    """
+    Calculate chi square significance value for each possible simultaneous breaks window.
+
+    Used only when calculating simultaneous breaks.
+
+    Chi square formula: 2 * (hl.log(total_alt) - hl.log(total_null))
+
+    :param hl.expr.Int32Expression max_idx: Largest list index value.
+    :param hl.expr.Int32Expression i: Smaller list index value corresponding to the smaller position of the two break window.
+    :param hl.expr.Int32Expression j: Larger list index value corresponding to the larger position of the two break window.
+    :param hl.expr.ArrayExpression cum_obs: List containing cumulative observed missense values.
+    :param hl.expr.ArrayExpression cum_exp: List containing cumulative expected missense values.
+    :param hl.expr.Float64Expression section_oe: Transcript/transcript section overall observed/expected (OE) missense ratio.
+    :param hl.expr.Float64Expression min_num_exp_mis: Minimum expected missense value for all three windows defined by two possible
+        simultaneous breaks.
+    :return: Chi square significance value.
+    """
+    return hl.or_missing(
+        # Return missing when breakpoints do not create 3 windows
+        # (return missing when index is the smallest or largest position)
+        (i != 0) & (j != max_idx) &
+        # Return missing when any of the windows do not have the minimum
+        # number of expected missense variants
+        (cum_exp[i - 1] >= min_num_exp_mis)
+        & ((cum_exp[j] - cum_exp[i - 1]) >= min_num_exp_mis)
+        & ((cum_exp[-1] - cum_exp[j]) >= min_num_exp_mis),
+        (
+            2
+            * (
+                # Create alt distribution
+                (
+                    # Create alt distribution for section [start_pos, pos[i])
+                    # The missense values for this section are the cumulative values at
+                    # one index smaller than index i
+                    get_dpois_expr(
+                        oe_expr=get_obs_exp_expr(
+                            cum_obs[i - 1],
+                            hl.max(cum_exp[i - 1], 1e-09),
+                        ),
+                        obs_expr=cum_obs[i - 1],
+                        exp_expr=hl.max(cum_exp[i - 1], 1e-09),
+                    )
+                    # Create alt distribution for section [pos[i], pos[j]]
+                    # The missense values for this section are the cumulative values at index j
+                    # minus the cumulative values at index i -1
+                    + get_dpois_expr(
+                        oe_expr=get_obs_exp_expr(
+                            (cum_obs[j] - cum_obs[i - 1]),
+                            hl.max(cum_exp[j] - cum_exp[i - 1], 1e-09),
+                        ),
+                        obs_expr=cum_obs[j] - cum_obs[i - 1],
+                        exp_expr=hl.max(cum_exp[j] - cum_exp[i - 1], 1e-09),
+                    )
+                    # Create alt distribution for section (pos[j], end_pos]
+                    # The missense values for this section are the cumulative values at the last index
+                    # minus the cumulative values at index j
+                    + get_dpois_expr(
+                        oe_expr=get_obs_exp_expr(
+                            (cum_obs[-1] - cum_obs[j]),
+                            hl.max(cum_exp[-1] - cum_exp[j], 1e-09),
+                        ),
+                        obs_expr=cum_obs[-1] - cum_obs[j],
+                        exp_expr=hl.max(cum_exp[-1] - cum_exp[j], 1e-09),
+                    )
+                )
+                # Create null distribution
+                - (
+                    get_dpois_expr(
+                        oe_expr=section_oe,
+                        obs_expr=cum_obs[i - 1],
+                        exp_expr=hl.max(cum_exp[i - 1], 1e-09),
+                    )
+                    + get_dpois_expr(
+                        oe_expr=section_oe,
+                        obs_expr=cum_obs[j] - cum_obs[i - 1],
+                        exp_expr=hl.max(cum_exp[j] - cum_exp[i - 1], 1e-09),
+                    )
+                    + get_dpois_expr(
+                        oe_expr=section_oe,
+                        obs_expr=cum_obs[-1] - cum_obs[j],
+                        exp_expr=hl.max(cum_exp[-1] - cum_exp[j], 1e-09),
+                    )
+                )
+            )
+        ),
+    )
+
+
+def search_for_two_breaks(
+    group_ht: hl.Table,
+    count: int,
+    chisq_threshold: float = scipy.stats.chi2.ppf(1 - P_VALUE, 2),
+    min_num_exp_mis: float = MIN_EXP_MIS,
+    min_chisq_threshold: float = MIN_CHISQ_THRESHOLD,
+    save_chisq_ht: bool = False,
+    freeze: int = CURRENT_FREEZE,
+) -> hl.Table:
+    """
+    Search for transcripts/transcript sections with simultaneous breaks.
+
+    This function searches for breaks for all possible window sizes that exceed a minimum threshold of expected missense variants.
+
+    :param group_ht: Input Table aggregated by transcript/transcript section with lists of cumulative observed
+        and expected missense values. HT is filtered to contain only transcript/sections without
+        a single significant breakpoint.
+    :param count: Which transcript group is being run (based on counter generated in `main`).
+    :param chisq_threshold: Chi-square significance threshold. Default is
+        `scipy.stats.chi2.ppf(1 - P_VALUE, 2)`.
+        Default value used in ExAC was 13.8, which corresponds to a p-value of 0.001
+        with 2 degrees of freedom.
+        (https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm)
+    :param min_num_exp_mis: Minimum expected missense value for all three windows defined by two possible
+        simultaneous breaks.
+    :param min_chisq_threshold: Minimum chi square value to emit from search.
+        Default is MIN_CHISQ_THRESHOLD,
+        which corresponds to a p-value of 0.025 with 2 degrees of freedom.
+    :param save_chisq_ht: Whether to save HT with chi square values annotated for every locus
+        (as long as chi square value is >= min_chisq_threshold).
+        This saves a lot of extra data and should only occur during the initial search round.
+        Default is False.
+    :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
+    :return: Table filtered to transcript/sections with significant simultaneous breakpoints
+        and annotated with breakpoint information.
+    """
+    # Create ArrayExpression of StructExpressions that stores each
+    # pair of positions (window breakpoints) and their corresponding chi square value
+    break_values_expr = hl.range(
+        group_ht.start_idx.i_start, group_ht.i_max_idx
+    ).flatmap(
+        lambda i: hl.range(group_ht.start_idx.j_start, group_ht.j_max_idx).map(
+            lambda j: hl.struct(
+                i=i,
+                j=j,
+                chisq=hl.nanmax(
+                    calculate_window_chisq(
+                        group_ht.max_idx,
+                        i,
+                        j,
+                        group_ht.cum_obs,
+                        group_ht.cum_exp,
+                        group_ht.section_oe,
+                        min_num_exp_mis,
+                    ),
+                    -1,
+                ),
+            )
+        )
+    )
+    # Filter ArrayExpression to only keep chi square values that are at least
+    # some minimum value (to shorten this array and save on storage)
+    break_values_expr = break_values_expr.filter(
+        lambda x: x.chisq >= min_chisq_threshold
+    )
+    group_ht = group_ht.annotate(break_values=break_values_expr)
+    # Extract the positions with the maximum chi square value (the "best" break)
+    group_ht = group_ht.annotate(
+        best_break=group_ht.break_values.fold(
+            lambda x, y: hl.if_else(x.chisq >= y.chisq, x, y),
+            hl.struct(i=-1, j=-1, chisq=-99),
+        )
+    )
+    group_ht = group_ht.transmute(
+        chisq=group_ht.best_break.chisq,
+        # Adjust breakpoint inclusive/exclusiveness to be consistent with single break breakpoints, i.e.
+        # so that the breakpoint site itself is the last site in the left subsection. Thus, the resulting
+        # subsections will be divided as follows:
+        # [section_start, first_break_pos] (first_break_pos, second_break_pos] (second_break_pos, section_end]
+        breakpoints=(
+            group_ht.positions[group_ht.best_break.i] - 1,
+            group_ht.positions[group_ht.best_break.j],
+        ),
+    )
+    group_ht_path = (
+        f"{TEMP_PATH_WITH_FAST_DEL}/freeze{freeze}_batch_temp_chisq_group{count}.ht"
+    )
+    if save_chisq_ht:
+        group_ht_path = (
+            f"{SIMUL_BREAK_TEMP_PATH}/freeze{freeze}/batch_temp_chisq_group{count}.ht"
+        )
+    group_ht = group_ht.checkpoint(group_ht_path, overwrite=True)
+
+    # Remove rows with maximum chi square values below the threshold
+    group_ht = group_ht.filter(group_ht.chisq >= chisq_threshold)
+    return group_ht
 
 
 def process_section_group(
@@ -277,7 +600,7 @@ def main(args):
     if not args.docker_image:
         logger.info("Picking default docker image...")
         args.docker_image = (
-            "us-central1-docker.pkg.dev/broad-mpg-gnomad/images/rmc_simul_search"
+            "us-central1-docker.pkg.dev/hailgenetics/hail:0.2.132-py3.10"
         )
         # NOTE: Python version on your local machine must match the Python version in this image
         logger.warning(
@@ -518,8 +841,7 @@ if __name__ == "__main__":
         "--docker-image",
         help="""
         Docker image to provide to hail Batch. Must have dill, hail, and python installed.
-        Suggested image: us-central1-docker.pkg.dev/broad-mpg-gnomad/images/rmc_simul_search.
-
+        Suggested image: hailgenetics/hail:0.2.132-py3.10.
         Default is None -- script will select default image if not specified on the command line.
         """,
         default=None,

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -679,17 +679,11 @@ def main(args):
                 ), "Number of section groups doesn't match specified number of batches!"
             else:
                 group_num = count
-            if args.use_custom_machine:
-                # NOTE: you do not specify memory and cpu when specifying a custom machine
-                j = b.new_python_job(name=job_name)
-                j._machine_type = "n1-highmem-32"
-                j._preemptible = True
-                j.storage("100Gi")
-            else:
-                j = b.new_python_job(name=group[0])
-                j.memory(args.batch_memory)
-                j.cpu(args.batch_cpu)
-                j.storage(args.batch_storage)
+
+            j = b.new_python_job(name=group[0])
+            j.memory(args.batch_memory)
+            j.cpu(args.batch_cpu)
+            j.storage(args.batch_storage)
 
             j.call(
                 process_section_group,

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -2,43 +2,32 @@
 This script searches for two simultaneous breaks in groups of transcripts using Hail Batch.
 
 # TODO: Add RMC repo to docker image and make sure it's up to date
-
-Note that a couple functions have been copied into this script from `constraint.py`:
-- `get_obs_exp_expr`
-- `get_dpois_expr`
-
-Note also that a few functions have been copied into this script from `simultaneous_breaks.py`:
-- `calculate_window_chisq`
-- `search_for_two_breaks`
-- `process_section_group`
-
-This is because python imports do not work in Hail Batch PythonJobs unless
-the python scripts are included within the provided Dockerfile, and the scripts within the RMC repo are
-too interdependent (would have to copy the entire repo into the Dockerfile).
+NOTE: `process_section_group` has been copied here to make sure Hail initializes properly
+(and can read from requester-pays buckets) in Batch.
 
 This script should be run locally because it submits jobs to the Hail Batch service.
 """
 import argparse
 import logging
-from typing import List, Optional, Set
+from typing import List
 
 import hail as hl
 import hailtop.batch as hb
 import scipy
-from gnomad.resources.resource_utils import DataException
 from gnomad.utils.slack import slack_notifications
 from tqdm import tqdm
 
-from rmc.resources.basics import TEMP_PATH_WITH_FAST_DEL
+from rmc.resources.basics import RMC_PREFIX, TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.rmc import (
     CURRENT_FREEZE,
-    MIN_CHISQ_THRESHOLD,
     MIN_EXP_MIS,
     P_VALUE,
     grouped_single_no_break_ht_path,
+    simul_search_round_bucket_path,
     simul_sections_split_by_len_path,
 )
 from rmc.slack_creds import slack_token
+from rmc.utils.simultaneous_breaks import search_for_two_breaks
 
 logging.basicConfig(
     format="%(asctime)s (%(name)s %(lineno)s): %(message)s",
@@ -46,321 +35,6 @@ logging.basicConfig(
 )
 logger = logging.getLogger("run_batches")
 logger.setLevel(logging.INFO)
-
-
-RMC_PREFIX = "gs://regional_missense_constraint"
-"""
-Path to bucket attached to regional missense constraint (RMC) project.
-
-Adding this constant here to avoid ModuleNotFound errors in the
-PythonJobs. See `rmc.resources.basics` for full docstring.
-"""
-
-TEMP_PATH_WITH_FAST_DEL = "gs://gnomad-tmp-4day/rmc"
-"""
-Path to bucket for temporary files.
-
-Adding this constant here to avoid ModuleNotFound errors in the
-PythonJobs. See `rmc.resources.basics` for full docstring.
-"""
-
-SIMUL_BREAK_TEMP_PATH = f"{RMC_PREFIX}/temp/simul_breaks"
-"""
-Path to bucket to store temporary results for simultaneous searches.
-
-Adding this constant here to avoid ModuleNotFound errors in the
-PythonJobs. See `rmc.resources.basics` for full docstring.
-"""
-
-
-SIMUL_SEARCH_BUCKET_NAMES = {"prep", "raw_results", "final_results", "success_files"}
-"""
-Names of buckets nested within round bucket of `SIMUL_BREAK_TEMP_PATH`.
-
-Adding this constant here to avoid ModuleNotFound errors in the
-PythonJobs. See `rmc.resources.rmc` for full docstring.
-"""
-
-
-def simul_search_bucket_path(
-    search_num: Optional[int] = None,
-    freeze: int = CURRENT_FREEZE,
-) -> str:
-    """
-    Return path to bucket associated with simultaneous break search inputs and results.
-
-    Adding this constant here to avoid ModuleNotFound errors in the
-    PythonJobs. See `rmc.resources.rmc` for full docstring.
-
-    :param search_num: Search iteration number
-        (e.g., second round of searching for simultaneous break would be 2).
-        Default is None.
-    :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
-    :return: Path to simultaneous break search round bucket.
-    """
-    return (
-        f"{SIMUL_BREAK_TEMP_PATH}/{freeze}/round{search_num}"
-        if search_num
-        else f"{SIMUL_BREAK_TEMP_PATH}/{freeze}"
-    )
-
-
-def simul_search_round_bucket_path(
-    search_num: int,
-    bucket_type: str,
-    bucket_names: Set[str] = SIMUL_SEARCH_BUCKET_NAMES,
-    freeze: int = CURRENT_FREEZE,
-) -> str:
-    """
-    Return path to bucket with  Tables resulting from a specific round of simultaneous break search.
-
-    Adding this constant here to avoid ModuleNotFound errors in the
-    PythonJobs. See `rmc.resources.rmc` for full docstring.
-
-    :param search_num: Search iteration number
-        (e.g., second round of searching for single break would be 2).
-    :param bucket_type: Bucket type.
-        Must be in `bucket_names`.
-    :param bucket_names: Possible bucket names for simultaneous search bucket type.
-        Default is `SIMUL_SEARCH_BUCKET_NAMES`.
-    :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
-    :return: Path to a bucket in the simultaneous break search round bucket.
-    """
-    assert bucket_type in bucket_names, f"Bucket type must be one of {bucket_names}!"
-    return f"{simul_search_bucket_path(search_num, freeze)}/{bucket_type}"
-
-
-def get_obs_exp_expr(
-    obs_expr: hl.expr.Int64Expression,
-    exp_expr: hl.expr.Float64Expression,
-) -> hl.expr.Float64Expression:
-    """
-    Return observed/expected annotation based on inputs.
-
-    Typically imported from `constraint.py`. See `constraint.py` for full docstring.
-
-    :param hl.expr.Int64Expression obs_expr: Expression containing number of observed variants.
-    :param hl.expr.Float64Expression exp_expr: Expression containing number of expected variants.
-    :return: Observed/expected expression.
-    :rtype: hl.expr.Float64Expression
-    """
-    # Cap the o/e ratio at 1 to avoid pulling out regions that are enriched for missense variation
-    # Code is looking for missense constraint, so regions with a ratio of >= 1.0 can be grouped together
-    return hl.nanmin(obs_expr / exp_expr, 1)
-
-
-def get_dpois_expr(
-    oe_expr: hl.expr.Float64Expression,
-    obs_expr: hl.expr.Int64Expression,
-    exp_expr: hl.expr.Float64Expression,
-) -> hl.expr.StructExpression:
-    """
-    Calculate probability densities (natural log) of the observed values under a Poisson model.
-
-    Typically imported from `constraint.py`. See `constraint.py` for full docstring.
-
-    :param oe_expr: Expression of observed/expected value.
-    :param obs_expr: Expression containing observed variants count.
-    :param exp_expr: Expression containing expected variants count.
-    :return: Natural log of the probability density under Poisson model.
-    """
-    # log_p = True returns the natural logarithm of the probability density
-    return hl.dpois(obs_expr, exp_expr * oe_expr, log_p=True)
-
-
-def calculate_window_chisq(
-    max_idx: hl.expr.Int32Expression,
-    i: hl.expr.Int32Expression,
-    j: hl.expr.Int32Expression,
-    cum_obs: hl.expr.ArrayExpression,
-    cum_exp: hl.expr.ArrayExpression,
-    section_oe: hl.expr.Float64Expression,
-    min_num_exp_mis: hl.expr.Float64Expression,
-) -> hl.expr.Float64Expression:
-    """
-    Calculate chi square significance value for each possible simultaneous breaks window.
-
-    Used only when calculating simultaneous breaks.
-
-    Chi square formula: 2 * (hl.log(total_alt) - hl.log(total_null))
-
-    :param hl.expr.Int32Expression max_idx: Largest list index value.
-    :param hl.expr.Int32Expression i: Smaller list index value corresponding to the smaller position of the two break window.
-    :param hl.expr.Int32Expression j: Larger list index value corresponding to the larger position of the two break window.
-    :param hl.expr.ArrayExpression cum_obs: List containing cumulative observed missense values.
-    :param hl.expr.ArrayExpression cum_exp: List containing cumulative expected missense values.
-    :param hl.expr.Float64Expression section_oe: Transcript/transcript section overall observed/expected (OE) missense ratio.
-    :param hl.expr.Float64Expression min_num_exp_mis: Minimum expected missense value for all three windows defined by two possible
-        simultaneous breaks.
-    :return: Chi square significance value.
-    """
-    return hl.or_missing(
-        # Return missing when breakpoints do not create 3 windows
-        # (return missing when index is the smallest or largest position)
-        (i != 0) & (j != max_idx) &
-        # Return missing when any of the windows do not have the minimum
-        # number of expected missense variants
-        (cum_exp[i - 1] >= min_num_exp_mis)
-        & ((cum_exp[j] - cum_exp[i - 1]) >= min_num_exp_mis)
-        & ((cum_exp[-1] - cum_exp[j]) >= min_num_exp_mis),
-        (
-            2
-            * (
-                # Create alt distribution
-                (
-                    # Create alt distribution for section [start_pos, pos[i])
-                    # The missense values for this section are the cumulative values at
-                    # one index smaller than index i
-                    get_dpois_expr(
-                        oe_expr=get_obs_exp_expr(
-                            cum_obs[i - 1],
-                            hl.max(cum_exp[i - 1], 1e-09),
-                        ),
-                        obs_expr=cum_obs[i - 1],
-                        exp_expr=hl.max(cum_exp[i - 1], 1e-09),
-                    )
-                    # Create alt distribution for section [pos[i], pos[j]]
-                    # The missense values for this section are the cumulative values at index j
-                    # minus the cumulative values at index i -1
-                    + get_dpois_expr(
-                        oe_expr=get_obs_exp_expr(
-                            (cum_obs[j] - cum_obs[i - 1]),
-                            hl.max(cum_exp[j] - cum_exp[i - 1], 1e-09),
-                        ),
-                        obs_expr=cum_obs[j] - cum_obs[i - 1],
-                        exp_expr=hl.max(cum_exp[j] - cum_exp[i - 1], 1e-09),
-                    )
-                    # Create alt distribution for section (pos[j], end_pos]
-                    # The missense values for this section are the cumulative values at the last index
-                    # minus the cumulative values at index j
-                    + get_dpois_expr(
-                        oe_expr=get_obs_exp_expr(
-                            (cum_obs[-1] - cum_obs[j]),
-                            hl.max(cum_exp[-1] - cum_exp[j], 1e-09),
-                        ),
-                        obs_expr=cum_obs[-1] - cum_obs[j],
-                        exp_expr=hl.max(cum_exp[-1] - cum_exp[j], 1e-09),
-                    )
-                )
-                # Create null distribution
-                - (
-                    get_dpois_expr(
-                        oe_expr=section_oe,
-                        obs_expr=cum_obs[i - 1],
-                        exp_expr=hl.max(cum_exp[i - 1], 1e-09),
-                    )
-                    + get_dpois_expr(
-                        oe_expr=section_oe,
-                        obs_expr=cum_obs[j] - cum_obs[i - 1],
-                        exp_expr=hl.max(cum_exp[j] - cum_exp[i - 1], 1e-09),
-                    )
-                    + get_dpois_expr(
-                        oe_expr=section_oe,
-                        obs_expr=cum_obs[-1] - cum_obs[j],
-                        exp_expr=hl.max(cum_exp[-1] - cum_exp[j], 1e-09),
-                    )
-                )
-            )
-        ),
-    )
-
-
-def search_for_two_breaks(
-    group_ht: hl.Table,
-    count: int,
-    chisq_threshold: float = scipy.stats.chi2.ppf(1 - P_VALUE, 2),
-    min_num_exp_mis: float = MIN_EXP_MIS,
-    min_chisq_threshold: float = MIN_CHISQ_THRESHOLD,
-    save_chisq_ht: bool = False,
-    freeze: int = CURRENT_FREEZE,
-) -> hl.Table:
-    """
-    Search for transcripts/transcript sections with simultaneous breaks.
-
-    This function searches for breaks for all possible window sizes that exceed a minimum threshold of expected missense variants.
-
-    :param group_ht: Input Table aggregated by transcript/transcript section with lists of cumulative observed
-        and expected missense values. HT is filtered to contain only transcript/sections without
-        a single significant breakpoint.
-    :param count: Which transcript group is being run (based on counter generated in `main`).
-    :param chisq_threshold: Chi-square significance threshold. Default is
-        `scipy.stats.chi2.ppf(1 - P_VALUE, 2)`.
-        Default value used in ExAC was 13.8, which corresponds to a p-value of 0.001
-        with 2 degrees of freedom.
-        (https://www.itl.nist.gov/div898/handbook/eda/section3/eda3674.htm)
-    :param min_num_exp_mis: Minimum expected missense value for all three windows defined by two possible
-        simultaneous breaks.
-    :param min_chisq_threshold: Minimum chi square value to emit from search.
-        Default is MIN_CHISQ_THRESHOLD,
-        which corresponds to a p-value of 0.025 with 2 degrees of freedom.
-    :param save_chisq_ht: Whether to save HT with chi square values annotated for every locus
-        (as long as chi square value is >= min_chisq_threshold).
-        This saves a lot of extra data and should only occur during the initial search round.
-        Default is False.
-    :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
-    :return: Table filtered to transcript/sections with significant simultaneous breakpoints
-        and annotated with breakpoint information.
-    """
-    # Create ArrayExpression of StructExpressions that stores each
-    # pair of positions (window breakpoints) and their corresponding chi square value
-    break_values_expr = hl.range(
-        group_ht.start_idx.i_start, group_ht.i_max_idx
-    ).flatmap(
-        lambda i: hl.range(group_ht.start_idx.j_start, group_ht.j_max_idx).map(
-            lambda j: hl.struct(
-                i=i,
-                j=j,
-                chisq=hl.nanmax(
-                    calculate_window_chisq(
-                        group_ht.max_idx,
-                        i,
-                        j,
-                        group_ht.cum_obs,
-                        group_ht.cum_exp,
-                        group_ht.section_oe,
-                        min_num_exp_mis,
-                    ),
-                    -1,
-                ),
-            )
-        )
-    )
-    # Filter ArrayExpression to only keep chi square values that are at least
-    # some minimum value (to shorten this array and save on storage)
-    break_values_expr = break_values_expr.filter(
-        lambda x: x.chisq >= min_chisq_threshold
-    )
-    group_ht = group_ht.annotate(break_values=break_values_expr)
-    # Extract the positions with the maximum chi square value (the "best" break)
-    group_ht = group_ht.annotate(
-        best_break=group_ht.break_values.fold(
-            lambda x, y: hl.if_else(x.chisq >= y.chisq, x, y),
-            hl.struct(i=-1, j=-1, chisq=-99),
-        )
-    )
-    group_ht = group_ht.transmute(
-        chisq=group_ht.best_break.chisq,
-        # Adjust breakpoint inclusive/exclusiveness to be consistent with single break breakpoints, i.e.
-        # so that the breakpoint site itself is the last site in the left subsection. Thus, the resulting
-        # subsections will be divided as follows:
-        # [section_start, first_break_pos] (first_break_pos, second_break_pos] (second_break_pos, section_end]
-        breakpoints=(
-            group_ht.positions[group_ht.best_break.i] - 1,
-            group_ht.positions[group_ht.best_break.j],
-        ),
-    )
-    group_ht_path = (
-        f"{TEMP_PATH_WITH_FAST_DEL}/freeze{freeze}_batch_temp_chisq_group{count}.ht"
-    )
-    if save_chisq_ht:
-        group_ht_path = (
-            f"{SIMUL_BREAK_TEMP_PATH}/freeze{freeze}/batch_temp_chisq_group{count}.ht"
-        )
-    group_ht = group_ht.checkpoint(group_ht_path, overwrite=True)
-
-    # Remove rows with maximum chi square values below the threshold
-    group_ht = group_ht.filter(group_ht.chisq >= chisq_threshold)
-    return group_ht
 
 
 def process_section_group(
@@ -560,13 +234,6 @@ def main(args):
         tmp_dir=TEMP_PATH_WITH_FAST_DEL,
     )
 
-    # Make sure custom machine wasn't specified with under threshold
-    if args.under_threshold and args.use_custom_machine:
-        raise DataException(
-            "Do not specify --use-custom-machine when transcripts/sections are"
-            " --under-threshold size!"
-        )
-
     chisq_threshold = hl.eval(hl.qchisqtail(P_VALUE, 2))
     if args.p_value:
         chisq_threshold = hl.eval(hl.qchisqtail(args.p_value, 2))
@@ -609,23 +276,15 @@ def main(args):
 
     if not args.docker_image:
         logger.info("Picking default docker image...")
-        # Use a docker image that specifies spark memory allocation if --use-custom-machine was specified
-        if args.use_custom_machine:
-            args.docker_image = "gcr.io/broad-mpg-gnomad/rmc:20220930"
-            # Hail versions >= 0.2.119 are no longer backwards compatible
-            # (older Hail versions cannot read data written using version >= 0.2.119)
-            raise DataException(f"Hail in {args.docker_image} image is out of date!")
-        # Otherwise, use the default docker image
-        else:
-            args.docker_image = (
-                "us-central1-docker.pkg.dev/broad-mpg-gnomad/images/rmc_simul_search"
-            )
-            # NOTE: Python version on your local machine must match the Python version in this image
-            logger.warning(
-                "Using %s image; please make sure Hail and Python versions in image are"
-                " up to date",
-                args.docker_image,
-            )
+        args.docker_image = (
+            "us-central1-docker.pkg.dev/broad-mpg-gnomad/images/rmc_simul_search"
+        )
+        # NOTE: Python version on your local machine must match the Python version in this image
+        logger.warning(
+            "Using %s image; please make sure Hail and Python versions in image are"
+            " up to date",
+            args.docker_image,
+        )
 
     logger.info("Setting up Batch parameters...")
     backend = hb.ServiceBackend(
@@ -840,15 +499,6 @@ if __name__ == "__main__":
         default="broad-mpg-gnomad",
     )
     parser.add_argument(
-        "--use-custom-machine",
-        help="""
-        Use custom large machine for hail batch rather than setting batch memory, cpu, and storage.
-        Used when the batch defaults are not enough and jobs run into out of memory errors.
-        Only necessary if --over-threshold.
-        """,
-        action="store_true",
-    )
-    parser.add_argument(
         "--batch-memory",
         help="Amount of memory to request for hail batch jobs.",
         default="standard",
@@ -869,11 +519,6 @@ if __name__ == "__main__":
         help="""
         Docker image to provide to hail Batch. Must have dill, hail, and python installed.
         Suggested image: us-central1-docker.pkg.dev/broad-mpg-gnomad/images/rmc_simul_search.
-
-        If running with --use-custom-machine, Docker image must also contain this line:
-        `ENV PYSPARK_SUBMIT_ARGS="--driver-memory 8g --executor-memory 8g pyspark-shell"`
-        to make sure the job allocates memory correctly.
-        Example image: gcr.io/broad-mpg-gnomad/rmc:20220930.
 
         Default is None -- script will select default image if not specified on the command line.
         """,

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -429,6 +429,7 @@ def process_section_group(
         },
         tmp_dir=TEMP_PATH_WITH_FAST_DEL,
     )
+    hl.default_reference("GRCh38")
     ht = hl.read_table(ht_path)
     ht = ht.filter(hl.literal(section_group).contains(ht.section))
 
@@ -556,6 +557,7 @@ def main(args):
         log="search_for_two_breaks_run_batches.log",
         tmp_dir=TEMP_PATH_WITH_FAST_DEL,
     )
+    hl.default_reference("GRCh38")
 
     chisq_threshold = hl.eval(hl.qchisqtail(P_VALUE, 2))
     if args.p_value:

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -599,9 +599,7 @@ def main(args):
 
     if not args.docker_image:
         logger.info("Picking default docker image...")
-        args.docker_image = (
-            "us-central1-docker.pkg.dev/hailgenetics/hail:0.2.132-py3.10"
-        )
+        args.docker_image = "hailgenetics/hail:0.2.132-py3.11"
         # NOTE: Python version on your local machine must match the Python version in this image
         logger.warning(
             "Using %s image; please make sure Hail and Python versions in image are"

--- a/rmc/pipeline/two_breaks/run_batches.py
+++ b/rmc/pipeline/two_breaks/run_batches.py
@@ -841,7 +841,7 @@ if __name__ == "__main__":
         "--docker-image",
         help="""
         Docker image to provide to hail Batch. Must have dill, hail, and python installed.
-        Suggested image: hailgenetics/hail:0.2.132-py3.10.
+        Suggested image: hailgenetics/hail:0.2.132-py3.11.
         Default is None -- script will select default image if not specified on the command line.
         """,
         default=None,

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -4,9 +4,6 @@ This script searches for two simultaneous breaks in groups of transcripts using 
 This script should be run only on transcripts that are greater than or equal
 to the --transcript-len-threshold specified in `prepare_transcripts.py` if these transcripts are too slow or getting preempted in Hail Batch.
 Transcripts smaller than --transcript-len-threshold  should be run using `run_batches.py` as they run quickly and inexpensively in Hail Batch.
-
-If using this step to run TTN, use a large autoscaling cluster (highmem-8, scales to 100 preemptibles).
-Otherwise, an autoscaling cluster of highmem-8s that scales to 50 preemptibles should suffice.
 """
 import argparse
 import logging

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -42,6 +42,7 @@ def main(args):
             ),
             tmp_dir=TEMP_PATH_WITH_FAST_DEL,
         )
+        hl.default_reference("GRCh38")
 
         chisq_threshold = hl.eval(hl.qchisqtail(P_VALUE, 2))
         if args.p_value:

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -4,7 +4,7 @@ from typing import List
 
 import hail as hl
 import scipy
-from gnomad.utils.file_utils import file_exists, parallel_file_exists
+from gnomad.utils.file_utils import file_exists
 
 from rmc.resources.basics import SIMUL_BREAK_TEMP_PATH, TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.rmc import (
@@ -158,7 +158,6 @@ def split_sections_by_len(
 def get_sections_to_run(
     sections: List[str],
     search_num: int,
-    in_parallel: bool = True,
     freeze: int = CURRENT_FREEZE,
 ) -> List[str]:
     """
@@ -170,8 +169,6 @@ def get_sections_to_run(
     :param List[str] sections: List of transcripts/transcript sections to check.
     :param search_num: Search iteration number
         (e.g., second round of searching for single break would be 2).
-    :param bool in_parallel: Whether to check if successful file exist in parallel.
-        If True, must be run locally and not in Dataproc. Default is True.
     :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
     :return: List of transcripts/sections that didn't have success TSVs and therefore still need to be processed.
     """
@@ -186,18 +183,9 @@ def get_sections_to_run(
     for section in sections:
         section_success_map[section] = f"{success_file_path}/{section}.tsv"
 
-    if in_parallel:
-        # Use parallel_file_exists if in_parallel is set to True
-        success_tsvs_exist = parallel_file_exists(list(section_success_map.values()))
-        for section in sections:
-            if not success_tsvs_exist[section_success_map[section]]:
-                sections_to_run.append(section)
-    else:
-        # Otherwise, use `file_exists`
-        for section in sections:
-            if not file_exists(section_success_map[section]):
-                sections_to_run.append(section)
-
+    for section in sections:
+        if not file_exists(section_success_map[section]):
+            sections_to_run.append(section)
     return sections_to_run
 
 

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -166,7 +166,7 @@ def get_sections_to_run(
     .. note::
         This step needs to be run locally due to permissions involved with `parallel_file_exists`.
 
-    :param List[str] sections: List of transcripts/transcript sections to check.
+    :param sections: List of transcripts/transcript sections to check.
     :param search_num: Search iteration number
         (e.g., second round of searching for single break would be 2).
     :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
@@ -205,13 +205,13 @@ def calculate_window_chisq(
 
     Chi square formula: 2 * (hl.log(total_alt) - hl.log(total_null))
 
-    :param hl.expr.Int32Expression max_idx: Largest list index value.
-    :param hl.expr.Int32Expression i: Smaller list index value corresponding to the smaller position of the two break window.
-    :param hl.expr.Int32Expression j: Larger list index value corresponding to the larger position of the two break window.
-    :param hl.expr.ArrayExpression cum_obs: List containing cumulative observed missense values.
-    :param hl.expr.ArrayExpression cum_exp: List containing cumulative expected missense values.
-    :param hl.expr.Float64Expression section_oe: Transcript/transcript section overall observed/expected (OE) missense ratio.
-    :param hl.expr.Float64Expression min_num_exp_mis: Minimum expected missense value for all three windows defined by two possible
+    :param max_idx: Largest list index value.
+    :param i: Smaller list index value corresponding to the smaller position of the two break window.
+    :param j: Larger list index value corresponding to the larger position of the two break window.
+    :param cum_obs: List containing cumulative observed missense values.
+    :param cum_exp: List containing cumulative expected missense values.
+    :param section_oe: Transcript/transcript section overall observed/expected (OE) missense ratio.
+    :param min_num_exp_mis: Minimum expected missense value for all three windows defined by two possible
         simultaneous breaks.
     :return: Chi square significance value.
     """

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -4,7 +4,6 @@ from typing import List
 
 import hail as hl
 import scipy
-from gnomad.utils.file_utils import file_exists
 
 from rmc.resources.basics import SIMUL_BREAK_TEMP_PATH, TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.rmc import (
@@ -153,40 +152,6 @@ def split_sections_by_len(
             ),
             overwrite,
         )
-
-
-def get_sections_to_run(
-    sections: List[str],
-    search_num: int,
-    freeze: int = CURRENT_FREEZE,
-) -> List[str]:
-    """
-    Check if any transcripts/sections have been previously searched by searching for success TSV existence.
-
-    .. note::
-        This step needs to be run locally due to permissions involved with `parallel_file_exists`.
-
-    :param sections: List of transcripts/transcript sections to check.
-    :param search_num: Search iteration number
-        (e.g., second round of searching for single break would be 2).
-    :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
-    :return: List of transcripts/sections that didn't have success TSVs and therefore still need to be processed.
-    """
-    logger.info("Checking if any transcripts have already been searched...")
-    success_file_path = simul_search_round_bucket_path(
-        search_num=search_num,
-        bucket_type="success_files",
-        freeze=freeze,
-    )
-    section_success_map = {}
-    sections_to_run = []
-    for section in sections:
-        section_success_map[section] = f"{success_file_path}/{section}.tsv"
-
-    for section in sections:
-        if not file_exists(section_success_map[section]):
-            sections_to_run.append(section)
-    return sections_to_run
 
 
 def calculate_window_chisq(


### PR DESCRIPTION
(hopefully) last PR migrating region search code to GRCh38.

Major changes:
- Update docker image and remove option for custom machine in `rmc/pipeline/two_breaks/run_batches.py`

Minor changes:
- Remove `gnomad_qc` from requirements (looks like it's been added to gnomad-constraint requirements)
- Update number of desired partitions for constraint tables in `rmc/pipeline/regional_constraint.py` (also clean up some booleans and remove an obsolete TODO)
- Remove `parallel_file_exists` usage (function has been removed from gnomad_methods; `rmc/utils/simultaneous_breaks.py`)
- Remove dated cluster guidance in `rmc/pipeline/two_breaks/run_batches_dataproc.py`