### PR TITLE
Switch to new constraint resource path for building browser HT and update context with OE to use browser table

### DIFF
--- a/rmc/resources/gnomad.py
+++ b/rmc/resources/gnomad.py
@@ -10,7 +10,7 @@ constraint_ht = VersionedTableResource(
             path="gs://gcp-public-data--gnomad/release/2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_transcript.ht"
         ),
         "4.1": TableResource(
-            path="gs://gcp-public-data--gnomad/release/4.1/constraint/gnomad.v4.1.constraint_metrics.ht"
+            path="gs://gcp-public-data--gnomad/release/4.1/constraint_cov_corrected/gnomad.v4.1.constraint_metrics.ht"
         ),
     },
 )

--- a/rmc/resources/gnomad.py
+++ b/rmc/resources/gnomad.py
@@ -10,9 +10,8 @@ constraint_ht = VersionedTableResource(
         "4.1": TableResource(
             path="gs://gcp-public-data--gnomad/release/4.1/constraint/gnomad.v4.1.constraint_metrics.ht"
         ),
-        # TODO: Update this path when the new public version is released.
         "4.1.1": TableResource(
-            path="gs://gnomad/v4.1/constraint_coverage_corrected/metrics/transcript_consequences/gnomad.v4.1.constraint_metrics.coverage_corrected.ht"
+            path="gs://gcp-public-data--gnomad/release/4.1.1/constraint/gnomad.v4.1.1.constraint_metrics.ht"
         ),
     },
 )

--- a/rmc/resources/gnomad.py
+++ b/rmc/resources/gnomad.py
@@ -21,7 +21,7 @@ Public gnomAD gene constraint Table.
 
 v2.1.1: Observed variants count is annotated as `ht.obs_mis` and expected variants count is annotated as `ht.exp_mis`.
 v4.1: Observed variants count is annotated as `ht.mis.obs` and expected variants count is annotated as `ht.mis.exp`.
-NOTE: default version is manually set to point to most updated resource. When public resource is updated,
-please set the default version to CURRENT_GNOMAD_VERSION and add this import
-from rmc.resources.resource_utils import CURRENT_GNOMAD_VERSION
+NOTE: Default version is manually set to point to most updated resource. When public resource is updated,
+please update `CURRENT_GNOMAD_VERSION`, set the default version to `CURRENT_GNOMAD_VERSION` and add this import:
+`from rmc.resources.resource_utils import CURRENT_GNOMAD_VERSION`
 """

--- a/rmc/resources/gnomad.py
+++ b/rmc/resources/gnomad.py
@@ -1,8 +1,6 @@
 """Script containing resources for the current gnomAD version."""
 from gnomad.resources.resource_utils import TableResource, VersionedTableResource
 
-# from rmc.resources.resource_utils import CURRENT_GNOMAD_VERSION
-
 constraint_ht = VersionedTableResource(
     default_version="4.1.1",
     versions={
@@ -23,4 +21,7 @@ Public gnomAD gene constraint Table.
 
 v2.1.1: Observed variants count is annotated as `ht.obs_mis` and expected variants count is annotated as `ht.exp_mis`.
 v4.1: Observed variants count is annotated as `ht.mis.obs` and expected variants count is annotated as `ht.mis.exp`.
+NOTE: default version is manually set to point to most updated resource. When public resource is updated,
+please set the default version to CURRENT_GNOMAD_VERSION and add this import
+from rmc.resources.resource_utils import CURRENT_GNOMAD_VERSION
 """

--- a/rmc/resources/gnomad.py
+++ b/rmc/resources/gnomad.py
@@ -1,16 +1,20 @@
 """Script containing resources for the current gnomAD version."""
 from gnomad.resources.resource_utils import TableResource, VersionedTableResource
 
