### PR TITLE
Runtime fixes to RMC break search and generating the regions 

### DIFF
--- a/rmc/pipeline/regional_constraint.py
+++ b/rmc/pipeline/regional_constraint.py
@@ -396,7 +396,9 @@ def main(args):
             )
             hl.default_reference("GRCh38")
             logger.info("Checking round paths...")
-            round_nums = check_break_search_round_nums(args.freeze)
+            round_nums = check_break_search_round_nums(
+                args.freeze, google_project=args.google_project
+            )
 
             logger.info("Finalizing section-level RMC table...")
             rmc_ht = merge_rmc_hts(
@@ -538,10 +540,6 @@ if __name__ == "__main__":
         action="store_true",
     )
     parser.add_argument(
-        "--slack-channel",
-        help="Send message to Slack channel/user.",
-    )
-    parser.add_argument(
         "--quiet",
         help="Initialize Hail with `quiet=True` to print fewer log messages",
         action="store_true",
@@ -555,6 +553,13 @@ if __name__ == "__main__":
         "--filter-to-canonical",
         help="Filter to canonical transcripts only.",
         action="store_true",
+    )
+    parser.add_argument(
+        "--google-project",
+        help="""
+            Google cloud project used to read from requester-pays buckets.
+            """,
+        default="broad-mpg-gnomad",
     )
 
     subparsers = parser.add_subparsers(title="command", dest="command", required=True)

--- a/rmc/pipeline/two_breaks/merge_hts.py
+++ b/rmc/pipeline/two_breaks/merge_hts.py
@@ -7,11 +7,9 @@ import argparse
 import logging
 
 import hail as hl
-from gnomad.utils.slack import slack_notifications
 
 from rmc.resources.basics import LOGGING_PATH, TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.rmc import CURRENT_FREEZE, simul_search_round_bucket_path
