### PR TITLE
Update browser HT globals

### DIFF
--- a/rmc/utils/constraint.py
+++ b/rmc/utils/constraint.py
@@ -2118,6 +2118,14 @@ def add_globals_rmc_browser(
     outlier_transcripts = get_constraint_transcripts(
         filter_to_canonical=filter_to_canonical, outlier=True
     )
+    # Split outlier transcripts into those missing at least one class of variation
+    # ("no_exp" constraint flags) and those with outlier counts of variation
+    no_exp_outlier_transcripts = get_constraint_transcripts(
+        filter_to_canonical=filter_to_canonical, outlier=True, outlier_class="no_exp"
+    )
+    count_outlier_transcripts = get_constraint_transcripts(
+        filter_to_canonical=filter_to_canonical, outlier=True, outlier_class="count"
+    )
     qc_pass_transcripts = all_transcripts.difference(outlier_transcripts)
 
     ht = ht.select_globals()
@@ -2131,7 +2139,9 @@ def add_globals_rmc_browser(
             all_transcripts=all_transcripts,
             rmc_transcripts=rmc_transcripts,
             transcripts_no_rmc=all_transcripts.difference(rmc_transcripts),
-            outlier_transcripts=outlier_transcripts,
+            all_outlier_transcripts=outlier_transcripts,
+            no_exp_outlier_transcripts=no_exp_outlier_transcripts,
+            count_outlier_transcripts=count_outlier_transcripts,
         ),
     )
 
@@ -2190,7 +2200,9 @@ def format_rmc_browser_ht(
             'all_transcripts': set<str>
             'rmc_transcripts': set<str>
             'transcripts_no_rmc': set<str>
-            'outlier_transcripts': set<str>
+            'all_outlier_transcripts': set<str>
+            'no_exp_outlier_transcripts': set<str>
+            'count_outlier_transcripts': set<str>
         }
     ----------------------------------------
     Row fields:

--- a/rmc/utils/generic.py
+++ b/rmc/utils/generic.py
@@ -603,6 +603,7 @@ def get_constraint_transcripts(
     all_transcripts: bool = False,
     filter_to_canonical: bool = False,
     outlier: bool = True,
+    outlier_class: str = None,
 ) -> hl.expr.SetExpression:
     """
     Read in LoF constraint HT results to get set of transcripts.
@@ -624,9 +625,18 @@ def get_constraint_transcripts(
     :param outlier: Whether to filter LoF constraint HT to outlier transcripts (if True),
         or QC-pass transcripts (if False). Applies only if `all_transcripts` is False.
         Default is True.
+    :param outlier_class: Optionally restrict outlier transcripts to a single class.
+        Applies only if `all_transcripts` is False and `outlier` is True. One of:
+            - "no_exp": Outliers missing at least one class of variation (any
+                constraint flag starting with "no_exp").
+            - "count": Outliers with outlier counts of variation only (no "no_exp"
+                flags).
+        Default is None (return all outlier transcripts).
     :return: Set of outlier transcripts or transcript QC pass transcripts.
     :rtype: hl.expr.SetExpression
     """
+    if outlier_class is not None and outlier_class not in {"no_exp", "count"}:
+        raise ValueError("`outlier_class` must be one of None, 'no_exp', or 'count'!")
     logger.warning(
         "Assumes LoF constraint has been separately calculated and that constraint HT"
         " exists..."
@@ -646,6 +656,15 @@ def get_constraint_transcripts(
     if not all_transcripts:
         if outlier:
             filter_expr &= hl.len(constraint_transcript_ht.constraint_flags) > 0
+            if outlier_class is not None:
+                # Outliers missing a class of variation carry a constraint flag
+                # starting with "no_exp"; count outliers carry none of these flags
+                missing_var = constraint_transcript_ht.constraint_flags.any(
+                    lambda f: f.startswith("no_exp")
+                )
+                filter_expr &= (
+                    missing_var if outlier_class == "no_exp" else ~missing_var
+                )
         else:
             filter_expr &= hl.len(constraint_transcript_ht.constraint_flags) == 0
 


### PR DESCRIPTION
Update globals to differentiate between outlier transcripts missing expected counts (constraint metrics are not displayed) vs. transcripts with outlier counts (constraint metrics are displayed with a warning)