### PR TITLE
Adapt RMC to use per variant expected counts from constraint table

### DIFF
--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -4,7 +4,6 @@ import logging
 import hail as hl
 from gnomad.utils.file_utils import file_exists
 
-
 from rmc.resources.basics import (
     CONSTRAINT_PREFIX,
     LOGGING_PATH,

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -26,7 +26,7 @@ from rmc.resources.rmc import (
     simul_search_round_bucket_path,
     single_search_round_ht_path,
 )
-from rmc.slack_creds import slack_token
+# from rmc.slack_creds import slack_token
 from rmc.utils.constraint import (
     annotate_max_chisq_per_section,
     check_break_search_round_nums,

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -26,6 +26,7 @@ from rmc.resources.rmc import (
     simul_search_round_bucket_path,
     single_search_round_ht_path,
 )
+
 # from rmc.slack_creds import slack_token
 from rmc.utils.constraint import (
     annotate_max_chisq_per_section,
@@ -65,20 +66,20 @@ def main(args):
             create_transcript_ref(build="GRCh38", overwrite=args.overwrite)
 
         # NOTE: This code block is no longer needed since the expected values are now calculated per-variant upstream
-        # if args.command == "prep-filtered-context":
-        #     hl.init(
-        #         log="/RMC_pre_process.log",
-        #         tmp_dir=TEMP_PATH_WITH_FAST_DEL,
-        #         quiet=args.quiet,
-        #     )
-        #     hl.default_reference("GRCh38")
-        #     logger.info("Creating filtered context HT...")
-        #     n_partitions = 10000
-        #     create_filtered_context_ht(
-        #         canonical_only=args.filter_to_canonical,
-        #         n_partitions=args.n_partitions if args.n_partitions else n_partitions,
-        #         overwrite=args.overwrite_temp,
-        #     )
+        if args.command == "prep-filtered-context":
+            hl.init(
+                log="/RMC_pre_process.log",
+                tmp_dir=TEMP_PATH_WITH_FAST_DEL,
+                quiet=args.quiet,
+            )
+            hl.default_reference("GRCh38")
+            logger.info("Creating filtered context HT...")
+            n_partitions = 10000
+            create_filtered_context_ht(
+                canonical_only=args.filter_to_canonical,
+                n_partitions=args.n_partitions if args.n_partitions else n_partitions,
+                overwrite=args.overwrite_temp,
+            )
 
         if args.command == "prep-constraint":
             hl.init(
@@ -643,8 +644,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    if args.slack_channel:
-        with slack_notifications(slack_token, args.slack_channel):
-            main(args)
-    else:
-        main(args)
+    # if args.slack_channel:
+    #     with slack_notifications(slack_token, args.slack_channel):
+    #         main(args)
+    # else:
+    #     main(args)
+    main(args)

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -64,20 +64,21 @@ def main(args):
             logger.info("Creating transcript reference resources...")
             create_transcript_ref(build="GRCh38", overwrite=args.overwrite)
 
-        if args.command == "prep-filtered-context":
-            hl.init(
-                log="/RMC_pre_process.log",
-                tmp_dir=TEMP_PATH_WITH_FAST_DEL,
-                quiet=args.quiet,
-            )
-            hl.default_reference("GRCh38")
-            logger.info("Creating filtered context HT...")
-            n_partitions = 10000
-            create_filtered_context_ht(
-                canonical_only=args.filter_to_canonical,
-                n_partitions=args.n_partitions if args.n_partitions else n_partitions,
-                overwrite=args.overwrite_temp,
-            )
+        # TODO: This is not needed for now since we directly read apply_models HT from constraint as our filtered context
+        # if args.command == "prep-filtered-context":
+        #     hl.init(
+        #         log="/RMC_pre_process.log",
+        #         tmp_dir=TEMP_PATH_WITH_FAST_DEL,
+        #         quiet=args.quiet,
+        #     )
+        #     hl.default_reference("GRCh38")
+        #     logger.info("Creating filtered context HT...")
+        #     n_partitions = 10000
+        #     create_filtered_context_ht(
+        #         canonical_only=args.filter_to_canonical,
+        #         n_partitions=args.n_partitions if args.n_partitions else n_partitions,
+        #         overwrite=args.overwrite_temp,
+        #     )
 
         if args.command == "prep-constraint":
             hl.init(

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -25,7 +25,6 @@ from rmc.resources.rmc import (
     simul_search_round_bucket_path,
     single_search_round_ht_path,
 )
-
 from rmc.utils.constraint import (
     annotate_max_chisq_per_section,
     check_break_search_round_nums,

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -27,7 +27,6 @@ from rmc.resources.rmc import (
     single_search_round_ht_path,
 )
 
-# from rmc.slack_creds import slack_token
 from rmc.utils.constraint import (
     annotate_max_chisq_per_section,
     check_break_search_round_nums,
@@ -644,9 +643,4 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    # if args.slack_channel:
-    #     with slack_notifications(slack_token, args.slack_channel):
-    #         main(args)
-    # else:
-    #     main(args)
     main(args)

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -3,7 +3,7 @@ import logging
 
 import hail as hl
 from gnomad.utils.file_utils import file_exists
-from gnomad.utils.slack import slack_notifications
+
 
 from rmc.resources.basics import (
     CONSTRAINT_PREFIX,

--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -64,7 +64,7 @@ def main(args):
             logger.info("Creating transcript reference resources...")
             create_transcript_ref(build="GRCh38", overwrite=args.overwrite)
 
-        # TODO: This is not needed for now since we directly read apply_models HT from constraint as our filtered context
+        # NOTE: This code block is no longer needed since the expected values are now calculated per-variant upstream
         # if args.command == "prep-filtered-context":
         #     hl.init(
         #         log="/RMC_pre_process.log",

--- a/rmc/resources/gnomad.py
+++ b/rmc/resources/gnomad.py
@@ -10,7 +10,9 @@ constraint_ht = VersionedTableResource(
             path="gs://gcp-public-data--gnomad/release/2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_transcript.ht"
         ),
         "4.1": TableResource(
-            path="gs://gcp-public-data--gnomad/release/4.1/constraint/gnomad.v4.1.constraint_metrics.ht"
+            # TODO: change this back when new constraint metrics are made public
+            # path="gs://gcp-public-data--gnomad/release/4.1/constraint/gnomad.v4.1.constraint_metrics.ht"
+            path="gs://gnomad/v4.1/constraint_an_3_10_25/metrics/transcript_consequences/gnomad.v4.1.constraint_metrics.ht"
         ),
     },
 )

--- a/rmc/resources/gnomad.py
+++ b/rmc/resources/gnomad.py
@@ -10,9 +10,7 @@ constraint_ht = VersionedTableResource(
             path="gs://gcp-public-data--gnomad/release/2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_transcript.ht"
         ),
         "4.1": TableResource(
-            # TODO: change this back when new constraint metrics are made public
-            # path="gs://gcp-public-data--gnomad/release/4.1/constraint/gnomad.v4.1.constraint_metrics.ht"
-            path="gs://gnomad/v4.1/constraint_an_3_10_25/metrics/transcript_consequences/gnomad.v4.1.constraint_metrics.ht"
+            path="gs://gcp-public-data--gnomad/release/4.1/constraint/gnomad.v4.1.constraint_metrics.ht"
         ),
     },
 )

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -24,14 +24,14 @@ from rmc.resources.basics import (
 from rmc.resources.reference_data import FOLD_K
 from rmc.resources.resource_utils import CURRENT_GNOMAD_VERSION
 
-FREEZES = [1]
+FREEZES = [1, 2]
 """
 RMC/MPC data versions computed with current gnomAD version.
 
 gnomAD v2.1.1 freezes: [1, 2, 3, 4, 5, 6, 7].
 """
 
-CURRENT_FREEZE = 1
+CURRENT_FREEZE = 2
 """
 Current RMC/MPC data version.
 

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -33,9 +33,8 @@ gnomAD v2.1.1 freezes: [1, 2, 3, 4, 5, 6, 7].
 
 gnomAD v4.1 freezes: [1, 2].
 
-NOTE: v4.1 freeze 1 uses AN as proxy for coverage with high coverage defined as AN>66%.
-v4.1 freeze 2 uses AN>90% as high coverage definition, uses per-variant expected calculated upstream from gene constraint
-and corrects for low coverage sites using coverage model.
+NOTE: v4.1 freeze 1 was a test run to ensure that RMC results calculated using allele number (AN) as a proxy for coverage looked reasonable. This freeze defined high coverage as AN > 66%.
+v4.1 freeze 2 also uses AN as a proxy for coverage and defines high coverage as AN>= 90%.
 """
 
 CURRENT_FREEZE = 2

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -4,6 +4,7 @@ Script containing RMC and MPC related resources.
 RMC: Regional missense constraint
 MPC: Missense badness, Polyphen-2, and Constraint score
 """
+
 from typing import Set
 
 import scipy
@@ -29,6 +30,12 @@ FREEZES = [1, 2]
 RMC/MPC data versions computed with current gnomAD version.
 
 gnomAD v2.1.1 freezes: [1, 2, 3, 4, 5, 6, 7].
+
+gnomAD v4.1 freezes: [1, 2].
+
+NOTE: v4.1 freeze 1 uses AN as proxy for coverage with high coverage defined as AN>66%.
+v4.1 freeze 2 uses AN>90% as high coverage definition, uses per-variant expected calculated upstream from gene constraint
+and corrects for low coverage sites using coverage model.
 """
 
 CURRENT_FREEZE = 2
@@ -267,9 +274,7 @@ def single_search_round_ht_path(
     """
     break_status = "break_found" if is_break_found else "no_break_found"
     breakpoint_status = "_breakpoint_only" if is_breakpoint_only else ""
-    return (
-        f"{single_search_bucket_path(search_num, freeze)}/{break_status}{breakpoint_status}.ht"
-    )
+    return f"{single_search_bucket_path(search_num, freeze)}/{break_status}{breakpoint_status}.ht"
 
 
 SIMUL_SEARCH_BUCKET_NAMES = {"prep", "raw_results", "final_results", "success_files"}

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -273,7 +273,9 @@ def single_search_round_ht_path(
     """
     break_status = "break_found" if is_break_found else "no_break_found"
     breakpoint_status = "_breakpoint_only" if is_breakpoint_only else ""
-    return f"{single_search_bucket_path(search_num, freeze)}/{break_status}{breakpoint_status}.ht"
+    return (
+        f"{single_search_bucket_path(search_num, freeze)}/{break_status}{breakpoint_status}.ht"
+    )
 
 
 SIMUL_SEARCH_BUCKET_NAMES = {"prep", "raw_results", "final_results", "success_files"}

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -229,9 +229,9 @@ def calculate_exp_from_mu(
 
     # TODO: uncomment when the other models exist
     # Used this for testing:
-    plateau_model = hl.experimental.read_expression(
-        "gs://gnomad/v4.1/constraint_an/models/gnomad.v4.1.plateau.autosome_par.he"
-    )
+    # plateau_model = hl.experimental.read_expression(
+    #     "gs://gnomad/v4.1/constraint_an/models/gnomad.v4.1.plateau.autosome_par.he"
+    # )
     # if locus_type == "X":
     #    plateau_model = (
     #        get_models(model_type="plateau", genomic_region="chrx_non_par").he(),
@@ -353,12 +353,12 @@ def create_possible_hts(
     # Annotate HT globals with models
     possible_ht = possible_ht.annotate_globals(
         # TODO: Uncomment lines below when chrX/chrY, coverage models are ready
-        plateau_x_models=get_models(
-            model_type="plateau", genomic_region="chrx_non_par"
-        ).he(),
-        plateau_y_models=get_models(
-            model_type="plateau", genomic_region="chry_non_par"
-        ).he(),
+        # plateau_x_models=get_models(
+        #     model_type="plateau", genomic_region="chrx_non_par"
+        # ).he(),
+        # plateau_y_models=get_models(
+        #     model_type="plateau", genomic_region="chry_non_par"
+        # ).he(),
         # Used this for testing
         # coverage_model=hl.experimental.read_expression(
         #     "gs://gnomad/v4.1/constraint_an/models/gnomad.v4.1.coverage.autosome_par.he"
@@ -525,7 +525,7 @@ def create_constraint_prep_ht(
     ht = get_per_variant_expected_dataset(
         directory_post_fix="an_coverage_corrected", path_post_fix="coverage_corrected"
     ).ht()
-    # Annotate obs and exp columns to be used downstream
+    # Annotate obs and exp counts as the zero index (pop global) since they are arrays
     ht = ht.annotate(
         observed=ht.calibrate_mu.observed_variants[0], expected=ht.expected_variants[0]
     )

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -520,7 +520,6 @@ def create_constraint_prep_ht(
     :param overwrite: Whether to overwrite Table. Default is True.
     :return: None; writes Table to path.
     """
-
     # NOTE: Observed counts upstream now includes variants with AF <= 0.001 instead of AF < 0.001.
     # ht = filtered_context.ht()
     ht = get_per_variant_expected_dataset(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -525,7 +525,7 @@ def create_constraint_prep_ht(
     :param overwrite: Whether to overwrite Table. Default is True.
     :param directory_post_fix: Directory suffix for reading per-variant expected dataset. Default is "an_coverage_corrected".
     :param path_post_fix: File suffix to use for reading per-variant expected dataset. Default is "coverage_corrected".
-    :param variant_idx: Index of observed and expected arrays to use. Default is 0.
+    :param variant_idx: Index of observed and expected arrays to use. Default is 0 (corresponds to counts calculated on gnomAD-wide / "global" frequencies).
     :return: None; writes Table to path.
     """
     # NOTE: Observed counts upstream now includes variants with AF <= 0.001 instead of AF < 0.001.

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -500,7 +500,12 @@ def create_filtered_context_ht(
 
 
 def create_constraint_prep_ht(
-    filter_csq: Set[str] = {MISSENSE}, n_partitions: int = 10000, overwrite: bool = True
+    filter_csq: Set[str] = {MISSENSE},
+    n_partitions: int = 10000,
+    overwrite: bool = True,
+    directory_post_fix: str = "an_coverage_corrected",
+    path_post_fix: str = "coverage_corrected",
+    variant_idx: int = 0,
 ) -> None:
     """
     Create locus-level constraint prep Table from filtered context Table.
@@ -518,16 +523,20 @@ def create_constraint_prep_ht(
     :param n_partitions: Number of desired partitions for the Table. Default is 15000.
     :param csq: Desired consequences. Default is {`MISSENSE`}. Must be specified if filter is True.
     :param overwrite: Whether to overwrite Table. Default is True.
+    :param directory_post_fix: Specify directory suffix for reading per-variant expected dataset. Default is "an_coverage_corrected".
+    :param path_post_fix: Specify file suffix to use for reading per-variant expected dataset. Default is "coverage_corrected".
+    :param variant_idx: Index of observed and expected arrays to use. Default is 0.
     :return: None; writes Table to path.
     """
     # NOTE: Observed counts upstream now includes variants with AF <= 0.001 instead of AF < 0.001.
     ht = get_per_variant_expected_dataset(
-        directory_post_fix="an_coverage_corrected", path_post_fix="coverage_corrected"
+        directory_post_fix=directory_post_fix, path_post_fix=path_post_fix
     ).ht()
     # Obs and exp counts are arrays to account for different frequency strata
     # Use zeroth index (gnomAD-wide ["global"] frequencies)
     ht = ht.annotate(
-        observed=ht.calibrate_mu.observed_variants[0], expected=ht.expected_variants[0]
+        observed=ht.calibrate_mu.observed_variants[variant_idx],
+        expected=ht.expected_variants[variant_idx],
     )
     if filter_csq:
         logger.info("Filtering to %s...", filter_csq)

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -523,8 +523,8 @@ def create_constraint_prep_ht(
     :param n_partitions: Number of desired partitions for the Table. Default is 15000.
     :param csq: Desired consequences. Default is {`MISSENSE`}. Must be specified if filter is True.
     :param overwrite: Whether to overwrite Table. Default is True.
-    :param directory_post_fix: Specify directory suffix for reading per-variant expected dataset. Default is "an_coverage_corrected".
-    :param path_post_fix: Specify file suffix to use for reading per-variant expected dataset. Default is "coverage_corrected".
+    :param directory_post_fix: Directory suffix for reading per-variant expected dataset. Default is "an_coverage_corrected".
+    :param path_post_fix: File suffix to use for reading per-variant expected dataset. Default is "coverage_corrected".
     :param variant_idx: Index of observed and expected arrays to use. Default is 0.
     :return: None; writes Table to path.
     """

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -185,8 +185,7 @@ def adjust_fwd_cumulative_count_expr(
     )
 
 
-# TODO: This is not needed for now since reading per-variant apply models HT from constraint
-# directly as filtered context HT for downstream prep-constraint step.
+# NOTE: This is no longer needed because expected values are now calculated per-variant upstream
 def calculate_exp_from_mu(
     context_ht: hl.Table,
     possible_ht: hl.Table,

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -181,14 +181,16 @@ def adjust_fwd_cumulative_count_expr(
     )
 
 # TODO: replace or remove this to read exp directly from per-variant constraint results
-def annotate_exp_from_constraint(
-    context_ht: hl.Table,
-    apply_ht: hl.Table,
-    locus_type: str,
-    # groupings: List[str] = GROUPINGS,
-    overwrite: bool = False,
-    n_partitions: int = 5000,
-) -> hl.Table:
+# TODO: This is not needed for now since reading per-variant apply models HT from constraint
+# directly as filtered context HT for downstream prep-constraint step.
+# def annotate_exp_from_constraint(
+#     context_ht: hl.Table,
+#     apply_ht: hl.Table,
+#     locus_type: str,
+#     # groupings: List[str] = GROUPINGS,
+#     overwrite: bool = False,
+#     n_partitions: int = 5000,
+# ) -> hl.Table:
     """
     Annotate context Table with the per-variant (locus-allele) expected counts based on per-variant constraint table.
 
@@ -276,34 +278,34 @@ def annotate_exp_from_constraint(
     # group_ht = group_ht.annotate(
     #     expected=group_ht.expected_variants / group_ht.possible_variants
     # ).select("expected")
-    logger.info(
-        "Annotating expected counts per allele from the constraint table.."
-    )
-    apply_ht = apply_ht.annotate(expected = apply_ht.expected_variants[0]).select("expected")
-    context_ht = context_ht.annotate(
-        expected = apply_ht[context_ht.key].expected
-    )
-    context_ht = context_ht.checkpoint(
-        f"{TEMP_PATH_WITH_FAST_DEL}/{locus_type}_context_exp.ht",
-        _read_if_exists=not overwrite,
-        overwrite=overwrite,
-    )
-    return context_ht
+    # logger.info(
+    #     "Annotating expected counts per allele from the constraint table.."
+    # )
+    # apply_ht = apply_ht.annotate(expected = apply_ht.expected_variants[0]).select("expected")
+    # context_ht = context_ht.annotate(
+    #     expected = apply_ht[context_ht.key].expected
+    # )
+    # context_ht = context_ht.checkpoint(
+    #     f"{TEMP_PATH_WITH_FAST_DEL}/{locus_type}_context_exp.ht",
+    #     _read_if_exists=not overwrite,
+    #     overwrite=overwrite,
+    # )
+    # return context_ht
 
 # TODO: Might not need this function since annotating expected directly from constraint
-def create_possible_hts(
-    ht: hl.Table,
-    locus_type: str = "autosomes",
-    additional_grouping: List[str] = [
-        "cpg",
-        "annotation",
-        "modifier",
-        "transcript",
-        "exomes_AN_percent",
-    ],
-    mu_ht_partitions: int = 100,
-    overwrite: bool = False,
-) -> hl.Table:
+# def create_possible_hts(
+#     ht: hl.Table,
+#     locus_type: str = "autosomes",
+#     additional_grouping: List[str] = [
+#         "cpg",
+#         "annotation",
+#         "modifier",
+#         "transcript",
+#         "exomes_AN_percent",
+#     ],
+#     mu_ht_partitions: int = 100,
+#     overwrite: bool = False,
+# ) -> hl.Table:
     """
     Create Table with possible variants per variant type for each locus type.
 
@@ -331,56 +333,57 @@ def create_possible_hts(
     :param overwrite: Whether to overwrite temporary data. Default is False.
     :return: Table filtered to `locus_type` with possible variants per variant type.
     """
-    logger.info("Filtering to region: %s", locus_type)
-    ht = filter_to_region_type(ht, locus_type)
+    # logger.info("Filtering to region: %s", locus_type)
+    # ht = filter_to_region_type(ht, locus_type)
 
-    logger.info(
-        "Counting number of possible variants by variant type + transcript grouping..."
-    )
-    possible_ht = count_variants_by_group(
-        ht,
-        additional_grouping=additional_grouping,
-        use_table_group_by=True,
-    )
-    mu_ht = hl.read_table(
-        get_mutation_ht().path, _n_partitions=mu_ht_partitions
-    ).select("mu_snp")
-    possible_ht = annotate_with_mu(possible_ht, mu_ht)
-    possible_ht = possible_ht.transmute(possible_variants=possible_ht.variant_count)
+    # logger.info(
+    #     "Counting number of possible variants by variant type + transcript grouping..."
+    # )
+    # possible_ht = count_variants_by_group(
+    #     ht,
+    #     additional_grouping=additional_grouping,
+    #     use_table_group_by=True,
+    # )
+    # mu_ht = hl.read_table(
+    #     get_mutation_ht().path, _n_partitions=mu_ht_partitions
+    # ).select("mu_snp")
+    # possible_ht = annotate_with_mu(possible_ht, mu_ht)
+    # possible_ht = possible_ht.transmute(possible_variants=possible_ht.variant_count)
 
-    # Annotate HT globals with models
-    possible_ht = possible_ht.annotate_globals(
-        # TODO: Uncomment lines below when chrX/chrY, coverage models are ready
-        plateau_x_models=get_models(model_type="plateau", genomic_region="chrx_non_par").he(),
-        plateau_y_models=get_models(model_type="plateau", genomic_region="chry_non_par").he(),
-        # Used this for testing
-        # coverage_model=hl.experimental.read_expression(
-        #     "gs://gnomad/v4.1/constraint_an/models/gnomad.v4.1.coverage.autosome_par.he"
-        # ),
-        coverage_model=get_models(model_type="coverage").he(),
-    )
-    possible_ht = possible_ht.checkpoint(
-        f"{TEMP_PATH_WITH_FAST_DEL}/{locus_type}_possible_variants.ht",
-        _read_if_exists=not overwrite,
-        overwrite=overwrite,
-    )
-    return possible_ht
+    # # Annotate HT globals with models
+    # possible_ht = possible_ht.annotate_globals(
+    #     # TODO: Uncomment lines below when chrX/chrY, coverage models are ready
+    #     plateau_x_models=get_models(model_type="plateau", genomic_region="chrx_non_par").he(),
+    #     plateau_y_models=get_models(model_type="plateau", genomic_region="chry_non_par").he(),
+    #     # Used this for testing
+    #     # coverage_model=hl.experimental.read_expression(
+    #     #     "gs://gnomad/v4.1/constraint_an/models/gnomad.v4.1.coverage.autosome_par.he"
+    #     # ),
+    #     coverage_model=get_models(model_type="coverage").he(),
+    # )
+    # possible_ht = possible_ht.checkpoint(
+    #     f"{TEMP_PATH_WITH_FAST_DEL}/{locus_type}_possible_variants.ht",
+    #     _read_if_exists=not overwrite,
+    #     overwrite=overwrite,
+    # )
+    # return possible_ht
 
-
-def create_filtered_context_ht(
-    csq: Set[str] = KEEP_CODING_CSQ,
-    n_partitions: int = 10000,
-    overwrite: bool = False,
-    additional_grouping: List[str] = [
-        "cpg",
-        "annotation",
-        "modifier",
-        "transcript",
-        "exomes_AN_percent",
-    ],
-    mu_ht_partitions: int = 100,
-    canonical_only: bool = True,
-) -> None:
+# TODO: This function is an upstream step to create filtered context used in prep-constraint.
+# TODO: Using the apply models HT directly as filtered context for prep-constraint step. 
+# def create_filtered_context_ht(
+#     csq: Set[str] = KEEP_CODING_CSQ,
+#     n_partitions: int = 10000,
+#     overwrite: bool = False,
+#     additional_grouping: List[str] = [
+#         "cpg",
+#         "annotation",
+#         "modifier",
+#         "transcript",
+#         "exomes_AN_percent",
+#     ],
+#     mu_ht_partitions: int = 100,
+#     canonical_only: bool = True,
+# ) -> None:
     """
     Create allele-level VEP context Table with constraint annotations including expected variant counts.
 
@@ -400,103 +403,103 @@ def create_filtered_context_ht(
     :param canonical_only: Whether to filter to canonical transcripts only. Default is True.
     :return: None; writes Table to path.
     """
-    logger.info(
-        "Preprocessing VEP context HT to filter to missense, nonsense, and"
-        " synonymous variants, and add constraint annotations..."
-    )
-    # NOTE: Constraint outlier transcripts are not removed
-    ht = process_context_ht(filter_to_canonical=canonical_only, filter_csq=csq)
+    # logger.info(
+    #     "Preprocessing VEP context HT to filter to missense, nonsense, and"
+    #     " synonymous variants, and add constraint annotations..."
+    # )
+    # # NOTE: Constraint outlier transcripts are not removed
+    # ht = process_context_ht(filter_to_canonical=canonical_only, filter_csq=csq)
 
-    logger.info(
-        "Filtering context HT to all covered sites not found or rare in gnomAD"
-        " exomes and checkpointing..."
-    )
-    ht = filter_context_using_gnomad(ht, "exomes")
-    # Reducing number of partitions as the VEP context table has 62k
-    ht = ht.naive_coalesce(n_partitions)
-    ht = ht.checkpoint(
-        f"{TEMP_PATH_WITH_FAST_DEL}/processed_context.ht",
-        _read_if_exists=not overwrite,
-        overwrite=overwrite,
-    )
+    # logger.info(
+    #     "Filtering context HT to all covered sites not found or rare in gnomAD"
+    #     " exomes and checkpointing..."
+    # )
+    # ht = filter_context_using_gnomad(ht, "exomes")
+    # # Reducing number of partitions as the VEP context table has 62k
+    # ht = ht.naive_coalesce(n_partitions)
+    # ht = ht.checkpoint(
+    #     f"{TEMP_PATH_WITH_FAST_DEL}/processed_context.ht",
+    #     _read_if_exists=not overwrite,
+    #     overwrite=overwrite,
+    # )
 
-    # logger.info("Calculating expected values per allele and checkpointing...")
-    logger.info("Annotating with expected values per allele and checkpointing...")
-    # TODO: replace this with more general resource path when available
-    apply_ht = hl.read_table(
-        "gs://gnomad/v4.1/constraint_an_coverage_corrected/apply_models/transcript_consequences/gnomad.v4.1.per_variant_expected.coverage_corrected.ht"
-        )
-    ht = (
-        annotate_exp_from_constraint(
-            filter_to_region_type(ht, "autosome_or_par"),
-            apply_ht.filter(apply_ht.genomic_region == "autosome_or_par"),
-            # create_possible_hts(
-            #     ht=ht,
-            #     locus_type="autosomes",
-            #     additional_grouping=additional_grouping,
-            #     mu_ht_partitions=mu_ht_partitions,
-            #     overwrite=overwrite,
-            # ),
-            locus_type="autosome_or_par",
-        )
-        .union(annotate_exp_from_constraint(
-           filter_to_region_type(ht, "chrx_nonpar"),
-           apply_ht.filter(apply_ht.genomic_region == "chrx_nonpar"),
-           # create_possible_hts(
-           #     ht=ht,
-           #     locus_type="chrX",
-           #     additional_grouping=additional_grouping,
-           #     mu_ht_partitions=mu_ht_partitions,
-           #     overwrite=overwrite,
-           # ),
-           locus_type="chrx_nonpar",
-           )
-        )
-        .union(annotate_exp_from_constraint(
-           filter_to_region_type(ht, "chry_nonpar"),
-           apply_ht.filter(apply_ht.genomic_region == "chry_nonpar"),
-           # create_possible_hts(
-           #     ht=ht,
-           #     locus_type="chrY",
-           #     additional_grouping=additional_grouping,
-           #     mu_ht_partitions=mu_ht_partitions,
-           #     overwrite=overwrite,
-           # ),
-           locus_type="chry_nonpar",
-           )
-        )
-    )
-    ht = ht.checkpoint(
-        f"{TEMP_PATH_WITH_FAST_DEL}/context_exp.ht",
-        _read_if_exists=not overwrite,
-        overwrite=overwrite,
-    )
-    # Repartition HT
-    ht = hl.read_table(
-        f"{TEMP_PATH_WITH_FAST_DEL}/context_exp.ht", _n_partitions=n_partitions
-    )
+    # # logger.info("Calculating expected values per allele and checkpointing...")
+    # logger.info("Annotating with expected values per allele and checkpointing...")
+    # # TODO: replace this with more general resource path when available
+    # apply_ht = hl.read_table(
+    #     "gs://gnomad/v4.1/constraint_an_coverage_corrected/apply_models/transcript_consequences/gnomad.v4.1.per_variant_expected.coverage_corrected.ht"
+    #     )
+    # ht = (
+    #     annotate_exp_from_constraint(
+    #         filter_to_region_type(ht, "autosome_or_par"),
+    #         apply_ht.filter(apply_ht.genomic_region == "autosome_or_par"),
+    #         # create_possible_hts(
+    #         #     ht=ht,
+    #         #     locus_type="autosomes",
+    #         #     additional_grouping=additional_grouping,
+    #         #     mu_ht_partitions=mu_ht_partitions,
+    #         #     overwrite=overwrite,
+    #         # ),
+    #         locus_type="autosome_or_par",
+    #     )
+    #     .union(annotate_exp_from_constraint(
+    #        filter_to_region_type(ht, "chrx_nonpar"),
+    #        apply_ht.filter(apply_ht.genomic_region == "chrx_nonpar"),
+    #        # create_possible_hts(
+    #        #     ht=ht,
+    #        #     locus_type="chrX",
+    #        #     additional_grouping=additional_grouping,
+    #        #     mu_ht_partitions=mu_ht_partitions,
+    #        #     overwrite=overwrite,
+    #        # ),
+    #        locus_type="chrx_nonpar",
+    #        )
+    #     )
+    #     .union(annotate_exp_from_constraint(
+    #        filter_to_region_type(ht, "chry_nonpar"),
+    #        apply_ht.filter(apply_ht.genomic_region == "chry_nonpar"),
+    #        # create_possible_hts(
+    #        #     ht=ht,
+    #        #     locus_type="chrY",
+    #        #     additional_grouping=additional_grouping,
+    #        #     mu_ht_partitions=mu_ht_partitions,
+    #        #     overwrite=overwrite,
+    #        # ),
+    #        locus_type="chry_nonpar",
+    #        )
+    #     )
+    # )
+    # ht = ht.checkpoint(
+    #     f"{TEMP_PATH_WITH_FAST_DEL}/context_exp.ht",
+    #     _read_if_exists=not overwrite,
+    #     overwrite=overwrite,
+    # )
+    # # Repartition HT
+    # ht = hl.read_table(
+    #     f"{TEMP_PATH_WITH_FAST_DEL}/context_exp.ht", _n_partitions=n_partitions
+    # )
 
-    # Check for negative expected values
-    zero_exp = ht.filter(ht.expected <= 0)
-    negative_exp = zero_exp.filter(zero_exp.expected < 0).count()
-    if negative_exp > 0:
-        # NOTE: in v2, we found negative expected values for a handful of alleles on chrY
-        # due to negative coefficient in the model on this chr
-        # (we decided to remove these sites for v2)
-        raise DataException(
-            f"Found {negative_exp} variants with negative expected values!"
-        )
-    if zero_exp.count() > 0:
-        logger.warning(
-            "Found %d variants with zero expected values!",
-            zero_exp.count() - negative_exp,
-        )
+    # # Check for negative expected values
+    # zero_exp = ht.filter(ht.expected <= 0)
+    # negative_exp = zero_exp.filter(zero_exp.expected < 0).count()
+    # if negative_exp > 0:
+    #     # NOTE: in v2, we found negative expected values for a handful of alleles on chrY
+    #     # due to negative coefficient in the model on this chr
+    #     # (we decided to remove these sites for v2)
+    #     raise DataException(
+    #         f"Found {negative_exp} variants with negative expected values!"
+    #     )
+    # if zero_exp.count() > 0:
+    #     logger.warning(
+    #         "Found %d variants with zero expected values!",
+    #         zero_exp.count() - negative_exp,
+    #     )
 
-    logger.info(
-        "Annotating context HT with number of observed variants and writing out..."
-    )
-    ht = add_obs_annotation(ht)
-    ht.write(filtered_context.path, overwrite=True)
+    # logger.info(
+    #     "Annotating context HT with number of observed variants and writing out..."
+    # )
+    # ht = add_obs_annotation(ht)
+    # ht.write(filtered_context.path, overwrite=True)
 
 
 def create_constraint_prep_ht(
@@ -520,7 +523,16 @@ def create_constraint_prep_ht(
     :param overwrite: Whether to overwrite Table. Default is True.
     :return: None; writes Table to path.
     """
-    ht = filtered_context.ht()
+    #TODO: Make a resource path for this table.
+    # ht = filtered_context.ht()
+    ht = hl.read_table(
+        "gs://gnomad/v4.1/constraint_an_coverage_corrected/apply_models/transcript_consequences/gnomad.v4.1.per_variant_expected.coverage_corrected.ht"
+        )
+    # Annotate obs and exp columns to be used downstream
+    ht = ht.annotate(
+        observed=ht.calibrate_mu.observed_variants[0],
+        expected=ht.expected_variants[0]
+        )
     if filter_csq:
         logger.info("Filtering to %s...", filter_csq)
         ht = ht.filter(hl.literal(filter_csq).contains(ht.annotation))

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -521,7 +521,6 @@ def create_constraint_prep_ht(
     :return: None; writes Table to path.
     """
     # NOTE: Observed counts upstream now includes variants with AF <= 0.001 instead of AF < 0.001.
-    # ht = filtered_context.ht()
     ht = get_per_variant_expected_dataset(
         directory_post_fix="an_coverage_corrected", path_post_fix="coverage_corrected"
     ).ht()

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -373,8 +373,7 @@ def create_possible_hts(
     return possible_ht
 
 
-# TODO: This function is an upstream step to create filtered context used in prep-constraint.
-# NOTE: Not using this function since using the apply models HT directly as filtered context for prep-constraint step.
+# NOTE: This function is no longer needed because the filtered context HT is now created upstream
 def create_filtered_context_ht(
     csq: Set[str] = KEEP_CODING_CSQ,
     n_partitions: int = 10000,

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -524,7 +524,8 @@ def create_constraint_prep_ht(
     ht = get_per_variant_expected_dataset(
         directory_post_fix="an_coverage_corrected", path_post_fix="coverage_corrected"
     ).ht()
-    # Annotate obs and exp counts as the zero index (pop global) since they are arrays
+    # Obs and exp counts are arrays to account for different frequency strata
+    # Use zeroth index (gnomAD-wide ["global"] frequencies)
     ht = ht.annotate(
         observed=ht.calibrate_mu.observed_variants[0], expected=ht.expected_variants[0]
     )

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -533,7 +533,6 @@ def create_constraint_prep_ht(
         directory_post_fix=directory_post_fix, path_post_fix=path_post_fix
     ).ht()
     # Obs and exp counts are arrays to account for different frequency strata
-    # Use zeroth index (gnomAD-wide ["global"] frequencies)
     ht = ht.annotate(
         observed=ht.calibrate_mu.observed_variants[variant_idx],
         expected=ht.expected_variants[variant_idx],

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -292,7 +292,7 @@ def calculate_exp_from_mu(
     return context_ht
 
 
-# TODO: Might not need this function since annotating expected directly from constraint
+# NOTE: We no longer need this function because expected values are calculated per-variant upstream
 def create_possible_hts(
     ht: hl.Table,
     locus_type: str = "autosomes",

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -521,6 +521,7 @@ def create_constraint_prep_ht(
     :return: None; writes Table to path.
     """
     # TODO: Make a resource path for this table.
+    # NOTE: Observed counts upstream now includes variants with AF <= 0.001 instead of AF < 0.001.
     # ht = filtered_context.ht()
     ht = get_per_variant_expected_dataset(
         directory_post_fix="an_coverage_corrected", path_post_fix="coverage_corrected"

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -242,7 +242,7 @@ def calculate_exp_from_mu(
     #    )
     # else:
     #    plateau_model = get_models(model_type="plateau").he()
-    # plateau_model = get_models(model_type="plateau").he()
+    plateau_model = get_models(model_type="plateau").he()
 
     agg_expr = {
         "mu": hl.agg.sum(mu_expr * cov_corr_expr),
@@ -520,7 +520,7 @@ def create_constraint_prep_ht(
     :param overwrite: Whether to overwrite Table. Default is True.
     :return: None; writes Table to path.
     """
-    # TODO: Make a resource path for this table.
+
     # NOTE: Observed counts upstream now includes variants with AF <= 0.001 instead of AF < 0.001.
     # ht = filtered_context.ht()
     ht = get_per_variant_expected_dataset(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -14,7 +14,11 @@ from gnomad.utils.constraint import (
 )
 from gnomad.utils.file_utils import check_file_exists_raise_error, file_exists
 from gnomad.utils.vep import explode_by_vep_annotation, filter_vep_transcript_csqs
-from gnomad_constraint.resources.resource_utils import get_models, get_mutation_ht
+from gnomad_constraint.resources.resource_utils import (
+    get_models,
+    get_mutation_ht,
+    get_per_variant_expected_dataset,
+)
 
 from rmc.resources.basics import (
     CONSTRAINT_PREFIX,
@@ -520,9 +524,9 @@ def create_constraint_prep_ht(
     """
     # TODO: Make a resource path for this table.
     # ht = filtered_context.ht()
-    ht = hl.read_table(
-        "gs://gnomad/v4.1/constraint_an_coverage_corrected/apply_models/transcript_consequences/gnomad.v4.1.per_variant_expected.coverage_corrected.ht"
-    )
+    ht = get_per_variant_expected_dataset(
+        directory_post_fix="an_coverage_corrected", path_post_fix="coverage_corrected"
+    ).ht()
     # Annotate obs and exp columns to be used downstream
     ht = ht.annotate(
         observed=ht.calibrate_mu.observed_variants[0], expected=ht.expected_variants[0]

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -132,7 +132,11 @@ def process_context_ht(
     # ht = hl.read_table(
     #    "gs://gnomad/v4.1/constraint_an/preprocessed_data/gnomad.v4.1.context.preprocessed.autosome_par.ht"
     # ).select_globals()
-    ht = get_preprocessed_ht("context").ht().select_globals()
+    # TODO: Update this path once new 4.1 constraint is released
+    ht = hl.read_table(
+        "gs://gnomad/v4.1/constraint_an_coverage_corrected/preprocessed_data/gnomad.v4.1.context.preprocessed.ht"
+        ).select_globals()
+    # ht = get_preprocessed_ht("context").ht().select_globals()
 
     if filter_to_canonical:
         logger.info("Filtering to canonical transcripts only...")

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -493,7 +493,7 @@ def keep_criteria(
     """
     Return Boolean expression to filter variants in input Table.
 
-    Default values will filter to rare variants (AC > 0, AF < 0.001) that pass filters.
+    Default values will filter to rare variants (AC > 0, AF <= 0.001) that pass filters.
 
     :param ac_expr: Allele count (AC) Int32Expression.
     :param af_expr: Allele frequency (AF) Float64Expression.
@@ -506,7 +506,7 @@ def keep_criteria(
     :return: Boolean expression used to filter variants.
     """
     af_filter_expr = (
-        (af_expr < af_threshold) if filter_to_rare else (af_expr >= af_threshold)
+        (af_expr <= af_threshold) if filter_to_rare else (af_expr > af_threshold)
     )
     return (ac_expr > 0) & (af_filter_expr) & (hl.len(filters_expr) == 0)
 

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -163,7 +163,7 @@ def process_context_ht(
     # for documentation on annotations added
     ht, _ = annotate_exploded_vep_for_constraint_groupings(
         ht=ht,
-        coverage_expr=ht.exomes_AN,
+        coverage_expr=ht.exomes_AN_percent,
         vep_annotation="transcript_consequences",
         include_canonical_group=True,
         # NOTE: all canonical transcripts are also the MANE select transcript in

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -132,11 +132,7 @@ def process_context_ht(
     # ht = hl.read_table(
     #    "gs://gnomad/v4.1/constraint_an/preprocessed_data/gnomad.v4.1.context.preprocessed.autosome_par.ht"
     # ).select_globals()
-    # TODO: Update this path once new 4.1 constraint is released
-    ht = hl.read_table(
-        "gs://gnomad/v4.1/constraint_an_coverage_corrected/preprocessed_data/gnomad.v4.1.context.preprocessed.ht"
-        ).select_globals()
-    # ht = get_preprocessed_ht("context").ht().select_globals()
+    ht = get_preprocessed_ht("context").ht().select_globals()
 
     if filter_to_canonical:
         logger.info("Filtering to canonical transcripts only...")
@@ -163,7 +159,7 @@ def process_context_ht(
     # for documentation on annotations added
     ht, _ = annotate_exploded_vep_for_constraint_groupings(
         ht=ht,
-        coverage_expr=ht.exomes_AN_percent,
+        coverage_expr=ht.exomes_AN,
         vep_annotation="transcript_consequences",
         include_canonical_group=True,
         # NOTE: all canonical transcripts are also the MANE select transcript in

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -500,8 +500,8 @@ def keep_criteria(
     :param filters_expr: Filters SetExpression.
     :param af_threshold: AF threshold used for filtering variants in combination with `filter_to_rare`. Default is 0.001.
     :param filter_to_rare: Whether to filter to keep rare variants only.
-        If True, only variants with AF < `af_threshold` will be kept.
-        If False, only variants with AF >= `af_threshold` will be kept.
+        If True, only variants with AF <= `af_threshold` will be kept.
+        If False, only variants with AF > `af_threshold` will be kept.
         Default is True.
     :return: Boolean expression used to filter variants.
     """


### PR DESCRIPTION
Minor changes:

1. Comment out code not used which created per variant expected using mutation rates and context HT
2. Read output HT of `--apply-models` step of the constraint pipeline as input table for `prep-constraint` step of RMC pipeline