### PR TITLE
Update browser release HT for v4.1.1

### DIFF
--- a/rmc/resources/gnomad.py
+++ b/rmc/resources/gnomad.py
@@ -1,6 +1,7 @@
 """Script containing resources for the current gnomAD version."""
 from gnomad.resources.resource_utils import TableResource, VersionedTableResource
 
+# TODO: replace with `constraint()` from gnomad_methods
 constraint_ht = VersionedTableResource(
     default_version="4.1.1",
     versions={

--- a/rmc/resources/reference_data.py
+++ b/rmc/resources/reference_data.py
@@ -36,6 +36,7 @@ VEP_VERSION = "105"
 VEP version used to annotate variants.
 """
 
+# TODO: Replace this with `browser_gene()` gnomad_methods resource
 gene_model = VersionedTableResource(
     default_version=CURRENT_BUILD,
     versions={
@@ -43,7 +44,7 @@ gene_model = VersionedTableResource(
             path=f"{get_resource_build_prefix('GRCh37')}/browser/b37_transcripts.ht"
         ),
         "GRCh38": TableResource(
-            path="gs://gcp-public-data--gnomad/resources/grch38/browser/gnomad.genes.GRCh38.GENCODEv39.ht"
+            path="gs://gcp-public-data--gnomad/resources/grch38/browser/gnomad.genes.GRCh38.GENCODEv39.pext.flags.ht"
         ),
     },
 )

--- a/rmc/resources/resource_utils.py
+++ b/rmc/resources/resource_utils.py
@@ -2,6 +2,8 @@
 CURRENT_BUILD = "GRCh38"
 BUILDS = ["GRCh37", "GRCh38"]
 
+# NOTE: RMC on v4 was started on gnomAD v4.1, which is why the version here is still 4.1
+# However, the models underlying the expected variant counts match computed gnomAD v4.1.1
 CURRENT_GNOMAD_VERSION = "4.1"
 GNOMAD_VERSIONS = ["2.1.1", "4.1"]
 

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -498,6 +498,19 @@ a most severe consequence of 'missense_variant' in more than one canonical trans
 This Table contains only one row per each unique locus/alleles combination.
 """
 
+rmc_coverage_stats_ht = VersionedTableResource(
+    default_version=CURRENT_FREEZE,
+    versions={
+        freeze: TableResource(
+            path=f"{CONSTRAINT_PREFIX}/{CURRENT_GNOMAD_VERSION}/{freeze}/rmc_coverage_stats.ht"
+        )
+        for freeze in FREEZES
+    },
+)
+"""
+Table containing exome AN percent per RMC region.
+"""
+
 rmc_browser = VersionedTableResource(
     default_version=CURRENT_FREEZE,
     versions={

--- a/rmc/resources/rmc.py
+++ b/rmc/resources/rmc.py
@@ -10,6 +10,7 @@ from typing import Set
 import scipy
 from gnomad.resources.resource_utils import (
     DataException,
+    ExpressionResource,
     TableResource,
     VersionedTableResource,
 )
@@ -509,6 +510,13 @@ rmc_coverage_stats_ht = VersionedTableResource(
 )
 """
 Table containing exome AN percent per RMC region.
+"""
+
+mis_oe_percentiles = ExpressionResource(
+    path="gs://gnomad-public-requester-pays/papers/2026-rmc/gnomad_v4.1.1_coding_locus_oe_percentiles.he"
+)
+"""
+Expression containing missense OE depletion percentiles for coding loci.
 """
 
 rmc_browser = VersionedTableResource(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -2223,9 +2223,6 @@ def format_rmc_browser_ht(
     )
     # Group Table by transcript
     ht = ht.group_by("transcript").aggregate(regions=hl.agg.collect(ht.region))
-    ht = ht.checkpoint(
-        f"{TEMP_PATH_WITH_FAST_DEL}/rmc_browser_ht_grouped.ht", overwrite=True
-    )
 
     # Annotate globals and write
     ht = add_globals_rmc_browser(ht, filter_to_canonical)

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -2089,50 +2089,45 @@ def check_and_fix_missing_aa(
 
 
 def add_globals_rmc_browser(
-    ht: hl.Table, filter_to_canonical: bool, keep_outliers: bool = True
+    ht: hl.Table,
+    filter_to_canonical: bool = True,
 ) -> hl.Table:
     """
     Annotate HT globals with RMC transcript information.
 
     Function is used when reformatting RMC results for browser release.
-    Annotates:
-        - transcripts not searched for RMC
-        - transcripts without evidence of RMC
-        - outlier transcripts
+
+    Annotates two structs:
+        - `transcript_counts`: Counts of total transcripts and transcripts with/without evidence of RMC (QC pass only).
+        - `transcript_counts_all`: Counts of all transcripts, transcripts with/without evidence of RMC, and outlier transcripts.
+
     :param HT: Input Table. Should be RMC regions HT annotated with amino acid
         information for region starts and stops.
-    :param filter_to_canonical: Whether to filter to canonical transcripts only.
-    :param keep_outliers: Whether to keep outlier transcripts.
-        Default is True.
+    :param filter_to_canonical: Whether to filter to canonical transcripts only. Default is True.
     :return: RMC regions HT with updated globals annotations.
     """
-    # Get transcripts with evidence of RMC
+    # Get all transcripts with evidence of RMC
     rmc_transcripts = hl.literal(ht.aggregate(hl.agg.collect_as_set(ht.transcript)))
-
-    # Get all QC pass transcripts
-    qc_pass_transcripts = get_constraint_transcripts(
-        filter_to_canonical=filter_to_canonical, outlier=False
-    )
-    outlier_transcripts = get_constraint_transcripts(
-        filter_to_canonical=filter_to_canonical, outlier=True
-    )
 
     # Get all transcripts from constraint HT
     all_transcripts = get_constraint_transcripts(
         all_transcripts=True, filter_to_canonical=filter_to_canonical
     )
-    if keep_outliers:
-        transcripts_no_rmc = all_transcripts.difference(rmc_transcripts)
-        transcripts_not_searched = hl.empty_array(hl.tstr)
-    else:
-        transcripts_no_rmc = qc_pass_transcripts.difference(rmc_transcripts)
-        transcripts_not_searched = all_transcripts.difference(qc_pass_transcripts)
+    outlier_transcripts = get_constraint_transcripts(
+        filter_to_canonical=filter_to_canonical, outlier=True
+    )
 
     ht = ht.select_globals()
     return ht.annotate_globals(
-        transcripts_not_searched=transcripts_not_searched,
-        transcripts_no_rmc=transcripts_no_rmc,
-        outlier_transcripts=outlier_transcripts,
+        transcript_counts=hl.struct(
+            all_transcripts=all_transcripts.difference(outlier_transcripts),
+            rmc_transcripts=rmc_transcripts.difference(outlier_transcripts),
+        ),
+        transcript_counts_all=hl.struct(
+            all_transcripts=all_transcripts,
+            rmc_transcripts=rmc_transcripts,
+            outlier_transcripts=outlier_transcripts,
+        ),
     )
 
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -2168,7 +2168,7 @@ def format_rmc_browser_ht(
             chisq: float64,
             p: float64,
             low_coverage: bool,
-            is_gray: bool,
+            no_color: bool,
         }>
     ----------------------------------------
     Key: ['transcript']
@@ -2222,7 +2222,7 @@ def format_rmc_browser_ht(
             low_coverage=ht.low_coverage,
         )
     )
-    ht = ht.annotate(is_gray=(ht.regions.p > P_VALUE) | ht.regions.low_coverage)
+    ht = ht.annotate(no_color=(ht.regions.p > P_VALUE) | ht.regions.low_coverage)
 
     # Group Table by transcript
     ht = ht.group_by("transcript").aggregate(regions=hl.agg.collect(ht.region))

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -57,6 +57,7 @@ from rmc.resources.rmc import (
     no_breaks_he_path,
     oe_bin_counts_tsv,
     rmc_browser,
+    rmc_coverage_stats_ht,
     rmc_downloads_resource_paths,
     rmc_results,
     simul_search_bucket_path,
@@ -2180,6 +2181,7 @@ def format_rmc_browser_ht(
     :return: None; writes Table with desired schema to resource path.
     """
     ht = rmc_results.versions[freeze].ht()
+    cov_ht = rmc_coverage_stats_ht.versions[freeze].ht()
 
     # Annotate start and stop coordinates per region
     ht = ht.annotate(
@@ -2189,6 +2191,12 @@ def format_rmc_browser_ht(
 
     # Annotate start and stop amino acids per region
     ht = annot_rmc_with_start_stop_aas(ht, overwrite_temp, filter_to_canonical)
+
+    # Annotate low coverage flag per region using coverage stats
+    cov_ht = cov_ht.key_by("interval", "transcript")
+    ht = ht.annotate(
+        low_coverage=cov_ht[ht.interval, ht.transcript].median_exomes_AN_percent < 90
+    )
 
     # Remove missense O/E cap of 1
     # (Missense O/E capped for RMC search, but
@@ -2210,10 +2218,14 @@ def format_rmc_browser_ht(
             oe=ht.section_oe,
             chisq=ht.section_chisq,
             p=ht.section_p_value,
+            low_coverage=ht.low_coverage,
         )
     )
     # Group Table by transcript
     ht = ht.group_by("transcript").aggregate(regions=hl.agg.collect(ht.region))
+    ht = ht.checkpoint(
+        f"{TEMP_PATH_WITH_FAST_DEL}/rmc_browser_ht_grouped.ht", overwrite=True
+    )
 
     # Annotate globals and write
     ht = add_globals_rmc_browser(ht, filter_to_canonical)

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -2168,6 +2168,7 @@ def format_rmc_browser_ht(
             chisq: float64,
             p: float64,
             low_coverage: bool,
+            is_gray: bool,
         }>
     ----------------------------------------
     Key: ['transcript']

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -54,6 +54,7 @@ from rmc.resources.rmc import (
     context_with_oe,
     context_with_oe_dedup,
     filtered_context,
+    mis_oe_percentiles,
     no_breaks_he_path,
     oe_bin_counts_tsv,
     rmc_browser,
@@ -2132,6 +2133,40 @@ def add_globals_rmc_browser(
     )
 
 
+def annot_rmc_with_percentile(ht: hl.Table, oe_field: str) -> hl.Table:
+    """
+    Annotate input HT with missense OE depletion percentile using `mis_oe_percentiles` resource.
+
+    This resource is a list with 100 elements corresponding to missense OE for that percentile.
+
+    Percentiles to annotate are:
+        - <=1
+        - <=5
+        - <=10
+        - <=15
+        - <=25
+        - <=50
+        - <=75
+
+    :param ht: Input HT with RMC information.
+    :param oe_field: Field name of OE to use for percentile annotation.
+    :return: HT with missense OE depletion percentile annotated per RMC region.
+    """
+    mis_oe_pcts = hl.eval(mis_oe_percentiles.he())
+    oe = ht[oe_field]
+    return ht.annotate(
+        mis_oe_percentile=hl.case()
+        .when(oe <= mis_oe_pcts[0], "<=1")
+        .when(oe <= mis_oe_pcts[4], "<=5")
+        .when(oe <= mis_oe_pcts[9], "<=10")
+        .when(oe <= mis_oe_pcts[14], "<=15")
+        .when(oe <= mis_oe_pcts[24], "<=25")
+        .when(oe <= mis_oe_pcts[49], "<=50")
+        .when(oe <= mis_oe_pcts[74], "<=75")
+        .default(">75")
+    )
+
+
 def format_rmc_browser_ht(
     freeze: int, overwrite_temp: bool, filter_to_canonical: bool = False
 ) -> None:
@@ -2169,6 +2204,7 @@ def format_rmc_browser_ht(
             p: float64,
             low_coverage: bool,
             no_color: bool,
+            percentile: str,
         }>
     ----------------------------------------
     Key: ['transcript']
@@ -2199,10 +2235,11 @@ def format_rmc_browser_ht(
         low_coverage=cov_ht[ht.interval, ht.transcript].median_exomes_AN_percent < 90
     )
 
-    # Remove missense O/E cap of 1
+    # Remove missense O/E cap of 1 and add percentile
     # (Missense O/E capped for RMC search, but
     # it shouldn't be capped when displayed in the browser)
     ht = ht.annotate(section_oe=ht.section_obs / ht.section_exp)
+    ht = annot_rmc_with_percentile(ht, "section_oe")
 
     # Convert chi square to p-value
     ht = ht.annotate(section_p_value=hl.pchisqtail(ht.section_chisq, 1))
@@ -2220,6 +2257,7 @@ def format_rmc_browser_ht(
             chisq=ht.section_chisq,
             p=ht.section_p_value,
             low_coverage=ht.low_coverage,
+            percentile=ht.mis_oe_percentile,
         )
     )
     ht = ht.annotate(

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -2118,16 +2118,19 @@ def add_globals_rmc_browser(
     outlier_transcripts = get_constraint_transcripts(
         filter_to_canonical=filter_to_canonical, outlier=True
     )
+    qc_pass_transcripts = all_transcripts.difference(outlier_transcripts)
 
     ht = ht.select_globals()
     return ht.annotate_globals(
         transcript_counts=hl.struct(
-            all_transcripts=all_transcripts.difference(outlier_transcripts),
+            all_transcripts=qc_pass_transcripts,
             rmc_transcripts=rmc_transcripts.difference(outlier_transcripts),
+            transcripts_no_rmc=qc_pass_transcripts.difference(rmc_transcripts),
         ),
         transcript_counts_all=hl.struct(
             all_transcripts=all_transcripts,
             rmc_transcripts=rmc_transcripts,
+            transcripts_no_rmc=all_transcripts.difference(rmc_transcripts),
             outlier_transcripts=outlier_transcripts,
         ),
     )

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -2142,10 +2142,17 @@ def format_rmc_browser_ht(
     Desired schema:
     ----------------------------------------
     Global fields:
-        'p_value': float64
-        'transcripts_not_searched': set<str>
-        'transcripts_no_rmc': set<str>
-        'outlier_transcripts': set<str>
+        'transcript_counts': struct {
+            'all_transcripts': set<str>
+            'rmc_transcripts': set<str>
+            'transcripts_no_rmc': set<str>
+        }
+        'transcript_counts_all': struct {
+            'all_transcripts': set<str>
+            'rmc_transcripts': set<str>
+            'transcripts_no_rmc': set<str>
+            'outlier_transcripts': set<str>
+        }
     ----------------------------------------
     Row fields:
         'transcript': str

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -2222,7 +2222,7 @@ def format_rmc_browser_ht(
             low_coverage=ht.low_coverage,
         )
     )
-    ht = ht.annotate(is_gray=(ht.region.p > P_VALUE) | ht.region.low_coverage)
+    ht = ht.annotate(is_gray=(ht.regions.p > P_VALUE) | ht.regions.low_coverage)
 
     # Group Table by transcript
     ht = ht.group_by("transcript").aggregate(regions=hl.agg.collect(ht.region))

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -2222,7 +2222,11 @@ def format_rmc_browser_ht(
             low_coverage=ht.low_coverage,
         )
     )
-    ht = ht.annotate(no_color=(ht.region.p > P_VALUE) | ht.region.low_coverage)
+    ht = ht.annotate(
+        region=ht.region.annotate(
+            no_color=(ht.region.p > P_VALUE) | ht.region.low_coverage
+        )
+    )
 
     # Group Table by transcript
     ht = ht.group_by("transcript").aggregate(regions=hl.agg.collect(ht.region))

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -2221,6 +2221,8 @@ def format_rmc_browser_ht(
             low_coverage=ht.low_coverage,
         )
     )
+    ht = ht.annotate(is_gray=(ht.region.p > P_VALUE) | ht.region.low_coverage)
+
     # Group Table by transcript
     ht = ht.group_by("transcript").aggregate(regions=hl.agg.collect(ht.region))
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -2089,45 +2089,50 @@ def check_and_fix_missing_aa(
 
 
 def add_globals_rmc_browser(
-    ht: hl.Table,
-    filter_to_canonical: bool = True,
+    ht: hl.Table, filter_to_canonical: bool, keep_outliers: bool = True
 ) -> hl.Table:
     """
     Annotate HT globals with RMC transcript information.
 
     Function is used when reformatting RMC results for browser release.
-
-    Annotates two structs:
-        - `transcript_counts`: Counts of total transcripts and transcripts with/without evidence of RMC (QC pass only).
-        - `transcript_counts_all`: Counts of all transcripts, transcripts with/without evidence of RMC, and outlier transcripts.
-
+    Annotates:
+        - transcripts not searched for RMC
+        - transcripts without evidence of RMC
+        - outlier transcripts
     :param HT: Input Table. Should be RMC regions HT annotated with amino acid
         information for region starts and stops.
-    :param filter_to_canonical: Whether to filter to canonical transcripts only. Default is True.
+    :param filter_to_canonical: Whether to filter to canonical transcripts only.
+    :param keep_outliers: Whether to keep outlier transcripts.
+        Default is True.
     :return: RMC regions HT with updated globals annotations.
     """
-    # Get all transcripts with evidence of RMC
+    # Get transcripts with evidence of RMC
     rmc_transcripts = hl.literal(ht.aggregate(hl.agg.collect_as_set(ht.transcript)))
 
-    # Get all transcripts from constraint HT
-    all_transcripts = get_constraint_transcripts(
-        all_transcripts=True, filter_to_canonical=filter_to_canonical
+    # Get all QC pass transcripts
+    qc_pass_transcripts = get_constraint_transcripts(
+        filter_to_canonical=filter_to_canonical, outlier=False
     )
     outlier_transcripts = get_constraint_transcripts(
         filter_to_canonical=filter_to_canonical, outlier=True
     )
 
+    # Get all transcripts from constraint HT
+    all_transcripts = get_constraint_transcripts(
+        all_transcripts=True, filter_to_canonical=filter_to_canonical
+    )
+    if keep_outliers:
+        transcripts_no_rmc = all_transcripts.difference(rmc_transcripts)
+        transcripts_not_searched = hl.empty_array(hl.tstr)
+    else:
+        transcripts_no_rmc = qc_pass_transcripts.difference(rmc_transcripts)
+        transcripts_not_searched = all_transcripts.difference(qc_pass_transcripts)
+
     ht = ht.select_globals()
     return ht.annotate_globals(
-        transcript_counts=hl.struct(
-            all_transcripts=all_transcripts.difference(outlier_transcripts),
-            rmc_transcripts=rmc_transcripts.difference(outlier_transcripts),
-        ),
-        transcript_counts_all=hl.struct(
-            all_transcripts=all_transcripts,
-            rmc_transcripts=rmc_transcripts,
-            outlier_transcripts=outlier_transcripts,
-        ),
+        transcripts_not_searched=transcripts_not_searched,
+        transcripts_no_rmc=transcripts_no_rmc,
+        outlier_transcripts=outlier_transcripts,
     )
 
 

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -2165,7 +2165,8 @@ def format_rmc_browser_ht(
             exp: float64,
             oe: float64,
             chisq: float64,
-            p: float64
+            p: float64,
+            low_coverage: bool,
         }>
     ----------------------------------------
     Key: ['transcript']

--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -2222,7 +2222,7 @@ def format_rmc_browser_ht(
             low_coverage=ht.low_coverage,
         )
     )
-    ht = ht.annotate(no_color=(ht.regions.p > P_VALUE) | ht.regions.low_coverage)
+    ht = ht.annotate(no_color=(ht.region.p > P_VALUE) | ht.region.low_coverage)
 
     # Group Table by transcript
     ht = ht.group_by("transcript").aggregate(regions=hl.agg.collect(ht.region))

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -639,6 +639,8 @@ def get_constraint_transcripts(
     constraint_transcript_ht = constraint_transcript_ht.filter(
         constraint_transcript_ht.transcript_type == "protein_coding"
     )
+
+    # NOTE: all MANE Select transcripts are also canonical in GENCODE v39/VEP v105
     if filter_to_canonical:
         constraint_transcript_ht = constraint_transcript_ht.filter(
             constraint_transcript_ht.canonical

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -635,28 +635,21 @@ def get_constraint_transcripts(
         raise DataException("Constraint HT not found!")
 
     constraint_transcript_ht = constraint_ht.ht()
+
     # NOTE: all protein-coding transcripts are ENST transcripts in constraint HT
-    constraint_transcript_ht = constraint_transcript_ht.filter(
-        constraint_transcript_ht.transcript_type == "protein_coding"
-    )
+    filter_expr = constraint_transcript_ht.transcript_type == "protein_coding"
 
     # NOTE: all MANE Select transcripts are also canonical in GENCODE v39/VEP v105
     if filter_to_canonical:
-        constraint_transcript_ht = constraint_transcript_ht.filter(
-            constraint_transcript_ht.canonical
-        )
+        filter_expr &= constraint_transcript_ht.canonical
 
     if not all_transcripts:
-        constraint_transcript_ht = constraint_transcript_ht.select("constraint_flags")
         if outlier:
-            constraint_transcript_ht = constraint_transcript_ht.filter(
-                hl.len(constraint_transcript_ht.constraint_flags) > 0
-            )
+            filter_expr &= hl.len(constraint_transcript_ht.constraint_flags) > 0
         else:
-            constraint_transcript_ht = constraint_transcript_ht.filter(
-                hl.len(constraint_transcript_ht.constraint_flags) == 0
-            )
+            filter_expr &= hl.len(constraint_transcript_ht.constraint_flags) == 0
 
+    constraint_transcript_ht = constraint_transcript_ht.filter(filter_expr)
     return hl.literal(
         constraint_transcript_ht.aggregate(
             hl.agg.collect_as_set(constraint_transcript_ht.transcript)

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -634,7 +634,7 @@ def get_constraint_transcripts(
     if not file_exists(constraint_ht.path):
         raise DataException("Constraint HT not found!")
 
-    constraint_transcript_ht = constraint_ht.ht().key_by("transcript")
+    constraint_transcript_ht = constraint_ht.ht()
     # NOTE: all protein-coding transcripts are ENST transcripts in constraint HT
     constraint_transcript_ht = constraint_transcript_ht.filter(
         constraint_transcript_ht.transcript_type == "protein_coding"


### PR DESCRIPTION
PR adds RMC coverage stats HT and updates globals for browser release HT and adds two new fields, `low_coverage` and `no_color`. PR test run is in `gs://regional_missense_constraint/notebooks/kc_update_browser_ht.ipynb`, though I didn't rerun the browser table creation after fixing the `no_color` annotation

Other minor changes:
- Updates path to gene models HT and adds various TODOs to update resources
- Streamlines `get_constraint_transcripts`