### PR TITLE
Runtime fixes for v4

### DIFF
--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -413,25 +413,16 @@ def main(args):
                 overwrite=args.overwrite,
             )
 
-            if args.filter_to_canonical:
-                logger.warning("Filtering to canonical transcripts only!")
+            if args.filter_outliers or args.filter_to_canonical:
                 # NOTE: RMC search should be run on only canonical transcripts
                 # rather than filtering to canonical transcripts at this step
                 # for compute efficiency
-                canonical_transcripts = get_constraint_transcripts(
-                    all_transcripts=True,
-                    filter_to_canonical=True,
+                keep_transcripts = get_constraint_transcripts(
+                    all_transcripts=not args.filter_outliers,
+                    filter_to_canonical=args.filter_to_canonical,
+                    outlier=not args.filter_outliers,
                 )
-                rmc_ht = rmc_ht.filter(
-                    canonical_transcripts.contains(rmc_ht.transcript)
-                )
-
-            if args.filter_outliers:
-                logger.info("Removing outlier transcripts...")
-                constraint_transcripts = get_constraint_transcripts(outlier=False)
-                rmc_ht = rmc_ht.filter(
-                    constraint_transcripts.contains(rmc_ht.transcript)
-                )
+                rmc_ht = rmc_ht.filter(keep_transcripts.contains(rmc_ht.transcript))
 
             # Add p-value threshold to globals
             if not args.p_value:

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -432,6 +432,19 @@ def main(args):
             # (used in RMC assessment plots)
             # TODO: For the above, also need a transcript-level table with missense total obs and total exp
 
+            logger.info("Reformatting RMC results for browser release...")
+            format_rmc_browser_ht(
+                args.freeze, args.overwrite_temp, args.filter_to_canonical
+            )
+
+        if args.command == "create-context-with-oe":
+            hl.init(
+                log="/RMC_create_context_with_oe.log",
+                tmp_dir=TEMP_PATH_WITH_FAST_DEL,
+                quiet=args.quiet,
+            )
+            hl.default_reference("GRCh38")
+            # NOTE: This step required highmem machines for v4.1.1
             logger.info("Creating OE-annotated context table...")
             create_context_with_oe(
                 freeze=args.freeze,
@@ -439,9 +452,6 @@ def main(args):
                 overwrite_temp=args.overwrite_temp,
                 filter_outliers=args.filter_outliers,
             )
-
-            logger.info("Reformatting RMC results for browser release...")
-            format_rmc_browser_ht(args.freeze, args.overwrite_temp)
 
         if args.command == "create-rmc-release":
             logger.info(
@@ -521,6 +531,16 @@ if __name__ == "__main__":
         help="Initialize Hail with `quiet=True` to print fewer log messages",
         action="store_true",
     )
+    parser.add_argument(
+        "--filter-outliers",
+        help="Remove constraint outlier transcripts from output.",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--filter-to-canonical",
+        help="Filter to canonical transcripts only.",
+        action="store_true",
+    )
 
     subparsers = parser.add_subparsers(title="command", dest="command", required=True)
 
@@ -592,16 +612,10 @@ if __name__ == "__main__":
     finalize = subparsers.add_parser(
         "finalize", help="Combine and reformat (finalize) RMC output."
     )
-    finalize.add_argument(
-        "--filter-outliers",
-        help="Remove constraint outlier transcripts from RMC output.",
-    )
-    finalize.add_argument(
-        "--filter-to-canonical",
-        help="""
-        Filter context Table to canonical transcripts only.
-        """,
-        action="store_true",
+
+    create_oe_context = subparsers.add_parser(
+        "create-context-with-oe",
+        help="Create context Table with observed/expected values for RMC assessment.",
     )
 
     create_release = subparsers.add_parser(

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -375,7 +375,6 @@ def main(args):
                     " writing..."
                 )
                 merged_break_ht = single_break_ht.union(simul_break_ht)
-                # TODO: Change break results bucket structure to have round first, then simul vs. single split
                 merged_break_ht.write(merged_path, overwrite=args.overwrite)
             elif single_exists:
                 single_break_ht.write(merged_path, overwrite=args.overwrite)

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -255,7 +255,8 @@ def main(args):
 
             logger.info("Checking if simul breaks merged HT exists...")
             # NOTE: Not checking for row count of zero because am assuming
-            # user didn't run merge step if simul breaks search didn't return any results
+            # user didn't run merge step (`merge_hts.py`) if simul breaks search
+            # didn't return any results
             simul_results_path = simul_search_round_bucket_path(
                 search_num=args.search_num,
                 bucket_type="final_results",

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -444,7 +444,6 @@ def main(args):
                 quiet=args.quiet,
             )
             hl.default_reference("GRCh38")
-            # NOTE: This step required highmem machines for v4.1.1
             logger.info("Creating OE-annotated context table...")
             create_context_with_oe(
                 freeze=args.freeze,

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -40,6 +40,7 @@ from rmc.utils.constraint import (
     process_sections,
     validate_rmc_release_downloads,
 )
+from rmc.utils.data_loading import create_transcript_ref
 from rmc.utils.generic import get_constraint_transcripts
 
 logging.basicConfig(
@@ -53,6 +54,16 @@ logger.setLevel(logging.INFO)
 def main(args):
     """Call functions from `constraint.py` to calculate regional missense constraint."""
     try:
+        if args.command == "create-transcript-refs":
+            hl.init(
+                log="/RMC_create_transcript_refs.log",
+                tmp_dir=TEMP_PATH_WITH_FAST_DEL,
+                quiet=args.quiet,
+            )
+            hl.default_reference("GRCh38")
+            logger.info("Creating transcript reference resources...")
+            create_transcript_ref(build="GRCh38", overwrite=args.overwrite)
+
         if args.command == "prep-filtered-context":
             hl.init(
                 log="/RMC_pre_process.log",
@@ -543,6 +554,10 @@ if __name__ == "__main__":
 
     subparsers = parser.add_subparsers(title="command", dest="command", required=True)
 
+    create_transcript_refs = subparsers.add_parser(
+        "create-transcript-refs",
+        help="Create transcript reference resources.",
+    )
     prep_filtered_context = subparsers.add_parser(
         "prep-filtered-context",
         help="""

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -446,6 +446,9 @@ def main(args):
             # TODO: For the above, also need a transcript-level table with missense total obs and total exp
 
             logger.info("Reformatting RMC results for browser release...")
+            # NOTE: `filter_to_canonical` is included here only to make
+            # amino acid annotation with context HT more efficient if
+            # RMC results were filtered to canonical transcripts
             format_rmc_browser_ht(
                 args.freeze, args.overwrite_temp, args.filter_to_canonical
             )

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -414,6 +414,19 @@ def main(args):
                 overwrite=args.overwrite,
             )
 
+            if args.filter_to_canonical:
+                logger.warning("Filtering to canonical transcripts only!")
+                # NOTE: RMC search should be run on only canonical transcripts
+                # rather than filtering to canonical transcripts at this step
+                # for compute efficiency
+                canonical_transcripts = get_constraint_transcripts(
+                    all_transcripts=True,
+                    filter_to_canonical=True,
+                )
+                rmc_ht = rmc_ht.filter(
+                    canonical_transcripts.contains(rmc_ht.transcript)
+                )
+
             if args.filter_outliers:
                 logger.info("Removing outlier transcripts...")
                 constraint_transcripts = get_constraint_transcripts(outlier=False)

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -87,6 +87,7 @@ def main(args):
             )
             hl.default_reference("GRCh38")
             logger.info("Creating constraint prep HT...")
+            # Input to constraint prep step is filtered context HT created above
             # Constraint prep HT is filtered to missense variants by default
             # Use these args to run constraint prep on other variant consequences
             csq = {MISSENSE}

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -455,7 +455,6 @@ def main(args):
             create_no_breaks_he(freeze=args.freeze, overwrite=args.overwrite)
             # TODO: Create region-level table that combines `rmc_results` and `no_breaks_he`
             # (used in RMC assessment plots)
-            # TODO: For the above, also need a transcript-level table with missense total obs and total exp
 
             logger.info("Reformatting RMC results for browser release...")
             # NOTE: `filter_to_canonical` is included here only to make

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -558,6 +558,7 @@ if __name__ == "__main__":
         "create-transcript-refs",
         help="Create transcript reference resources.",
     )
+
     prep_filtered_context = subparsers.add_parser(
         "prep-filtered-context",
         help="""

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -501,7 +501,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         "This script searches for regional missense constraint in gnomAD."
     )
-    # TODO: Make subparsers for prepping for RMC and running RMC
     parser.add_argument(
         "--n-partitions",
         help="""

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -567,13 +567,6 @@ if __name__ == "__main__":
         Process VEP context HT to create allele-level filtered context HT with constraint annotations.
         """,
     )
-    prep_filtered_context.add_argument(
-        "--filter-to-canonical",
-        help="""
-        Filter context Table to canonical transcripts only.
-        """,
-        action="store_true",
-    )
 
     prep_constraint = subparsers.add_parser(
         "prep-constraint",

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -125,11 +125,11 @@ def main(args):
         )
         for counter, group in enumerate(section_groups):
             if over_threshold is None:
-                output_ht_path = f"{raw_path}/simul_break_dataproc_{counter}.ht"
-            elif over_threshold:
-                output_ht_path = f"{raw_path}/simul_break_dataproc_under_{counter}.ht"
-            else:
                 output_ht_path = f"{raw_path}/simul_break_dataproc_all_{counter}.ht"
+            elif over_threshold:
+                output_ht_path = f"{raw_path}/simul_break_dataproc_{counter}.ht"
+            else:
+                output_ht_path = f"{raw_path}/simul_break_dataproc_under_{counter}.ht"
 
             if file_exists(output_ht_path):
                 raise DataException(

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -50,7 +50,6 @@ def main(args):
 
         if args.run_all_sections:
             over_threshold = None
-            under_threshold = None
             sections_to_run = list(
                 hl.eval(
                     hl.experimental.read_expression(
@@ -88,7 +87,6 @@ def main(args):
             )
 
         if args.run_sections_under_threshold:
-            under_threshold = True
             over_threshold = False
             sections_to_run = list(
                 hl.eval(
@@ -126,9 +124,9 @@ def main(args):
             freeze=args.freeze,
         )
         for counter, group in enumerate(section_groups):
-            if over_threshold:
+            if over_threshold is None:
                 output_ht_path = f"{raw_path}/simul_break_dataproc_{counter}.ht"
-            elif under_threshold:
+            elif over_threshold:
                 output_ht_path = f"{raw_path}/simul_break_dataproc_under_{counter}.ht"
             else:
                 output_ht_path = f"{raw_path}/simul_break_dataproc_all_{counter}.ht"

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -43,7 +43,7 @@ gene_model = VersionedTableResource(
             path=f"{get_resource_build_prefix('GRCh37')}/browser/b37_transcripts.ht"
         ),
         "GRCh38": TableResource(
-            path="gs://gcp-public-data--gnomad/resources/grch38/genes/gnomad.genes.GRCh38.GENCODEv39.ht"
+            path="gs://gcp-public-data--gnomad/resources/grch38/browser/gnomad.genes.GRCh38.GENCODEv39.ht"
         ),
     },
 )

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -42,9 +42,8 @@ gene_model = VersionedTableResource(
         "GRCh37": TableResource(
             path=f"{get_resource_build_prefix('GRCh37')}/browser/b37_transcripts.ht"
         ),
-        # TODO: Update this path when the gene model table is publicly available
         "GRCh38": TableResource(
-            path="gs://gnomad-v4-data-pipeline/output/genes/genes_grch38_annotated_5.ht"
+            path="gs://gcp-public-data--gnomad/resources/grch38/genes/gnomad.genes.GRCh38.GENCODEv39.ht"
         ),
     },
 )

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -97,7 +97,7 @@ filtered_context = VersionedTableResource(
     default_version=CURRENT_FREEZE,
     versions={
         freeze: TableResource(
-            path=f"{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/context_coding_snps_annot_AN_test.ht"
+            path=f"{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/context_coding_snps_annot.ht"
         )
         for freeze in FREEZES
     },
@@ -158,7 +158,7 @@ constraint_prep = VersionedTableResource(
     default_version=CURRENT_FREEZE,
     versions={
         freeze: TableResource(
-            path=f"{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/constraint_prep_AN_test.ht"
+            path=f"{MODEL_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/constraint_prep.ht"
         )
         for freeze in FREEZES
     },

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1484,6 +1484,7 @@ def create_context_with_oe(
         vep_root="vep",
         synonymous=False,
         canonical=filter_to_canonical,
+        protein_coding=True,
         ensembl_only=True,
         filter_empty_csq=True,
         csqs={missense_str},

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1371,9 +1371,7 @@ def get_oe_annotation(ht: hl.Table, freeze: int) -> hl.Table:
     group_rmc_prep_ht = group_rmc_prep_ht.checkpoint(
         f"{TEMP_PATH_WITH_FAST_DEL}/freeze{freeze}_group_rmc_prep.ht", overwrite=True
     )
-    group_rmc_prep_ht = hl.read_table(
-        f"{TEMP_PATH_WITH_FAST_DEL}/freeze{freeze}_group_rmc_prep.ht"
-    )
+
     ht = ht.annotate(
         transcript_oe=group_rmc_prep_ht[ht.transcript].transcript_oe,
     )

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -492,7 +492,12 @@ def create_constraint_prep_ht(
     filter_csq: Set[str] = {MISSENSE}, n_partitions: int = 10000, overwrite: bool = True
 ) -> None:
     """
-    Create locus-level constraint prep Table from filtered context Table for all canonical protein-coding transcripts.
+    Create locus-level constraint prep Table from filtered context Table.
+
+    Function will remove transcripts with zero expected values transcript-wide
+    but will not do any additional transcript filtering.
+    Transcripts need to be filtered to canonical only if desired in upstream step to
+    create the `filtered_context` Table.
 
     This Table is used in the first step of regional constraint breakpoint search.
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1859,12 +1859,6 @@ def fix_region_start_stop_aas(
         _read_if_exists=not overwrite_temp,
         overwrite=overwrite_temp,
     )
-    ht = join_and_fix_aa(ht, missing_ht)
-    ht = ht.checkpoint(
-        f"{TEMP_PATH_WITH_FAST_DEL}/rmc_results_region_start_stop_aa_fix.ht",
-        _read_if_exists=not overwrite_temp,
-        overwrite=overwrite_temp,
-    )
     ht = ht.annotate(
         start_coordinate=hl.if_else(
             hl.is_missing(ht.start_aa),
@@ -1889,6 +1883,7 @@ def fix_region_start_stop_aas(
             ht.stop_coordinate,
         ),
     )
+    ht = join_and_fix_aa(ht, missing_ht)
     ht = ht.checkpoint(
         f"{TEMP_PATH_WITH_FAST_DEL}/rmc_results_all_aa_fix.ht",
         _read_if_exists=not overwrite_temp,

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1966,12 +1966,14 @@ def add_globals_rmc_browser(ht: hl.Table, keep_outliers: bool = True) -> hl.Tabl
 
     # Get all transcripts displayed on browser
     transcript_ht = gene_model.ht()
-    all_transcripts = transcript_ht.aggregate(
-        hl.agg.collect_as_set(transcript_ht.preferred_transcript_id)
+    all_transcripts = hl.literal(
+        transcript_ht.aggregate(
+            hl.agg.collect_as_set(transcript_ht.preferred_transcript_id)
+        )
     )
     if keep_outliers:
         transcripts_no_rmc = all_transcripts.difference(rmc_transcripts)
-        transcripts_not_searched = []
+        transcripts_not_searched = hl.empty_array(hl.tstr)
     else:
         transcripts_no_rmc = qc_pass_transcripts.difference(rmc_transcripts)
         transcripts_not_searched = all_transcripts.difference(qc_pass_transcripts)

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1906,8 +1906,8 @@ def check_and_fix_missing_aa(
     ht = ht.annotate(**transcript_ht[ht.transcript])
     ht = ht.annotate(
         # NOTE: This is actually the transcript end for transcripts on the negative strand
-        is_transcript_start=ht.start_coordinate == ht.cds_start,
-        is_transcript_stop=ht.stop_coordinate == ht.cds_end,
+        is_transcript_start=ht.start_coordinate.position == ht.cds_start,
+        is_transcript_stop=ht.stop_coordinate.position == ht.cds_end,
     )
     # NOTE: We adjusted transcript starts and stops that were missing AA annotations for gnomAD v2
     # Some starts and stops had uninformative amino acid information in the VEP context HT:

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -554,6 +554,7 @@ def create_constraint_prep_ht(
     # rather than CDS
     build = ht.locus.dtype.reference_genome.name
     if not file_exists(transcript_ref.versions[build].path):
+        logger.warning("Transcript reference resources do not exist -- creating now...")
         create_transcript_ref(
             build, overwrite=not file_exists(transcript_cds.versions[build].path)
         )

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1446,6 +1446,7 @@ def create_context_with_oe(
     n_partitions: int = 10000,
     overwrite_temp: bool = False,
     filter_outliers: bool = False,
+    vep_version: str = "105",
 ) -> None:
     """
     Filter VEP context Table to missense variants in canonical transcripts, and add missense observed/expected.
@@ -1467,6 +1468,7 @@ def create_context_with_oe(
         If False, will read existing intermediate temporary data rather than overwriting.
         Default is False.
     :param filter_outliers: Whether to filter out outlier transcripts. Default is False.
+    :param vep_version: VEP version to use. Default is "105".
     :return: None; function writes Table to resource path.
     """
     logger.info(
@@ -1476,10 +1478,11 @@ def create_context_with_oe(
     # Using vep_context.path to read in table with fewer partitions
     # VEP context resource has 62164 partitions
     ht = (
-        hl.read_table(vep_context.path, _n_partitions=n_partitions)
+        hl.read_table(vep_context.versions[vep_version].path)
         .select_globals()
         .select("vep", "was_split")
     )
+    ht = ht.naive_coalesce(n_partitions)
     ht = filter_vep_transcript_csqs(
         t=ht,
         vep_root="vep",

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -14,7 +14,7 @@ from gnomad.utils.constraint import (
 )
 from gnomad.utils.file_utils import check_file_exists_raise_error, file_exists
 from gnomad.utils.vep import explode_by_vep_annotation, filter_vep_transcript_csqs
-from gnomad_constraint.resources.resource_utils import get_mutation_ht
+from gnomad_constraint.resources.resource_utils import get_models, get_mutation_ht
 
 from rmc.resources.basics import (
     CONSTRAINT_PREFIX,
@@ -224,6 +224,10 @@ def calculate_exp_from_mu(
     )
 
     # TODO: uncomment when the other models exist
+    # Used this for testing:
+    # plateau_model = hl.experimental.read_expression(
+    #    "gs://gnomad/v4.1/constraint_an/models/gnomad.v4.1.plateau.autosome_par.he"
+    # )
     # if locus_type == "X":
     #    plateau_model = (
     #        get_models(model_type="plateau", genomic_region="chrx_non_par").he(),
@@ -234,9 +238,7 @@ def calculate_exp_from_mu(
     #    )
     # else:
     #    plateau_model = get_models(model_type="plateau").he()
-    plateau_model = hl.experimental.read_expression(
-        "gs://gnomad/v4.1/constraint_an/models/gnomad.v4.1.plateau.autosome_par.he"
-    )
+    plateau_model = get_models(model_type="plateau").he()
 
     agg_expr = {
         "mu": hl.agg.sum(mu_expr * cov_corr_expr),
@@ -345,17 +347,14 @@ def create_possible_hts(
 
     # Annotate HT globals with models
     possible_ht = possible_ht.annotate_globals(
-        # plateau_models=get_models(model_type="plateau").he(),
-        plateau_models=hl.experimental.read_expression(
-            "gs://gnomad/v4.1/constraint_an/models/gnomad.v4.1.plateau.autosome_par.he"
-        ),
         # TODO: Uncomment lines below when chrX/chrY, coverage models are ready
         # plateau_x_models=get_models(model_type="plateau", genomic_region="chrx_non_par").he(),
         # plateau_y_models=get_models(model_type="plateau", genomic_region="chry_non_par").he(),
-        # coverage_model=plateau_x_models=get_models(model_type="coverage").he(),
-        coverage_model=hl.experimental.read_expression(
-            "gs://gnomad/v4.1/constraint_an/models/gnomad.v4.1.coverage.autosome_par.he"
-        ),
+        # Used this for testing
+        # coverage_model=hl.experimental.read_expression(
+        #     "gs://gnomad/v4.1/constraint_an/models/gnomad.v4.1.coverage.autosome_par.he"
+        # ),
+        coverage_model=get_models(model_type="coverage").he(),
     )
     possible_ht = possible_ht.checkpoint(
         f"{TEMP_PATH_WITH_FAST_DEL}/{locus_type}_possible_variants.ht",

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1585,6 +1585,16 @@ def join_and_fix_aa(ht: hl.Table, fix_ht: hl.Table) -> hl.Table:
     :return: RMC regions HT annotated with amino acid information from fix HT.
     """
     return ht.annotate(
+        start_coordinate=hl.if_else(
+            hl.is_missing(ht.start_aa),
+            fix_ht[ht.interval, ht.transcript].start_coordinate,
+            ht.start_coordinate,
+        ),
+        stop_coordinate=hl.if_else(
+            hl.is_missing(ht.stop_aa),
+            fix_ht[ht.interval, ht.transcript].stop_coordinate,
+            ht.stop_coordinate,
+        ),
         start_aa=hl.if_else(
             hl.is_missing(ht.start_aa),
             fix_ht[ht.interval, ht.transcript].start_aa,
@@ -1702,7 +1712,9 @@ def fix_transcript_start_stop_aas(
             miss_start_stop_ht.stop_aa,
         ),
     )
-    return miss_start_stop_ht.select("start_aa", "stop_aa")
+    return miss_start_stop_ht.select(
+        "start_aa", "stop_aa", "start_coordinate", "stop_coordinate"
+    )
 
 
 def fix_region_start_stop_aas(
@@ -1852,8 +1864,23 @@ def fix_region_start_stop_aas(
             context_ht[missing_ht.prev_exon_stop, missing_ht.transcript].ref_aa,
             missing_ht.stop_aa,
         ),
+        start_coordinate=hl.if_else(
+            hl.is_defined(missing_ht.next_exon_start),
+            missing_ht.next_exon_start,
+            missing_ht.start_coordinate,
+        ),
+        stop_coordinate=hl.if_else(
+            hl.is_defined(missing_ht.prev_exon_stop),
+            missing_ht.prev_exon_stop,
+            missing_ht.stop_coordinate,
+        ),
     )
-    return missing_ht.select("start_aa", "stop_aa")
+    return missing_ht.select(
+        "start_aa",
+        "stop_aa",
+        "start_coordinate",
+        "stop_coordinate",
+    )
 
 
 def check_and_fix_missing_aa(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1967,7 +1967,7 @@ def add_globals_rmc_browser(ht: hl.Table, keep_outliers: bool = True) -> hl.Tabl
     # Get all transcripts displayed on browser
     transcript_ht = gene_model.ht()
     all_transcripts = transcript_ht.aggregate(
-        hl.agg.collect_as_set(transcript_ht.transcript)
+        hl.agg.collect_as_set(transcript_ht.preferred_transcript_id)
     )
     if keep_outliers:
         transcripts_no_rmc = all_transcripts.difference(rmc_transcripts)

--- a/rmc/utils/data_loading.py
+++ b/rmc/utils/data_loading.py
@@ -80,7 +80,7 @@ def get_start_end_coords(ht: hl.Table, overwrite: bool = True) -> hl.Table:
     :return: Table with transcript and CDS start/end coordinates.
     """
     # Drop unnecessary annotations
-    ht = ht.select("chrom", "start", "stop", "exons")
+    ht = ht.select("chrom", "start", "stop", exons=ht.transcript.exons)
 
     # Explode exon annotation to get CDS intervals
     ht = ht.explode("exons")

--- a/rmc/utils/data_loading.py
+++ b/rmc/utils/data_loading.py
@@ -174,7 +174,7 @@ def create_transcript_ref(
         hgnc_symbol=ht.symbol,
     )
     ht = ht.annotate(
-        exons=ht.transcripts.exons,
+        exons=ht.transcripts[0].exons,
         transcript_version=ht.transcripts[0].transcript_version,
         chrom=hl.if_else(
             ht.chrom.startswith("chr"), ht.chrom, hl.format("%s%s", "chr", ht.chrom)

--- a/rmc/utils/data_loading.py
+++ b/rmc/utils/data_loading.py
@@ -41,6 +41,7 @@ logger.setLevel(logging.INFO)
 def create_transcript_cds(
     ht: hl.Table,
     build: str = CURRENT_BUILD,
+    keep_canonical_annotation: bool = False,
 ) -> None:
     """
     Create transcript reference Table with CDS annotations.
@@ -48,6 +49,8 @@ def create_transcript_cds(
     .. note ::
         - This function was written to create the GRCh38 Table only;
             the GRCh37 HT was created using code in a notebook.
+        - Assumes `preferred_transcript_id` is present in input HT
+            if `keep_canonical_annotation` is True.
 
     :param ht: Filtered gene model Table.
     :param build: Reference genome build. Default is CURRENT_BUILD.
@@ -64,7 +67,8 @@ def create_transcript_cds(
             reference_genome=build,
         )
     )
-    ht = ht.key_by("interval", "transcript").select()
+    keep_annotations = ["preferred_transcript_id"] if keep_canonical_annotation else []
+    ht = ht.key_by("interval", "transcript").select(*keep_annotations)
     ht.write(transcript_cds.versions[build].path, overwrite=True)
 
 
@@ -195,6 +199,10 @@ def create_transcript_ref(
         )
     else:
         # Add additional boolean to track whether transcript ID is preferred ID
+        # NOTE: This annotation is added for convenience but is not
+        # currently referenced anywhere in the repo
+        # TODO: add code to filter based on `is_preferred_transcript`
+        # if desired in the future
         extra_annotation = "is_preferred_transcript"
         start_annotations.append(extra_annotation)
         final_annotations.append(extra_annotation)

--- a/rmc/utils/data_loading.py
+++ b/rmc/utils/data_loading.py
@@ -174,12 +174,12 @@ def create_transcript_ref(
         hgnc_symbol=ht.symbol,
     )
     ht = ht.annotate(
+        exons=ht.transcripts.exons,
         transcript_version=ht.transcripts[0].transcript_version,
         chrom=hl.if_else(
             ht.chrom.startswith("chr"), ht.chrom, hl.format("%s%s", "chr", ht.chrom)
         ),
     )
-    ht = ht.annotate(exons=ht.transcripts.exons)
     ht = ht.select(*start_annotations)
     ht = ht.checkpoint(f"{TEMP_PATH_WITH_FAST_DEL}/gene_model_filt.ht", overwrite=True)
 

--- a/rmc/utils/data_loading.py
+++ b/rmc/utils/data_loading.py
@@ -173,9 +173,6 @@ def create_transcript_ref(
         # (but not all canonical are MANE select)
         ht = ht.key_by(transcript=ht.preferred_transcript_id)
 
-        # Filter transcript row annotation to canonical transcripts,
-        # rename symbol to hgnc_symbol, annotate with transcript version,
-        # and add 'chr' prefix to chrom if it doesn't exist
         ht = ht.transmute(
             transcripts=ht.transcripts.filter(
                 lambda x: x.transcript_id == ht.transcript
@@ -189,6 +186,8 @@ def create_transcript_ref(
                 "Transcript array length is not equal to 1 for"
                 f" {transcript_len_check} rows. Please double check!",
             )
+
+        # Filter transcript row annotation to canonical transcripts
         ht = ht.annotate(
             exons=ht.transcripts[0].exons,
             transcript_version=ht.transcripts[0].transcript_version,
@@ -210,6 +209,8 @@ def create_transcript_ref(
             is_preferred_transcript=(ht.transcript == ht.preferred_transcript_id),
         )
 
+    # Rename symbol to hgnc_symbol and add
+    # 'chr' prefix to chrom if it doesn't exist
     ht = ht.annotate(
         hgnc_symbol=ht.symbol,
         chrom=hl.if_else(

--- a/rmc/utils/data_loading.py
+++ b/rmc/utils/data_loading.py
@@ -86,11 +86,11 @@ def get_start_end_coords(ht: hl.Table, overwrite: bool = True) -> hl.Table:
     ht = ht.explode("exons")
     ht = ht.filter(ht.exons.feature_type == "CDS")
 
-    if not file_exists(transcript_cds.versions[CURRENT_BUILD].path):
-        if not overwrite:
-            raise DataException(
-                "`overwrite` is False, but `transcript_cds` does not exist!"
-            )
+    if not file_exists(transcript_cds.versions[CURRENT_BUILD].path) and not overwrite:
+        raise DataException(
+            "`overwrite` is False, but `transcript_cds` does not exist!"
+        )
+    if not file_exists(transcript_cds.versions[CURRENT_BUILD].path) or overwrite:
         # Create `transcript_cds` resource with filtered table
         create_transcript_cds(ht)
 

--- a/rmc/utils/data_loading.py
+++ b/rmc/utils/data_loading.py
@@ -86,13 +86,12 @@ def get_start_end_coords(ht: hl.Table, overwrite: bool = True) -> hl.Table:
     ht = ht.explode("exons")
     ht = ht.filter(ht.exons.feature_type == "CDS")
 
-    if not file_exists(transcript_cds.versions[CURRENT_BUILD].path) and not overwrite:
-        raise DataException(
-            "`overwrite` is False, but `transcript_cds` does not exist!"
-        )
     if not file_exists(transcript_cds.versions[CURRENT_BUILD].path) or overwrite:
         # Create `transcript_cds` resource with filtered table
         create_transcript_cds(ht)
+
+    if not overwrite:
+        logger.warning("Overwrite is False; skipping CDS interval creation...")
 
     # Group by transcript and aggregate start/end coordinates
     ht = ht.group_by("transcript").aggregate(

--- a/rmc/utils/data_loading.py
+++ b/rmc/utils/data_loading.py
@@ -142,7 +142,7 @@ def create_transcript_ref(
         - This function was written to create the GRCh38 Table only;
             the GRCh37 HT was created using code in a notebook.
         - Assumes all `annotations` (except `hgnc_symbol` and `transcript_version`)
-            are present at top level of gene model HT.
+            are present in gene model HT.
 
     :param build: Reference genome build. Default is CURRENT_BUILD.
     :param start_annotations: List of non-keyed annotations to select from gene model Table.

--- a/rmc/utils/data_loading.py
+++ b/rmc/utils/data_loading.py
@@ -148,7 +148,7 @@ def create_transcript_ref(
     :param start_annotations: List of non-keyed annotations to select from gene model Table.
         Default is ["chrom", "start", "stop", "strand", "exons", "gencode_symbol", "hgnc_symbol", "transcript_version"].
     :param final_annotations: List of non-keyed annotations to keep in final Table.
-        Default is ["chrom", "transcript_start", "transcript_stop", "cds_start", "cds_end", "strand", "gene_id", "gencode_symbol", "hgnc_symbol", "transcript_version"].
+        Default is ["chrom", "transcript_start", "transcript_end", "cds_start", "cds_end", "strand", "gene_id", "gencode_symbol", "hgnc_symbol", "transcript_version"].
     :param overwrite: Whether to overwrite `transcript_cds` resource. Default is True.
     :return: None; writes Table to resource path.
     """

--- a/rmc/utils/data_loading.py
+++ b/rmc/utils/data_loading.py
@@ -173,6 +173,12 @@ def create_transcript_ref(
         transcripts=ht.transcripts.filter(lambda x: x.transcript_id == ht.transcript),
         hgnc_symbol=ht.symbol,
     )
+    transcript_len_check = ht.aggregate(hl.agg.count_where(hl.len(ht.transcripts) != 1))
+    if transcript_len_check > 0:
+        raise DataException(
+            "Transcript array length is not equal to 1 for"
+            f" {transcript_len_check} rows. Please double check!",
+        )
     ht = ht.annotate(
         exons=ht.transcripts[0].exons,
         transcript_version=ht.transcripts[0].transcript_version,

--- a/rmc/utils/data_loading.py
+++ b/rmc/utils/data_loading.py
@@ -80,7 +80,7 @@ def get_start_end_coords(ht: hl.Table, overwrite: bool = True) -> hl.Table:
     :return: Table with transcript and CDS start/end coordinates.
     """
     # Drop unnecessary annotations
-    ht = ht.select("chrom", "start", "stop", exons=ht.transcript.exons)
+    ht = ht.select("chrom", "start", "stop", exons=ht.transcripts.exons)
 
     # Explode exon annotation to get CDS intervals
     ht = ht.explode("exons")

--- a/rmc/utils/data_loading.py
+++ b/rmc/utils/data_loading.py
@@ -80,7 +80,7 @@ def get_start_end_coords(ht: hl.Table, overwrite: bool = True) -> hl.Table:
     :return: Table with transcript and CDS start/end coordinates.
     """
     # Drop unnecessary annotations
-    ht = ht.select("chrom", "start", "stop", exons=ht.transcripts.exons)
+    ht = ht.select("chrom", "start", "stop", "exons")
 
     # Explode exon annotation to get CDS intervals
     ht = ht.explode("exons")
@@ -179,6 +179,7 @@ def create_transcript_ref(
             ht.chrom.startswith("chr"), ht.chrom, hl.format("%s%s", "chr", ht.chrom)
         ),
     )
+    ht = ht.annotate(exons=ht.transcripts.exons)
     ht = ht.select(*start_annotations)
     ht = ht.checkpoint(f"{TEMP_PATH_WITH_FAST_DEL}/gene_model_filt.ht", overwrite=True)
 

--- a/rmc/utils/data_loading.py
+++ b/rmc/utils/data_loading.py
@@ -155,7 +155,8 @@ def create_transcript_ref(
     :param final_annotations: List of non-keyed annotations to keep in final Table.
         Default is ["chrom", "transcript_start", "transcript_end", "cds_start", "cds_end", "strand", "gene_id", "gencode_symbol", "hgnc_symbol", "transcript_version"].
     :param overwrite: Whether to overwrite `transcript_cds` resource. Default is True.
-    :param filter_to_canonical: Whether to filter to canonical transcripts only. Default is False.
+    :param filter_to_canonical: Whether to filter to canonical transcripts only.
+        Applies to both `transcript_ref` and `transcript_cds` resources. Default is False.
     :return: None; writes Table to resource path.
     """
     ht = gene_model.versions[build].ht()

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -614,15 +614,18 @@ def get_constraint_transcripts(outlier: bool = True) -> hl.expr.SetExpression:
 
     constraint_transcript_ht = constraint_ht.ht().key_by("transcript")
     constraint_transcript_ht = constraint_transcript_ht.filter(
+        constraint_transcript_ht.transcript.contains("ENST")
+    )
+    constraint_transcript_ht = constraint_transcript_ht.filter(
         constraint_transcript_ht.canonical
     ).select("constraint_flags")
     if outlier:
         constraint_transcript_ht = constraint_transcript_ht.filter(
-            hl.len(constraint_transcript_ht.constraint_flag) > 0
+            hl.len(constraint_transcript_ht.constraint_flags) > 0
         )
     else:
         constraint_transcript_ht = constraint_transcript_ht.filter(
-            hl.len(constraint_transcript_ht.constraint_flag) == 0
+            hl.len(constraint_transcript_ht.constraint_flags) == 0
         )
     return hl.literal(
         constraint_transcript_ht.aggregate(

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -182,6 +182,7 @@ def get_aa_from_context(
     keep_transcripts: Set[str] = None,
     n_partitions: int = 10000,
     filter_to_canonical: bool = False,
+    vep_version: str = "105",
 ) -> hl.Table:
     """
     Extract amino acid information from VEP context HT.
@@ -194,6 +195,8 @@ def get_aa_from_context(
         Default is None.
     :param n_partitions: Desired number of partitions for context HT after filtering.
         Default is 10,000.
+    :param filter_to_canonical: Whether to filter to canonical transcripts only. Default is False.
+    :param vep_version: VEP version to use. Default is "105".
     :return: VEP context HT filtered to keep only transcript ID, protein number, and amino acid information.
     """
     logger.info(
@@ -202,7 +205,11 @@ def get_aa_from_context(
     )
     # TODO: Add option to filter to non-outliers if still desired
     # Drop globals and select only VEP transcript consequences field
-    ht = hl.read_table(vep_context.path).select_globals().select("vep", "was_split")
+    ht = (
+        hl.read_table(vep_context.versions[vep_version].path)
+        .select_globals()
+        .select("vep", "was_split")
+    )
     ht = ht.naive_coalesce(n_partitions)
     ht = filter_vep_transcript_csqs(
         t=ht,

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -614,7 +614,7 @@ def get_constraint_transcripts(
     https://gnomad.broadinstitute.org/faq#why-are-constraint-metrics-missing-for-this-gene-or-annotated-with-a-note
 
     :param all_transcripts: Whether to filter to all transcripts. Default is False.
-    :param filter_to_canonical: Whether to filter to canonical transcripts only. Default is False.s
+    :param filter_to_canonical: Whether to filter to canonical transcripts only. Default is False.
     :param outlier: Whether to filter LoF constraint HT to outlier transcripts (if True),
         or QC-pass transcripts (if False). Default is True.
     :return: Set of outlier transcripts or transcript QC pass transcripts.

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -532,7 +532,7 @@ def filter_to_region_type(ht: hl.Table, region: str) -> hl.Table:
 def get_coverage_correction_expr(
     an_expr: hl.expr.Int32Expression,
     coverage_model: Tuple[float, float],
-    high_AN_cutoff: int = 66,
+    high_AN_cutoff: int = 90,
 ) -> hl.expr.Float64Expression:
     """
     Get 'coverage' correction for expected variants count.
@@ -545,7 +545,7 @@ def get_coverage_correction_expr(
     :param ht: Input AN expression. Should be percent of exome AN defined at each locus.
     :param coverage_model: Model to determine coverage correction factor necessary
          for calculating expected variants at low AN sites.
-    :param high_AN_cutoff: Cutoff for high AN value. Default is 66.
+    :param high_AN_cutoff: Cutoff for high AN value. Default is 90.
         NOTE that default should be adjusted based on upstream gene constraint pipeline default.
     :return: Coverage correction expression.
     :rtype: hl.expr.Float64Expression

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -141,6 +141,7 @@ def process_context_ht(
         vep_root="vep",
         synonymous=False,
         canonical=filter_to_canonical,
+        protein_coding=True,
         ensembl_only=True,
         filter_empty_csq=True,
         csqs=filter_csq,
@@ -219,6 +220,7 @@ def get_aa_from_context(
         vep_root="vep",
         synonymous=False,
         canonical=filter_to_canonical,
+        protein_coding=True,
         ensembl_only=True,
         filter_empty_csq=True,
     )

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -13,6 +13,7 @@ from gnomad.utils.vep import (
     filter_vep_transcript_csqs,
     process_consequences,
 )
+from gnomad_constraint.resources.resource_utils import get_preprocessed_ht
 
 from rmc.resources.basics import (
     ACID_NAMES_PATH,
@@ -126,10 +127,11 @@ def process_context_ht(
     # https://github.com/broadinstitute/gnomad-constraint/blob/0acd2815e59c04d642bb705e6d1ca166f5d79e5f/gnomad_constraint/utils/constraint.py#L78
     # NOTE: The v4.1 constraint table currently only contains autosomes
     # TODO: Add allosomes and PAR
-    # ht = get_preprocessed_ht("context").ht().select_globals()
-    ht = hl.read_table(
-        "gs://gnomad/v4.1/constraint_an/preprocessed_data/gnomad.v4.1.context.preprocessed.autosome_par.ht"
-    ).select_globals()
+    # Used this table for testing
+    # ht = hl.read_table(
+    #    "gs://gnomad/v4.1/constraint_an/preprocessed_data/gnomad.v4.1.context.preprocessed.autosome_par.ht"
+    # ).select_globals()
+    ht = get_preprocessed_ht("context").ht().select_globals()
 
     if filter_to_canonical:
         logger.info("Filtering to canonical transcripts only...")

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -19,7 +19,6 @@ from rmc.resources.basics import (
     TEMP_PATH_WITH_FAST_DEL,
 )
 from rmc.resources.gnomad import constraint_ht
-from rmc.resources.resource_utils import MISSENSE
 
 logging.basicConfig(
     format="%(asctime)s (%(name)s %(lineno)s): %(message)s",
@@ -182,7 +181,6 @@ def get_aa_from_context(
     keep_transcripts: Set[str] = None,
     n_partitions: int = 10000,
     filter_to_canonical: bool = False,
-    missense_str: str = MISSENSE,
 ) -> hl.Table:
     """
     Extract amino acid information from VEP context HT.
@@ -195,8 +193,6 @@ def get_aa_from_context(
         Default is None.
     :param n_partitions: Desired number of partitions for context HT after filtering.
         Default is 10,000.
-    :param filter_to_canonical: Whether to filter to canonical transcripts only. Default is False.
-    :param missense_str: Missense consequence string. Default is "missense_variant".
     :return: VEP context HT filtered to keep only transcript ID, protein number, and amino acid information.
     """
     logger.info(
@@ -214,7 +210,6 @@ def get_aa_from_context(
         canonical=filter_to_canonical,
         ensembl_only=True,
         filter_empty_csq=True,
-        csqs={missense_str},
     )
     ht = explode_by_vep_annotation(ht, "transcript_consequences")
     ht = ht.select("transcript_consequences")

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -634,8 +634,9 @@ def get_constraint_transcripts(
         raise DataException("Constraint HT not found!")
 
     constraint_transcript_ht = constraint_ht.ht().key_by("transcript")
+    # NOTE: all protein-coding transcripts are ENST transcripts in constraint HT
     constraint_transcript_ht = constraint_transcript_ht.filter(
-        constraint_transcript_ht.transcript.contains("ENST")
+        constraint_transcript_ht.transcript_type == "protein_coding"
     )
     if filter_to_canonical:
         constraint_transcript_ht = constraint_transcript_ht.filter(

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -136,6 +136,8 @@ def process_context_ht(
 
     if filter_to_canonical:
         logger.info("Filtering to canonical transcripts only...")
+
+    # Filter to protein-coding ENST transcripts
     # Also optionally filter to canonical transcripts and specific consequences
     ht = filter_vep_transcript_csqs(
         t=ht,

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -203,7 +203,7 @@ def get_aa_from_context(
     :param n_partitions: Desired number of partitions for context HT after filtering.
         Default is 10,000.
     :param filter_to_canonical: Whether to filter to canonical transcripts only. Default is False.
-    :param vep_version: VEP version to use. Default is "105".
+    :param vep_version: VEP version to use. Default is `VEP_VERSION`.
     :return: VEP context HT filtered to keep only transcript ID, protein number, and amino acid information.
     """
     logger.info(

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -155,6 +155,7 @@ def process_context_ht(
     # for documentation on annotations added
     ht, _ = annotate_exploded_vep_for_constraint_groupings(
         ht=ht,
+        coverage_expr=ht.exomes_AN,
         vep_annotation="transcript_consequences",
         include_canonical_group=True,
         # NOTE: all canonical transcripts are also the MANE select transcript in

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -11,6 +11,7 @@ from gnomad.utils.vep import (
     CSQ_NON_CODING,
     explode_by_vep_annotation,
     filter_vep_transcript_csqs,
+    process_consequences,
 )
 
 from rmc.resources.basics import (
@@ -211,6 +212,7 @@ def get_aa_from_context(
         ensembl_only=True,
         filter_empty_csq=True,
     )
+    ht = process_consequences(ht)
     ht = explode_by_vep_annotation(ht, "transcript_consequences")
     ht = ht.select("transcript_consequences")
     ht = ht.filter(

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -21,6 +21,7 @@ from rmc.resources.basics import (
     TEMP_PATH_WITH_FAST_DEL,
 )
 from rmc.resources.gnomad import constraint_ht
+from rmc.resources.reference_data import VEP_VERSION
 
 logging.basicConfig(
     format="%(asctime)s (%(name)s %(lineno)s): %(message)s",
@@ -186,7 +187,7 @@ def get_aa_from_context(
     keep_transcripts: Set[str] = None,
     n_partitions: int = 10000,
     filter_to_canonical: bool = False,
-    vep_version: str = "105",
+    vep_version: str = VEP_VERSION,
 ) -> hl.Table:
     """
     Extract amino acid information from VEP context HT.

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -205,11 +205,8 @@ def get_aa_from_context(
     )
     # TODO: Add option to filter to non-outliers if still desired
     # Drop globals and select only VEP transcript consequences field
-    ht = (
-        hl.read_table(vep_context.path, _n_partitions=n_partitions)
-        .select_globals()
-        .select("vep", "was_split")
-    )
+    ht = hl.read_table(vep_context.path).select_globals().select("vep", "was_split")
+    ht = ht.naive_coalesce(n_partitions)
     ht = filter_vep_transcript_csqs(
         t=ht,
         vep_root="vep",
@@ -238,7 +235,6 @@ def get_aa_from_context(
         logger.info("Filtering to desired transcripts only...")
         ht = ht.filter(hl.literal(keep_transcripts).contains(ht.transcript))
 
-    ht = ht.naive_coalesce(n_partitions)
     ht = ht.checkpoint(
         f"{TEMP_PATH_WITH_FAST_DEL}/vep_amino_acids.ht",
         _read_if_exists=not overwrite_temp,

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -622,7 +622,8 @@ def get_constraint_transcripts(
         between removing or keeping non-outlier transcripts. Default is False.
     :param filter_to_canonical: Whether to filter to canonical transcripts only. Default is False.
     :param outlier: Whether to filter LoF constraint HT to outlier transcripts (if True),
-        or QC-pass transcripts (if False). Default is True.
+        or QC-pass transcripts (if False). Applies only if `all_transcripts` is False.
+        Default is True.
     :return: Set of outlier transcripts or transcript QC pass transcripts.
     :rtype: hl.expr.SetExpression
     """

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -613,6 +613,10 @@ def get_constraint_transcripts(
     Transcripts are removed for the reasons detailed here:
     https://gnomad.broadinstitute.org/faq#why-are-constraint-metrics-missing-for-this-gene-or-annotated-with-a-note
 
+    .. note::
+        - Function assumes that LoF constraint HT has been filtered to include only
+            protein-coding transcripts.
+
     :param all_transcripts: Whether to filter to all transcripts. Will only keep
         all transcripts if `filter_to_canonical` is False, otherwise toggles
         between removing or keeping non-outlier transcripts. Default is False.

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -613,7 +613,9 @@ def get_constraint_transcripts(
     Transcripts are removed for the reasons detailed here:
     https://gnomad.broadinstitute.org/faq#why-are-constraint-metrics-missing-for-this-gene-or-annotated-with-a-note
 
-    :param all_transcripts: Whether to filter to all transcripts. Default is False.
+    :param all_transcripts: Whether to filter to all transcripts. Will only keep
+        all transcripts if `filter_to_canonical` is False, otherwise toggles
+        between removing or keeping non-outlier transcripts. Default is False.
     :param filter_to_canonical: Whether to filter to canonical transcripts only. Default is False.
     :param outlier: Whether to filter LoF constraint HT to outlier transcripts (if True),
         or QC-pass transcripts (if False). Default is True.

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -545,7 +545,8 @@ def get_coverage_correction_expr(
     :param ht: Input AN expression. Should be percent of exome AN defined at each locus.
     :param coverage_model: Model to determine coverage correction factor necessary
          for calculating expected variants at low AN sites.
-    :param high_cov_cutoff: Cutoff for high AN value. Default is 66.
+    :param high_AN_cutoff: Cutoff for high AN value. Default is 66.
+        NOTE that default should be adjusted based on upstream gene constraint pipeline default.
     :return: Coverage correction expression.
     :rtype: hl.expr.Float64Expression
     """

--- a/rmc/utils/missense_badness.py
+++ b/rmc/utils/missense_badness.py
@@ -70,7 +70,9 @@ def prepare_amino_acid_ht(
 
     # Filter to rows with defined AN; previously filtered to defined coverage
     # but have switched coverage to AN
-    context_ht = context_ht.filter(context_ht.exomes_AN > an_threshold)
+    context_ht = context_ht.filter(
+        hl.is_defined(context_ht.exomes_AN) & (context_ht.exomes_AN > an_threshold)
+    )
 
     logger.info("Selecting relevant annotations...")
     context_ht = context_ht.select(

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -367,8 +367,6 @@ def process_section_group(
     :param ht_path: Path to input Table (Table written using `group_no_single_break_found_ht`).
     :param section_group: List of transcripts or transcript sections to process.
     :param count: Which transcript or transcript section group is being run (based on counter generated in `main`).
-    :param search_num: Search iteration number
-        (e.g., second round of searching for single break would be 2).
     :param over_threshold: Whether input transcript/sections have more
         possible missense sites than threshold specified in `run_simultaneous_breaks`.
     :param output_ht_path: Path to output results Table.

--- a/rmc/utils/simultaneous_breaks.py
+++ b/rmc/utils/simultaneous_breaks.py
@@ -452,7 +452,7 @@ def process_section_group(
         # (would sometimes repartition to a lower number of partitions)
         ht = ht.repartition(n_rows)
         ht = ht.checkpoint(
-            f"{TEMP_PATH_WITH_FAST_DEL}/{section_group[0]}.ht",
+            f"{TEMP_PATH_WITH_FAST_DEL}/{section_group[0]}_tmp_repart.ht",
             _read_if_exists=read_if_exists,
             overwrite=not read_if_exists,
         )


### PR DESCRIPTION
PR contains changes needed to get RMC search pipeline to run on v4/GRCh38.

Major changes:
- Added support to filter on AN instead of coverage/adjust expected values using AN instead of coverage; `rmc/utils/generic.py` and `rmc/utils/constraint.py`
- Updated context HT processing within `get_aa_from_context` to keep all of the annotations to actually extra AA information; `rmc/utils/generic.py`
- Updated handling of transcripts with 0 expected values; `rmc/utils/constraint.py`
- Fixed browser HT reformatting to actually adjust start/stop coordinates; `rmc/utils/constraint.py`
- Updated globals annotation for browser RMC HT; `rmc/utils/constraint.py` -- NOTE that this code hasn't been tested (updated after I finished running)

Minor changes:
- Added naive_coalesce for RMC results HT; `rmc/pipeline/regional_constraint.py`
- Added arguments to toggle filtering to canonical and outlier transcripts;`rmc/pipeline/regional_constraint.py`, `rmc/utils/constraint.py`
- Added arguments to pipeline script to create transcript resources and separate `context_with_oe` creation from RMC results finalizing; `rmc/pipeline/regional_constraint.py`
- Added check for whether single breaks HT had 0 rows; `rmc/pipeline/regional_constraint.py`
- Fixed `transcript_ref` and `transcript_cds` creation (previous code was buggy); `rmc/utils/data_loading.py`
- Updated default version for transcript resources; `rmc/resources/reference_data.py`
- Added option to run all sections through simul search a single run through dataproc; `rmc/pipeline/two_breaks/run_batches_dataproc.py`
- Removed success TSV writes (no longer used/taking up unnecessary space); `rmc/pipeline/two_breaks/run_batches.py`
- Update output paths to point to `TEMP_PATH_WITH_FAST_DEL` for temporary files generated that aren't needed; `rmc/utils/simultaneous_breaks.py`
- `naive_coalesce` > `repartition` to avoid zip length mismatch error; `rmc/utils/simultaneous_breaks.py`
- Preemptively removed coverage filter in `rmc/utils/mpc.py` due to removal of coverage filtering criteria from `keep_criteria`
- Preemptively updated coverage filter in `rmc/utils/missense_badness.py`
- Updated `constraint_flag`field name to `constraint_flags` and additional filter to `ENST` transcripts only; `rmc/utils/generic.py`