-from rmc.slack_creds import slack_token
 from rmc.utils.constraint import merge_simul_break_temp_hts
 
 logging.basicConfig(
@@ -95,10 +93,6 @@ if __name__ == "__main__":
         "--overwrite", help="Overwrite existing data.", action="store_true"
     )
     parser.add_argument(
-        "--slack-channel",
-        help="Send message to Slack channel/user.",
-    )
-    parser.add_argument(
         "--search-num",
         help=(
             "Search iteration number (e.g., second round of searching for two"
@@ -116,8 +110,4 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    if args.slack_channel:
-        with slack_notifications(slack_token, args.slack_channel):
-            main(args)
-    else:
-        main(args)
+    main(args)

--- a/rmc/pipeline/two_breaks/prepare_transcripts.py
+++ b/rmc/pipeline/two_breaks/prepare_transcripts.py
@@ -11,7 +11,6 @@ import argparse
 import logging
 
 import hail as hl
-from gnomad.utils.slack import slack_notifications
 
 from rmc.resources.basics import LOGGING_PATH, TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.rmc import (
@@ -19,7 +18,6 @@ from rmc.resources.rmc import (
     grouped_single_no_break_ht_path,
     single_search_round_ht_path,
 )
-from rmc.slack_creds import slack_token
 from rmc.utils.simultaneous_breaks import (
     group_no_single_break_found_ht,
     split_sections_by_len,
@@ -94,10 +92,6 @@ if __name__ == "__main__":
         "--overwrite", help="Overwrite existing data.", action="store_true"
     )
     parser.add_argument(
-        "--slack-channel",
-        help="Send message to Slack channel/user.",
-    )
-    parser.add_argument(
         "--search-num",
         help=(
             "Search iteration number (e.g., second round of searching for two"
@@ -144,8 +138,4 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    if args.slack_channel:
-        with slack_notifications(slack_token, args.slack_channel):
-            main(args)
-    else:
-        main(args)
+    main(args)

--- a/rmc/pipeline/two_breaks/run_batches_dataproc.py
+++ b/rmc/pipeline/two_breaks/run_batches_dataproc.py
@@ -11,7 +11,6 @@ import logging
 import hail as hl
 from gnomad.resources.resource_utils import DataException
 from gnomad.utils.file_utils import file_exists
-from gnomad.utils.slack import slack_notifications
 
 from rmc.resources.basics import LOGGING_PATH, TEMP_PATH_WITH_FAST_DEL
 from rmc.resources.rmc import (
@@ -21,7 +20,6 @@ from rmc.resources.rmc import (
     simul_search_round_bucket_path,
     simul_sections_split_by_len_path,
 )
-from rmc.slack_creds import slack_token
 from rmc.utils.simultaneous_breaks import process_section_group
 
 logging.basicConfig(
@@ -48,8 +46,10 @@ def main(args):
         if args.p_value:
             chisq_threshold = hl.eval(hl.qchisqtail(args.p_value, 2))
 
+        # Adding dummy values to variables to avoid pre-commit errors
+        sections_to_run = list()
+        over_threshold = None
         if args.run_all_sections:
-            over_threshold = None
             sections_to_run = list(
                 hl.eval(
                     hl.experimental.read_expression(
@@ -192,10 +192,6 @@ if __name__ == "__main__":
         default=10,
     )
     parser.add_argument(
-        "--slack-channel",
-        help="Send message to Slack channel/user.",
-    )
-    parser.add_argument(
         "--search-num",
         help=(
             "Search iteration number (e.g., second round of searching for two"
@@ -256,8 +252,4 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    if args.slack_channel:
-        with slack_notifications(slack_token, args.slack_channel):
-            main(args)
-    else:
-        main(args)
+    main(args)

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -538,6 +538,9 @@ def create_constraint_prep_ht(
     # NOTE: All MANE Select transcripts in GENCODE v39 are canonical, but not all canonical transcripts are MANE Select
     logger.info("Filtering to canonical Ensembl transcripts...")
     ht = ht.filter(ht.canonical & ht.transcript.startswith("ENST"))
+    # Count number of transcripts after filtering
+    n_transcripts = len(ht.aggregate(hl.agg.collect_as_set(ht.transcript)))
+    logger.info("Found %d transcripts after filtering...", n_transcripts)
     # Obs and exp counts are arrays to account for different frequency strata
     ht = ht.annotate(
         observed=ht.calibrate_mu.observed_variants[variant_idx],
@@ -1155,6 +1158,8 @@ def check_break_search_round_nums(
         Assumes there is a folder for each search round run, regardless of whether there were breaks discovered
 
     :param freeze: RMC freeze number. Default is CURRENT_FREEZE.
+    :param google_project: Google project to use to read data from requester-pays buckets.
+        Default is 'broad-mpg-gnomad'.
     :return: Sorted list of round numbers.
     """
     # Get sorted round numbers

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -534,6 +534,9 @@ def create_constraint_prep_ht(
     ht = get_per_variant_expected_dataset(
         directory_post_fix=directory_post_fix, path_post_fix=path_post_fix
     ).ht()
+    # filter to Canonical Ensembl transcripts
+    logger.info("Filtering to canonical Ensembl transcripts...")
+    ht = ht.filter(ht.canonical & ht.transcript.startswith("ENST"))
     # Obs and exp counts are arrays to account for different frequency strata
     ht = ht.annotate(
         observed=ht.calibrate_mu.observed_variants[variant_idx],
@@ -1137,7 +1140,10 @@ def get_break_search_round_nums(
     return sorted(round_nums)
 
 
-def check_break_search_round_nums(freeze: int = CURRENT_FREEZE) -> List[int]:
+def check_break_search_round_nums(
+    freeze: int = CURRENT_FREEZE,
+    google_project: str = "broad-mpg-gnomad",
+) -> List[int]:
     """
     Check for valid single and simultaneous break search round number outputs.
 
@@ -1152,10 +1158,12 @@ def check_break_search_round_nums(freeze: int = CURRENT_FREEZE) -> List[int]:
     """
     # Get sorted round numbers
     single_search_round_nums = get_break_search_round_nums(
-        single_search_bucket_path(freeze=freeze)
+        single_search_bucket_path(freeze=freeze),
+        google_project=google_project,
     )
     simul_search_round_nums = get_break_search_round_nums(
-        simul_search_bucket_path(freeze=freeze)
+        simul_search_bucket_path(freeze=freeze),
+        google_project=google_project,
     )
     logger.info(
         "Single search round numbers: %s\nSimultaneous search round numbers: %s",

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -534,7 +534,8 @@ def create_constraint_prep_ht(
     ht = get_per_variant_expected_dataset(
         directory_post_fix=directory_post_fix, path_post_fix=path_post_fix
     ).ht()
-    # filter to Canonical Ensembl transcripts
+    # Filter to Canonical Ensembl transcripts
+    # NOTE: All MANE Select transcripts in GENCODE v39 are canonical, but not all canonical transcripts are MANE Select
     logger.info("Filtering to canonical Ensembl transcripts...")
     ht = ht.filter(ht.canonical & ht.transcript.startswith("ENST"))
     # Obs and exp counts are arrays to account for different frequency strata


### PR DESCRIPTION
Major change:
1. Added step to filter the upstream constraint HT to canonical ensembl transcripts during `prep-constraint` step

Minor runtime fixes:
1. Removed slack notifications part throughout the pipeline.
2. Added feature to specify a custom google project in the required steps of the pipeline.
3. Minor variable assignment shift and adding dummy variable in `run_batches_dataproc.py` to avoid pre-commit errors 