-from rmc.resources.resource_utils import CURRENT_GNOMAD_VERSION
+# from rmc.resources.resource_utils import CURRENT_GNOMAD_VERSION
 
 constraint_ht = VersionedTableResource(
-    default_version=CURRENT_GNOMAD_VERSION,
+    default_version="4.1.1",
     versions={
         "2.1.1": TableResource(
             path="gs://gcp-public-data--gnomad/release/2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_transcript.ht"
         ),
         "4.1": TableResource(
-            path="gs://gcp-public-data--gnomad/release/4.1/constraint_cov_corrected/gnomad.v4.1.constraint_metrics.ht"
+            path="gs://gcp-public-data--gnomad/release/4.1/constraint/gnomad.v4.1.constraint_metrics.ht"
+        ),
+        # TODO: Update this path when the new public version is released.
+        "4.1.1": TableResource(
+            path="gs://gnomad/v4.1/constraint_coverage_corrected/metrics/transcript_consequences/gnomad.v4.1.constraint_metrics.coverage_corrected.ht"
         ),
     },
 )

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1440,6 +1440,8 @@ def get_oe_annotation(ht: hl.Table, freeze: int) -> hl.Table:
         interval=hl.interval(
             rmc_ht.regions.start_coordinate,
             rmc_ht.regions.stop_coordinate,
+            includes_start=True,
+            includes_end=True,
         )
     ).key_by("interval")
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1447,7 +1447,7 @@ def get_oe_annotation(ht: hl.Table, freeze: int) -> hl.Table:
     ).key_by("interval", "transcript")
 
     # Annotate with RMC OE
-    rmc_exploded = explode_intervals_to_loci(rmc_ht).key_by("locus", "transcript")
+    rmc_exploded = explode_intervals_to_loci(rmc_ht, interval_field="interval", keep_intervals=False).key_by("locus", "transcript")
     ht = ht.annotate(section_oe=rmc_exploded[ht.locus, ht.transcript].regions.oe)
 
     # Annotate with RMC OE where available, otherwise select transcript OE

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1429,17 +1429,25 @@ def get_oe_annotation(ht: hl.Table, freeze: int) -> hl.Table:
     )
 
     check_file_exists_raise_error(
-        rmc_results.versions[freeze].path,
+        rmc_browser.versions[freeze].path,
         error_if_not_exists=True,
         error_if_not_exists_msg="Merged RMC results table does not exist!",
     )
-    rmc_ht = rmc_results.versions[freeze].ht().key_by("interval")
+    rmc_ht = rmc_browser.versions[freeze].ht()
+    # Explode on regions and create intervals
+    rmc_ht = rmc_ht.explode(rmc_ht.regions)
+    rmc_ht = rmc_ht.annotate(
+        interval=hl.interval(
+            rmc_ht.regions.start_coordinate,
+            rmc_ht.regions.stop_coordinate,
+        )
+    ).key_by("interval")
 
     # Annotate with RMC OE
     ht = ht.annotate(
         section_oe=rmc_ht.index(ht.locus, all_matches=True)
         .filter(lambda x: x.transcript == ht.transcript)
-        .section_oe
+        .regions.oe
     )
     ht = ht.annotate(
         section_oe=hl.or_missing(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1511,7 +1511,7 @@ def create_context_with_oe(
     :param missense_str: String representing missense variant consequence. Default is MISSENSE.
     :param n_partitions: Number of desired partitions for the VEP context Table.
         Repartition VEP context Table to this number on read.
-        Default is 30000.
+        Default is 10000.
     :param overwrite_temp: Whether to overwrite intermediate temporary (OE-independent) data if it already exists.
         If False, will read existing intermediate temporary data rather than overwriting.
         Default is False.

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1447,7 +1447,9 @@ def get_oe_annotation(ht: hl.Table, freeze: int) -> hl.Table:
     ).key_by("interval", "transcript")
 
     # Annotate with RMC OE
-    rmc_exploded = explode_intervals_to_loci(rmc_ht, interval_field="interval", keep_intervals=False).key_by("locus", "transcript")
+    rmc_exploded = explode_intervals_to_loci(
+        rmc_ht, interval_field="interval", keep_intervals=False
+    ).key_by("locus", "transcript")
     ht = ht.annotate(section_oe=rmc_exploded[ht.locus, ht.transcript].regions.oe)
 
     # Annotate with RMC OE where available, otherwise select transcript OE

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -13,6 +13,7 @@ from gnomad.utils.constraint import (
     count_variants_by_group,
 )
 from gnomad.utils.file_utils import check_file_exists_raise_error, file_exists
+from gnomad.utils.intervals import explode_intervals_to_loci
 from gnomad.utils.vep import explode_by_vep_annotation, filter_vep_transcript_csqs
 from gnomad_constraint.resources.resource_utils import (
     get_models,
@@ -1443,20 +1444,12 @@ def get_oe_annotation(ht: hl.Table, freeze: int) -> hl.Table:
             includes_start=True,
             includes_end=True,
         )
-    ).key_by("interval")
+    ).key_by("interval", "transcript")
 
     # Annotate with RMC OE
