### PR TITLE
Fixed resource path arguments to point to new constraint table

### DIFF
--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -529,7 +529,7 @@ def create_constraint_prep_ht(
     :return: None; writes Table to path.
     """
     # NOTE: Observed counts upstream now includes variants with AF <= 0.001 instead of AF < 0.001.
-    # The resource path below is called from a non-native branch of gnomad-constraint repo:
+    # The resource path below is called from an alternative (non-main) branch of gnomad-constraint repo:
     # https://github.com/broadinstitute/gnomad-constraint/blob/fa2412e03b86bee714d9a6b6ed44e5a0bd9320f5/gnomad_constraint/resources/resource_utils.py#L410
     ht = get_per_variant_expected_dataset(
         directory_post_fix=directory_post_fix, path_post_fix=path_post_fix

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -503,7 +503,7 @@ def create_constraint_prep_ht(
     filter_csq: Set[str] = {MISSENSE},
     n_partitions: int = 10000,
     overwrite: bool = True,
-    directory_post_fix: str = "an_coverage_corrected",
+    directory_post_fix: str = "coverage_corrected",
     path_post_fix: str = "coverage_corrected",
     variant_idx: int = 0,
 ) -> None:

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -523,12 +523,14 @@ def create_constraint_prep_ht(
     :param n_partitions: Number of desired partitions for the Table. Default is 15000.
     :param csq: Desired consequences. Default is {`MISSENSE`}. Must be specified if filter is True.
     :param overwrite: Whether to overwrite Table. Default is True.
-    :param directory_post_fix: Directory suffix for reading per-variant expected dataset. Default is "an_coverage_corrected".
+    :param directory_post_fix: Directory suffix for reading per-variant expected dataset. Default is "coverage_corrected".
     :param path_post_fix: File suffix to use for reading per-variant expected dataset. Default is "coverage_corrected".
     :param variant_idx: Index of observed and expected arrays to use. Default is 0 (corresponds to counts calculated on gnomAD-wide / "global" frequencies).
     :return: None; writes Table to path.
     """
     # NOTE: Observed counts upstream now includes variants with AF <= 0.001 instead of AF < 0.001.
+    # The resource path below is called from a non-native branch of gnomad-constraint repo:
+    # https://github.com/broadinstitute/gnomad-constraint/blob/fa2412e03b86bee714d9a6b6ed44e5a0bd9320f5/gnomad_constraint/resources/resource_utils.py#L410
     ht = get_per_variant_expected_dataset(
         directory_post_fix=directory_post_fix, path_post_fix=path_post_fix
     ).ht()


### PR DESCRIPTION
This PR is during runtime of RMC on new v4.1 constraint model utilizing AN based coverage correction and per variant expected counts.

This also uses non-native branches of [gnomad-methods](https://github.com/broadinstitute/gnomad_methods/tree/jg/add_functions_for_per_base_constraint) and [gnomad-constraint](https://github.com/broadinstitute/gnomad-constraint/tree/jg/switch_constraint_to_per_base) to utilize the new resource path, specifically this [function](https://github.com/broadinstitute/gnomad-constraint/blob/fa2412e03b86bee714d9a6b6ed44e5a0bd9320f5/gnomad_constraint/resources/resource_utils.py#L410)