-    ht = ht.annotate(
-        section_oe=rmc_ht.index(ht.locus, all_matches=True)
-        .filter(lambda x: x.transcript == ht.transcript)
-        .regions.oe
-    )
-    ht = ht.annotate(
-        section_oe=hl.or_missing(
-            hl.len(ht.section_oe) > 0,
-            ht.section_oe[0],
-        ),
-    )
+    rmc_exploded = explode_intervals_to_loci(rmc_ht).key_by("locus", "transcript")
+    ht = ht.annotate(section_oe=rmc_exploded[ht.locus, ht.transcript].regions.oe)
+
     # Annotate with RMC OE where available, otherwise select transcript OE
     return ht.transmute(oe=hl.coalesce(ht.section_oe, ht.transcript_oe))
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -1,7 +1,7 @@
 import logging
 import re
 import subprocess
-from typing import List, Set, Tuple, Union
+from typing import List, Optional, Set, Tuple, Union
 
 import hail as hl
 import scipy
@@ -13,7 +13,10 @@ from gnomad.utils.constraint import (
     count_variants_by_group,
 )
 from gnomad.utils.file_utils import check_file_exists_raise_error, file_exists
-from gnomad.utils.intervals import explode_intervals_to_loci
+
+# from gnomad.utils.intervals import explode_intervals_to_loci #TODO: Uncomment when methods PR#789 is merged
+# TODO: Remove this import when methods PR#789 is merged
+from gnomad.utils.reference_genome import get_reference_genome
 from gnomad.utils.vep import explode_by_vep_annotation, filter_vep_transcript_csqs
 from gnomad_constraint.resources.resource_utils import (
     get_models,
@@ -102,6 +105,75 @@ Fields to group by when calculating expected variants per variant type.
 
 Fields based off of gnomAD LoF repo.
 """
+
+
+# TODO: Remove this function when methods PR#789 is merged
+def explode_intervals_to_loci(
+    intervals: Union[hl.Table, hl.expr.IntervalExpression],
+    interval_field: Optional[str] = None,
+    keep_intervals: Optional[bool] = False,
+) -> Union[hl.Table, hl.expr.ArrayExpression]:
+    """
+    Expand intervals to loci and key by loci, or return loci range expression.
+
+    :param intervals: Hail Table or Interval Expression.
+    :param interval_field: Name of the interval field. Only required if input is a Hail Table. Default is None.
+    :param keep_intervals: If True, keep the original intervals as a column in output. Only applies if input is a Hail Table. Default is False.
+    :return: If input is a Hail Table, returns exploded Table keyed by locus. If input is an IntervalExpression, returns position array expression.
+    """
+    assert isinstance(intervals, hl.Table) or isinstance(
+        intervals, hl.expr.IntervalExpression
+    ), "Input must be a Table or IntervalExpression!"
+
+    if isinstance(intervals, hl.Table) and (
+        not interval_field or keep_intervals is None
+    ):
+        raise ValueError(
+            "`interval_field` and `keep_intervals` must be defined if input is a Table!"
+        )
+    assert (
+        interval_field in intervals.row
+    ), "`interval_field` must be an annotation present on input Table!"
+    intervals_expr = (
+        intervals
+        if isinstance(intervals, hl.expr.IntervalExpression)
+        else intervals[interval_field]
+    )
+    intervals_start_expr = hl.if_else(
+        intervals_expr.includes_start,
+        intervals_expr.start.position,
+        intervals_expr.start.position + 1,
+    )
+    intervals_end_expr = hl.if_else(
+        intervals_expr.includes_end,
+        intervals_expr.end.position + 1,
+        intervals_expr.end.position,
+    )
+    if isinstance(intervals, hl.Table):
+        intervals = intervals.annotate(
+            pos=hl.range(intervals_start_expr, intervals_end_expr)
+        ).explode("pos")
+        intervals = intervals.key_by(
+            locus=hl.locus(
+                intervals[interval_field].start.contig,
+                intervals.pos,
+                reference_genome=get_reference_genome(intervals[interval_field]),
+            )
+        )
+
+        fields_to_drop = ["pos"]
+        if not keep_intervals:
+            fields_to_drop.append(interval_field)
+
+        return intervals.drop(*fields_to_drop)
+
+    logger.warning(
+        "Input is an IntervalExpression, so function will return ArrayExpression of"
+        " positions  within input intervals. To fully explode intervals to loci, we"
+        " recommend annotating your dataset with the returned ArrayExpression,"
+        " exploding the array, and converting the positions to loci!"
+    )
+    return hl.range(intervals_start_expr, intervals_end_expr)
 
 
 def add_obs_annotation(

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -632,15 +632,9 @@ def get_constraint_transcripts(
         " exists..."
     )
     if not file_exists(constraint_ht.path):
-        # NOTE: read the non-public consraint HT if the public one is not available
-        # raise DataException("Constraint HT not found!")
-        constraint_transcript_ht = hl.read_table(
-            "gs://gnomad/v4.1/constraint_coverage_corrected/metrics/transcript_consequences/gnomad.v4.1.constraint_metrics.coverage_corrected.ht"
-        )
-    else:
-        constraint_transcript_ht = constraint_ht.ht()
+        raise DataException("Constraint HT not found!")
 
-    constraint_transcript_ht = constraint_transcript_ht.key_by("transcript")
+    constraint_transcript_ht = constraint_ht.ht().key_by("transcript")
     # NOTE: all protein-coding transcripts are ENST transcripts in constraint HT
     constraint_transcript_ht = constraint_transcript_ht.filter(
         constraint_transcript_ht.transcript_type == "protein_coding"

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -632,9 +632,15 @@ def get_constraint_transcripts(
         " exists..."
     )
     if not file_exists(constraint_ht.path):
-        raise DataException("Constraint HT not found!")
+        # NOTE: read the non-public consraint HT if the public one is not available
+        # raise DataException("Constraint HT not found!")
+        constraint_transcript_ht = hl.read_table(
+            "gs://gnomad/v4.1/constraint_coverage_corrected/metrics/transcript_consequences/gnomad.v4.1.constraint_metrics.coverage_corrected.ht"
+        )
+    else:
+        constraint_transcript_ht = constraint_ht.ht()
 
-    constraint_transcript_ht = constraint_ht.ht().key_by("transcript")
+    constraint_transcript_ht = constraint_transcript_ht.key_by("transcript")
     # NOTE: all protein-coding transcripts are ENST transcripts in constraint HT
     constraint_transcript_ht = constraint_transcript_ht.filter(
         constraint_transcript_ht.transcript_type == "protein_coding"


### PR DESCRIPTION
List of Changes:
1. `get_constraint_transcripts` now uses new upstream constraint table to filter to canonical protein coding ENST 
2. Default resource path for `constraint_ht` is updated to point to new gene constraint table
3. `create_context_with_oe` will use the browser table instead of regions table. This also fixed a bug that the regions OE was still capped to 1 while transcript OE was uncapped.
4. `get_oe_annotation` is modified to explode the regions table into loci followed by a left join to annotate context table with region OE